### PR TITLE
fix: missing path for docker build cmd

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build containers
         run: |
-          docker build --tag topo-imagery --label "github_run_id=${GITHUB_RUN_ID}"
+          docker build . --tag topo-imagery --label "github_run_id=${GITHUB_RUN_ID}"
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Publish Containers


### PR DESCRIPTION
## Fix
Following this repository structure simplification, the `docker build` path has been deleted.