### PR TITLE
ci: init build.yml with build and publish container steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build-containers:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build containers
+        run: |
+          docker build container/gdal/ --tag topo-imagery-gdal --label "github_run_id=${GITHUB_RUN_ID}"
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Publish Containers
+        run: |
+          GIT_VERSION=$(git describe --tags --always --match 'v*')
+          docker tag topo-imagery-gdal ghcr.io/linz/topo-imagery:${GIT_VERSION}
+          docker push ghcr.io/linz/topo-imagery:${GIT_VERSION}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,6 +1,9 @@
-name: Build
+name: Build and Publish Containers
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'containers/'
 
 jobs:
   build-containers:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,7 +3,9 @@ name: Build and Publish Containers
 on:
   push:
     paths:
-      - 'containers/'
+      - 'containers/**'
+
+
 
 jobs:
   build-containers:


### PR DESCRIPTION
## Feature
Add a build pipeline containing the steps to build and publish the gdal docker image on each push related to changes in the `containers` folder on the master branch.
The image will be published in the GitHub LINZ Packages repository under the name `topo-imagery-gdal`.