### PR TITLE
chore: include all scripts in COPY in the Dockerfile (TDE-415)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/scripts/tests
+**/scripts/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,4 @@ RUN poetry config virtualenvs.create false \
     && poetry install --no-dev --no-interaction --no-ansi
 
 # Copy Python scripts
-COPY ./scripts/create_polygons.py /app/
-COPY ./scripts/standardising.py /app/
-COPY ./scripts/aws_helper.py /app/
-COPY ./scripts/format_source.py /app/
+COPY ./scripts/* /app/


### PR DESCRIPTION
## Description
Everytime a script is added in the `/scripts/` directory, we should not have to specify it in the `Dockerfile`

## Changes

- Add a `.dockerignore` file to exclude the tests and cache
- Modify the `Dockerfile` to include all the scripts (path instead of each file)

> **_NOTE:_**  If a script needs to be excluded, use the `.dockerignore` file.