### PR TITLE
feat: get_credentials can take a role as parameter (TDE-303)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ RUN poetry config virtualenvs.create false \
 
 # Copy Python scripts
 COPY ./scripts/create_polygons.py /app/
+COPY ./scripts/standardising.py /app/
 COPY ./scripts/aws_helper.py /app/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,26 @@
 [[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
 name = "boto3"
 version = "1.24.12"
 description = "The AWS SDK for Python"
@@ -31,6 +53,22 @@ urllib3 = ">=1.25.4,<1.27"
 crt = ["awscrt (==0.13.8)"]
 
 [[package]]
+name = "colorama"
+version = "0.4.5"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "jmespath"
 version = "1.0.0"
 description = "JSON Matching Expressions"
@@ -48,6 +86,69 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 structlog = ">=20.1.0,<21.0.0"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "dev"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pytest"
+version = "7.1.2"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -96,6 +197,14 @@ docs = ["furo", "sphinx", "sphinx-toolbox", "twisted"]
 tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio", "pytest-randomly", "pytest (>=6.0)", "simplejson"]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "urllib3"
 version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -111,9 +220,17 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.10"
-content-hash = "8199466825b761eb49438c47f5ab7696e4d26d51e28d732a16a92e9ad8f5cc3b"
+content-hash = "e68b70ce58ba79341c7e17e684270b55e159467e739daa27786f2103478ccd13"
 
 [metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
 boto3 = [
     {file = "boto3-1.24.12-py3-none-any.whl", hash = "sha256:0b9757575b8003928defc5fb6e816936fa1bdb1384d0edec6622bb9fb104e96c"},
     {file = "boto3-1.24.12.tar.gz", hash = "sha256:f39b91a4c3614db8e44912ee82426fb4b16d5df2cd66883f3aff6f76d7f5d310"},
@@ -122,6 +239,14 @@ botocore = [
     {file = "botocore-1.27.12-py3-none-any.whl", hash = "sha256:b8ac156e55267da6e728ea0b806bfcd97adf882801cffe7849c4b88ce4780326"},
     {file = "botocore-1.27.12.tar.gz", hash = "sha256:17d3ec9f684d21e06b64d9cb224934557bcd95031e2ecb551bf16271e8722fec"},
 ]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 jmespath = [
     {file = "jmespath-1.0.0-py3-none-any.whl", hash = "sha256:e8dcd576ed616f14ec02eed0005c85973b5890083313860136657e24784e4c04"},
     {file = "jmespath-1.0.0.tar.gz", hash = "sha256:a490e280edd1f57d6de88636992d05b71e97d69a26a19f058ecf7d304474bf5e"},
@@ -129,6 +254,26 @@ jmespath = [
 linz-logger = [
     {file = "linz_logger-0.6.0-py3-none-any.whl", hash = "sha256:b15e59399af1e289d59e39f68ab6f9d5abcc5b648146ff6abd52aefaad3154f2"},
     {file = "linz_logger-0.6.0.tar.gz", hash = "sha256:70460df866f33ba997d4f38ebcfcae6cb1cfff6f52d15b0cbe3f8dfece3ca27c"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
+    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -145,6 +290,10 @@ six = [
 structlog = [
     {file = "structlog-20.2.0-py2.py3-none-any.whl", hash = "sha256:33dd6bd5f49355e52c1c61bb6a4f20d0b48ce0328cc4a45fe872d38b97a05ccd"},
     {file = "structlog-20.2.0.tar.gz", hash = "sha256:af79dfa547d104af8d60f86eac12fb54825f54a46bc998e4504ef66177103174"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ boto3 = "^1.24.12"
 linz-logger = "^0.6.0"
 
 [tool.poetry.dev-dependencies]
+pytest = "^7.1.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/scripts/aws_helper.py
+++ b/scripts/aws_helper.py
@@ -37,16 +37,17 @@ def init_roles():
     for cfg in json_content["buckets"]:
         bucket_roles[cfg["bucket"]] = cfg
 
-def get_credentials(bucket_name: str, set_credentials: bool = False):
+def get_credentials(bucket_name: str, role_arn: str, set_credentials: bool = False):
     get_log().debug("get_credentials_bucket_name", bucket_name=bucket_name)
     if not bucket_roles:
         init_roles()
-    if bucket_name in bucket_roles:
+    if bucket_name in bucket_roles or role_arn:
         # FIXME: check if the token is expired - add a parameter
-        if bucket_name not in bucket_credentials:
-            role_arn = bucket_roles[bucket_name]["roleArn"]
+        if bucket_name not in bucket_credentials or role_arn:
+            if not role_arn:
+                role_arn = bucket_roles[bucket_name]["roleArn"]
             get_log().debug("s3_assume_role", bucket_name=bucket_name, role_arn=role_arn)
-            assumed_role_object = client_sts.assume_role(RoleArn=role_arn, RoleSessionName="gdal")
+            assumed_role_object = client_sts.assume_role(RoleArn=role_arn, RoleSessionName="topo-imagery")
             bucket_credentials[bucket_name] = Credentials(
                 assumed_role_object["Credentials"]["AccessKeyId"],
                 assumed_role_object["Credentials"]["SecretAccessKey"],

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -3,9 +3,8 @@ import os
 import subprocess
 import tempfile
 
-from linz_logger import get_log
-
 import aws_helper
+from linz_logger import get_log
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--source',dest='source', required=True)

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+import subprocess
+import tempfile
+
+from linz_logger import get_log
+
+import aws_helper
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--source',dest='source', required=True)
+parser.add_argument('--destination', dest='destination', required=True)
+arguments = parser.parse_args()
+source = arguments.source
+destination = arguments.destination
+#TODO if destination needs write permission we have to handle this
+
+get_log().info("standardising", source=source, destination=destination)
+
+src_bucket_name, src_file_path = aws_helper.parse_path(source)
+dst_bucket_name, dst_path = aws_helper.parse_path(destination)
+get_log().debug("source", bucket=src_bucket_name, file_path=src_file_path)
+get_log().debug("destination", bucket=dst_bucket_name, file_path=dst_path)
+dst_bucket = aws_helper.get_bucket(dst_bucket_name)
+
+with tempfile.TemporaryDirectory() as tmp_dir:
+    standardized_file_name = f"standardized_{os.path.basename(src_file_path)}"
+    tmp_file_path = os.path.join(tmp_dir, standardized_file_name)
+    src_gdal_path = f"/vsis3/{source.replace('s3://', '')}"
+
+    # Assume AWS Role for GDAL to be able to read the source file
+    aws_helper.get_credentials(src_bucket_name, set_credentials=True)
+
+    # Standardized the file
+    get_log().debug("run_gdal_translate", src=src_gdal_path, output=tmp_file_path)
+    command = ["gdal_translate", "-q", "-scale", "0", "255", "0", "254", "-a_srs", "EPSG:2193", "-a_nodata", "255", "-b", "1", "-b", "2", "-b", "3", "-co", "compress=lzw", src_gdal_path, tmp_file_path]
+    proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0:
+        get_log().error("run_gdal_translate_failed", command=" ".join(command))
+        raise Exception(proc.stderr.decode())
+    get_log().debug("run_gdal_translate_succeded", command=" ".join(command))
+
+    # Upload the standardized file to destination
+    dst_file_path = os.path.join(dst_path, standardized_file_name).strip("/")
+    get_log().debug("upload_file", path=dst_file_path)
+    dst_bucket.upload_file(tmp_file_path, dst_file_path)

--- a/scripts/tests/aws_helper_test.py
+++ b/scripts/tests/aws_helper_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from scripts.aws_helper import parse_path
 
 

--- a/scripts/tests/aws_helper_test.py
+++ b/scripts/tests/aws_helper_test.py
@@ -1,0 +1,10 @@
+import pytest
+from scripts.aws_helper import parse_path
+
+
+def test_parse_path() -> None:
+    s3_path = "s3://bucket-name/path/to/the/file.test"
+    bucket_name, file_path = parse_path(s3_path)
+
+    assert bucket_name == "bucket-name"
+    assert file_path == "/path/to/the/file.test"


### PR DESCRIPTION
## Description
In order to get the AWS credentials for a bucket which is not in the `bucket-config` roles, we need a easy way to assume a role which we know the `role_arn` value.

## Change
A parameter `role_arn` has been added to the `aws_helper.get_credentials` method signature to force the credentials to be initialised with this role.