### PR TITLE
fix: log Non Visual QA error report in a JSON format

### DIFF
--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -6,6 +6,10 @@ from aws_helper import get_bucket_name_from_path, get_credentials, is_s3
 from linz_logger import get_log
 
 
+class GDALExecutionException(Exception):
+    pass
+
+
 def get_vfs_path(path: str) -> str:
     """Make the path as a GDAL Virtual File Systems path.
 
@@ -67,8 +71,8 @@ def run_gdal(command: List[str], input_file: str = "", output_file: str = "") ->
             capture_output=True,
         )
     except subprocess.CalledProcessError as cpe:
-        get_log().error("run_gdal_failed", command=command_to_string(command))
-        raise cpe
+        get_log().error("run_gdal_failed", command=command_to_string(command), error=str(cpe.stderr, "utf-8"))
+        raise GDALExecutionException(f"GDAL {str(cpe.stderr, 'utf-8')}") from cpe
     get_log().debug("run_gdal_translate_succeded", command=command_to_string(command))
 
     return proc

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -76,7 +76,7 @@ def run_gdal(
 
     if proc.stderr:
         get_log().error("run_gdal_error", command=command_to_string(command), error=proc.stderr.decode())
-        raise Exception(proc.stderr.decode())
+        raise GDALExecutionException(proc.stderr.decode())
 
     get_log().debug("run_gdal_succeded", command=command_to_string(command), stdout=proc.stdout.decode())
 

--- a/scripts/non_visual_qa.py
+++ b/scripts/non_visual_qa.py
@@ -1,10 +1,23 @@
 import argparse
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from format_source import format_source
 from gdal_helper import GDALExecutionException, run_gdal
 from linz_logger import get_log
+
+
+class NonVisualQA:
+    def __init__(self) -> None:
+        self.errors: List[Dict[str, Any]] = []
+        self._valid = True
+
+    def add_error(self, type: str, description: str, custom_fields: Dict[str, str] = {}) -> None:
+        self.errors.append({"type": type, "description": description, custom_fields})
+        self._valid = False
+
+    def is_valid(self) -> bool:
+        return self._valid
 
 
 def check_no_data(gdalinfo: Dict[str, Any], file_errors: Dict[str, str]) -> None:

--- a/scripts/non_visual_qa.py
+++ b/scripts/non_visual_qa.py
@@ -1,13 +1,13 @@
 import argparse
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from format_source import format_source
-from gdal_helper import run_gdal
+from gdal_helper import GDALExecutionException, run_gdal
 from linz_logger import get_log
 
 
-def check_no_data(gdalinfo: Dict[str, Any], errors_list: List[str]) -> None:
+def check_no_data(gdalinfo: Dict[str, Any], file_errors: Dict[str, str]) -> None:
     """Add an error in errors_list if there is no "noDataValue" or the "noDataValue" is not equal to 255 in the "bands".
 
     Args:
@@ -18,12 +18,12 @@ def check_no_data(gdalinfo: Dict[str, Any], errors_list: List[str]) -> None:
     if "noDataValue" in bands[0]:
         current_nodata_val = bands[0]["noDataValue"]
         if current_nodata_val != 255:
-            errors_list.append(f"noDataValue is {int(current_nodata_val)} not 255")
+            file_errors["no_data"] = f"noDataValue is {int(current_nodata_val)} not 255"
     else:
-        errors_list.append("noDataValue not set")
+        file_errors["no_data"] = "noDataValue not set"
 
 
-def check_band_count(gdalinfo: Dict[str, Any], errors_list: List[str]) -> None:
+def check_band_count(gdalinfo: Dict[str, Any], file_errors: Dict[str, str]) -> None:
     """Add an error in errors_list if there is no exactly 3 bands found.
 
     Args:
@@ -33,10 +33,10 @@ def check_band_count(gdalinfo: Dict[str, Any], errors_list: List[str]) -> None:
     bands = gdalinfo["bands"]
     bands_num = len(bands)
     if bands_num != 3:
-        errors_list.append(f"not 3 bands, {bands_num} bands found")
+        file_errors["band_count"] = f"not 3 bands, {bands_num} bands found"
 
 
-def check_srs(gdalsrsinfo: bytes, gdalsrsinfo_tif: bytes, errors_list: List[str]) -> None:
+def check_srs(gdalsrsinfo: bytes, gdalsrsinfo_tif: bytes, file_errors: Dict[str, str]) -> None:
     """Add an error in errors_list if gdalsrsinfo and gdalsrsinfo_tif values are different.
 
     Args:
@@ -45,10 +45,10 @@ def check_srs(gdalsrsinfo: bytes, gdalsrsinfo_tif: bytes, errors_list: List[str]
         errors_list (List[str]): List of errors as strings.
     """
     if gdalsrsinfo_tif != gdalsrsinfo:
-        errors_list.append("different srs")
+        file_errors["srs"] = "different srs"
 
 
-def check_color_interpretation(gdalinfo: Dict[str, Any], errors_list: List[str]) -> None:
+def check_color_interpretation(gdalinfo: Dict[str, Any], file_errors: Dict[str, str]) -> None:
     bands = gdalinfo["bands"]
     missing_bands = []
     band_colour_ints = {1: "Red", 2: "Green", 3: "Blue"}
@@ -63,10 +63,10 @@ def check_color_interpretation(gdalinfo: Dict[str, Any], errors_list: List[str])
         n += 1
     if missing_bands:
         missing_bands.sort()
-        errors_list.append(f"unexpected color interpretation bands; {', '.join(missing_bands)}")
+        file_errors["color_interpretation"] = f"unexpected color interpretation bands; {', '.join(missing_bands)}"
 
 
-def main() -> None:
+def main() -> None:  # pylint: disable=too-many-locals
     parser = argparse.ArgumentParser()
     parser.add_argument("--source", dest="source", nargs="+", required=True)
     arguments = parser.parse_args()
@@ -83,20 +83,25 @@ def main() -> None:
         )
     srs = gdalsrsinfo_result.stdout
 
+    errors_report = {}
     for file in source:
         gdalinfo_command = ["gdalinfo", "-stats", "-json"]
-        gdalinfo_process = run_gdal(gdalinfo_command, file)
-        gdalinfo_result = {}
         try:
-            gdalinfo_result = json.loads(gdalinfo_process.stdout)
-        except json.JSONDecodeError as e:
-            get_log().error("load_gdalinfo_result_error", file=file, error=e)
+            gdalinfo_process = run_gdal(gdalinfo_command, file)
+            gdalinfo_result = {}
+            try:
+                gdalinfo_result = json.loads(gdalinfo_process.stdout)
+            except json.JSONDecodeError as e:
+                get_log().error("load_gdalinfo_result_error", file=file, error=e)
+                gdalinfo_errors = f"GDALINFO RESULT ISSUE: {str(e)}"
+                continue
+            gdalinfo_errors = str(gdalinfo_process.stderr)
+        except GDALExecutionException as gee:
+            gdalinfo_errors = f"GDALINFO FAILED: {str(gee)}"
             continue
 
-        gdalinfo_errors = gdalinfo_process.stderr
-
         # Check result
-        errors: List[str] = []
+        errors: Dict[str, str] = {}
         # No data
         check_no_data(gdalinfo_result, errors)
 
@@ -105,19 +110,26 @@ def main() -> None:
 
         # srs
         gdalsrsinfo_tif_command = ["gdalsrsinfo", "-o", "wkt"]
-        gdalsrsinfo_tif_result = run_gdal(gdalsrsinfo_tif_command, file)
-        check_srs(srs, gdalsrsinfo_tif_result.stdout, errors)
+        try:
+            gdalsrsinfo_tif_result = run_gdal(gdalsrsinfo_tif_command, file)
+            check_srs(srs, gdalsrsinfo_tif_result.stdout, errors)
+        except GDALExecutionException as gee:
+            errors["srs"] = f"NOT CHECKED: {str(gee)}"
 
         # Color interpretation
         check_color_interpretation(gdalinfo_result, errors)
 
         # gdal errors
-        errors.append(f"{gdalinfo_errors!r}")
+        if gdalinfo_errors:
+            errors["gdal"] = f"{gdalinfo_errors!r}"
 
-        if len(errors) > 0:
-            get_log().info("non_visual_qa_errors_found", file=file, result=errors)
-        else:
-            get_log().info("non_visual_qa_no_error", file=file)
+        if errors:
+            errors_report[file] = errors
+
+    if errors_report:
+        get_log().info("non_visual_qa_errors", errors=errors_report)
+    else:
+        get_log().info("non_visual_qa_no_error")
 
 
 if __name__ == "__main__":

--- a/scripts/non_visual_qa.py
+++ b/scripts/non_visual_qa.py
@@ -1,6 +1,6 @@
 import argparse
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from format_source import format_source
 from gdal_helper import GDALExecutionException, run_gdal
@@ -13,7 +13,7 @@ class NonVisualQA:
         self._valid = True
 
     def add_error(self, type: str, description: str, custom_fields: Dict[str, str] = {}) -> None:
-        self.errors.append({"type": type, "description": description, custom_fields})
+        self.errors.append({"type": type, "description": description, **custom_fields})
         self._valid = False
 
     def is_valid(self) -> bool:

--- a/scripts/non_visual_qa.py
+++ b/scripts/non_visual_qa.py
@@ -7,76 +7,115 @@ from gdal_helper import GDALExecutionException, run_gdal
 from linz_logger import get_log
 
 
-class NonVisualQA:
-    def __init__(self) -> None:
+class FileCheck:
+    def __init__(self, path: str, srs: str) -> None:
+        self.path = path
+        self.global_srs = srs
         self.errors: List[Dict[str, Any]] = []
         self._valid = True
 
-    def add_error(self, type: str, description: str, custom_fields: Dict[str, str] = {}) -> None:
-        self.errors.append({"type": type, "description": description, **custom_fields})
+    def add_error(self, error_type: str, error_message: str, custom_fields: Dict[str, str] = {}) -> None:
+        self.errors.append({"type": error_type, "message": error_message, **custom_fields})
         self._valid = False
 
     def is_valid(self) -> bool:
         return self._valid
 
+    def check_no_data(self, gdalinfo: Dict[str, Any]) -> None:
+        """Add an error if there is no "noDataValue" or the "noDataValue" is not equal to 255 in the "bands".
 
-def check_no_data(gdalinfo: Dict[str, Any], file_errors: Dict[str, str]) -> None:
-    """Add an error in errors_list if there is no "noDataValue" or the "noDataValue" is not equal to 255 in the "bands".
-
-    Args:
-        gdalinfo (Dict[str, Any]): JSON return of gdalinfo in a Python Dictionary.
-        errors_list (List[str]): List of errors as strings.
-    """
-    bands = gdalinfo["bands"]
-    if "noDataValue" in bands[0]:
-        current_nodata_val = bands[0]["noDataValue"]
-        if current_nodata_val != 255:
-            file_errors["no_data"] = f"noDataValue is {int(current_nodata_val)} not 255"
-    else:
-        file_errors["no_data"] = "noDataValue not set"
-
-
-def check_band_count(gdalinfo: Dict[str, Any], file_errors: Dict[str, str]) -> None:
-    """Add an error in errors_list if there is no exactly 3 bands found.
-
-    Args:
-        gdalinfo (Dict[str, Any]): JSON returned by gdalinfo as a Python Dictionary.
-        errors_list (List[str]): List of errors as strings.
-    """
-    bands = gdalinfo["bands"]
-    bands_num = len(bands)
-    if bands_num != 3:
-        file_errors["band_count"] = f"not 3 bands, {bands_num} bands found"
-
-
-def check_srs(gdalsrsinfo: bytes, gdalsrsinfo_tif: bytes, file_errors: Dict[str, str]) -> None:
-    """Add an error in errors_list if gdalsrsinfo and gdalsrsinfo_tif values are different.
-
-    Args:
-        gdalsrsinfo (str): Value returned by gdalsrsinfo as a string.
-        gdalsrsinfo_tif (str): Value returned by gdalsrsinfo for the tif as a string.
-        errors_list (List[str]): List of errors as strings.
-    """
-    if gdalsrsinfo_tif != gdalsrsinfo:
-        file_errors["srs"] = "different srs"
-
-
-def check_color_interpretation(gdalinfo: Dict[str, Any], file_errors: Dict[str, str]) -> None:
-    bands = gdalinfo["bands"]
-    missing_bands = []
-    band_colour_ints = {1: "Red", 2: "Green", 3: "Blue"}
-    n = 1
-    for band in bands:
-        colour_int = band["colorInterpretation"]
-        if n in band_colour_ints:
-            if colour_int != band_colour_ints[n]:
-                missing_bands.append(f"band {n} {colour_int}")
+        Args:
+            gdalinfo (Dict[str, Any]): JSON return of gdalinfo in a Python Dictionary.
+        """
+        bands = gdalinfo["bands"]
+        if "noDataValue" in bands[0]:
+            current_nodata_val = bands[0]["noDataValue"]
+            if current_nodata_val != 255:
+                self.add_error(
+                    error_type="nodata",
+                    error_message="noDataValue is not 255",
+                    custom_fields={"current": f"{int(current_nodata_val)}"},
+                )
         else:
-            missing_bands.append(f"band {n} {colour_int}")
-        n += 1
-    if missing_bands:
-        missing_bands.sort()
-        file_errors["color_interpretation"] = f"unexpected color interpretation bands; {', '.join(missing_bands)}"
+            self.add_error(error_type="nodata", error_message="noDataValue not set")
+
+    def check_band_count(self, gdalinfo: Dict[str, Any]) -> None:
+        """Add an error if there is no exactly 3 bands found.
+
+        Args:
+            gdalinfo (Dict[str, Any]): JSON returned by gdalinfo as a Python Dictionary.
+        """
+        bands = gdalinfo["bands"]
+        bands_num = len(bands)
+        if bands_num != 3:
+            self.add_error(
+                error_type="bands", error_message="bands count is not 3", custom_fields={"count": f"{int(bands_num)}"}
+            )
+
+    def check_srs(self, gdalsrsinfo: bytes, gdalsrsinfo_tif: bytes) -> None:
+        """Add an error if gdalsrsinfo and gdalsrsinfo_tif values are different.
+
+        Args:
+            gdalsrsinfo (str): Value returned by gdalsrsinfo as a string.
+            gdalsrsinfo_tif (str): Value returned by gdalsrsinfo for the tif as a string.
+        """
+        if gdalsrsinfo_tif != gdalsrsinfo:
+            self.add_error(error_type="srs", error_message="different srs")
+
+    def check_color_interpretation(self, gdalinfo: Dict[str, Any]) -> None:
+        """Add an error if the colors don't match RGB.
+
+        Args:
+            gdalinfo (Dict[str, Any]): JSON returned by gdalinfo as a Python Dictionary.
+        """
+        bands = gdalinfo["bands"]
+        missing_bands = []
+        band_colour_ints = {1: "Red", 2: "Green", 3: "Blue"}
+        n = 1
+        for band in bands:
+            colour_int = band["colorInterpretation"]
+            if n in band_colour_ints:
+                if colour_int != band_colour_ints[n]:
+                    missing_bands.append(f"band {n} {colour_int}")
+            else:
+                missing_bands.append(f"band {n} {colour_int}")
+            n += 1
+        if missing_bands:
+            missing_bands.sort()
+            self.add_error(
+                error_type="color",
+                error_message="unexpected color interpretation bands",
+                custom_fields={"missing": f"{', '.join(missing_bands)}"},
+            )
+
+    def run(self) -> None:
+        gdalinfo_success = True
+        gdalinfo_command = ["gdalinfo", "-stats", "-json"]
+        try:
+            gdalinfo_process = run_gdal(gdalinfo_command, self.path)
+            gdalinfo_result = {}
+            try:
+                gdalinfo_result = json.loads(gdalinfo_process.stdout)
+            except json.JSONDecodeError as e:
+                get_log().error("load_gdalinfo_result_error", file=self.path, error=e)
+                self.add_error(error_type="gdalinfo", error_message=f"parsing result issue: {str(e)}")
+                gdalinfo_success = False
+            if gdalinfo_process.stderr:
+                self.add_error(error_type="gdalinfo", error_message=f"error(s): {str(gdalinfo_process.stderr)}")
+        except GDALExecutionException as gee:
+            self.add_error(error_type="gdalinfo", error_message=f"failed: {str(gee)}")
+            gdalinfo_success = False
+
+        if gdalinfo_success:
+            self.check_no_data(gdalinfo_result)
+            self.check_band_count(gdalinfo_result)
+            self.check_color_interpretation(gdalinfo_result)
+            gdalsrsinfo_tif_command = ["gdalsrsinfo", "-o", "wkt"]
+            try:
+                gdalsrsinfo_tif_result = run_gdal(gdalsrsinfo_tif_command, self.path)
+                self.check_srs(self.global_srs, gdalsrsinfo_tif_result.stdout)
+            except GDALExecutionException as gee:
+                self.add_error(error_type="srs", error_message=f"not checked: {str(gee)}")
 
 
 def main() -> None:  # pylint: disable=too-many-locals
@@ -96,53 +135,13 @@ def main() -> None:  # pylint: disable=too-many-locals
         )
     srs = gdalsrsinfo_result.stdout
 
-    errors_report = {}
     for file in source:
-        gdalinfo_command = ["gdalinfo", "-stats", "-json"]
-        try:
-            gdalinfo_process = run_gdal(gdalinfo_command, file)
-            gdalinfo_result = {}
-            try:
-                gdalinfo_result = json.loads(gdalinfo_process.stdout)
-            except json.JSONDecodeError as e:
-                get_log().error("load_gdalinfo_result_error", file=file, error=e)
-                gdalinfo_errors = f"GDALINFO RESULT ISSUE: {str(e)}"
-                continue
-            gdalinfo_errors = str(gdalinfo_process.stderr)
-        except GDALExecutionException as gee:
-            gdalinfo_errors = f"GDALINFO FAILED: {str(gee)}"
-            continue
+        file_check = FileCheck(file, srs)
+        file_check.run()
 
-        # Check result
-        errors: Dict[str, str] = {}
-        # No data
-        check_no_data(gdalinfo_result, errors)
-
-        # Band count
-        check_band_count(gdalinfo_result, errors)
-
-        # srs
-        gdalsrsinfo_tif_command = ["gdalsrsinfo", "-o", "wkt"]
-        try:
-            gdalsrsinfo_tif_result = run_gdal(gdalsrsinfo_tif_command, file)
-            check_srs(srs, gdalsrsinfo_tif_result.stdout, errors)
-        except GDALExecutionException as gee:
-            errors["srs"] = f"NOT CHECKED: {str(gee)}"
-
-        # Color interpretation
-        check_color_interpretation(gdalinfo_result, errors)
-
-        # gdal errors
-        if gdalinfo_errors:
-            errors["gdal"] = f"{gdalinfo_errors!r}"
-
-        if errors:
-            errors_report[file] = errors
-
-    if errors_report:
-        get_log().info("non_visual_qa_errors", errors=errors_report)
-    else:
-        get_log().info("non_visual_qa_no_error")
+        if not file_check.is_valid():
+            for error in file_check.errors:
+                get_log().info("non_visual_qa", file=file_check.path, **error)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/non_visual_qa_test.py
+++ b/scripts/tests/non_visual_qa_test.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict
 
 from non_visual_qa import check_band_count, check_color_interpretation, check_no_data, check_srs
 
@@ -10,10 +10,10 @@ def test_check_band_count_valid() -> None:
     """
     gdalinfo = {}
     gdalinfo["bands"] = [{"band": 1}, {"band": 2}, {"band": 3}]
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_band_count(gdalinfo, errors)
-    assert len(errors) == 0
+    assert not errors
 
 
 def test_check_band_count_invalid() -> None:
@@ -23,10 +23,10 @@ def test_check_band_count_invalid() -> None:
     """
     gdalinfo = {}
     gdalinfo["bands"] = [{"band": 1}, {"band": 2}]
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_band_count(gdalinfo, errors)
-    assert len(errors) == 1
+    assert errors
 
 
 def test_check_color_interpretation_valid() -> None:
@@ -45,10 +45,10 @@ def test_check_color_interpretation_valid() -> None:
             "colorInterpretation": "Blue",
         },
     ]
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_color_interpretation(gdalinfo, errors)
-    assert len(errors) == 0
+    assert not errors
 
 
 def test_check_color_interpretation_invalid() -> None:
@@ -70,10 +70,10 @@ def test_check_color_interpretation_invalid() -> None:
             "colorInterpretation": "Undefined",
         },
     ]
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_color_interpretation(gdalinfo, errors)
-    assert len(errors) == 1
+    assert errors
 
 
 def test_check_no_data_valid() -> None:
@@ -86,10 +86,10 @@ def test_check_no_data_valid() -> None:
             "noDataValue": 255,
         }
     ]
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_no_data(gdalinfo, errors)
-    assert len(errors) == 0
+    assert not errors
 
 
 def test_check_no_data_no_value() -> None:
@@ -98,10 +98,10 @@ def test_check_no_data_no_value() -> None:
     """
     gdalinfo = {}
     gdalinfo["bands"] = [{"test": 1}]
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_no_data(gdalinfo, errors)
-    assert len(errors) == 1
+    assert errors
 
 
 def test_check_no_data_invalid_value() -> None:
@@ -114,10 +114,10 @@ def test_check_no_data_invalid_value() -> None:
             "noDataValue": 0,
         }
     ]
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_no_data(gdalinfo, errors)
-    assert len(errors) == 1
+    assert errors
 
 
 def test_check_srs_valid() -> None:
@@ -126,10 +126,10 @@ def test_check_srs_valid() -> None:
     """
     srs_to_test_against = b"SRS Test"
     srs_tif = b"SRS Test"
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_srs(srs_to_test_against, srs_tif, errors)
-    assert len(errors) == 0
+    assert not errors
 
 
 def test_check_srs_invalid() -> None:
@@ -138,7 +138,7 @@ def test_check_srs_invalid() -> None:
     """
     srs_to_test_against = b"SRS Test"
     srs_tif = b"SRS Different"
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
 
     check_srs(srs_to_test_against, srs_tif, errors)
-    assert len(errors) == 1
+    assert errors

--- a/scripts/tests/non_visual_qa_test.py
+++ b/scripts/tests/non_visual_qa_test.py
@@ -1,6 +1,4 @@
-from typing import Dict
-
-from non_visual_qa import check_band_count, check_color_interpretation, check_no_data, check_srs
+from non_visual_qa import FileCheck
 
 
 def test_check_band_count_valid() -> None:
@@ -10,10 +8,11 @@ def test_check_band_count_valid() -> None:
     """
     gdalinfo = {}
     gdalinfo["bands"] = [{"band": 1}, {"band": 2}, {"band": 3}]
-    errors: Dict[str, str] = {}
 
-    check_band_count(gdalinfo, errors)
-    assert not errors
+    file_check = FileCheck("test", b"srs")
+    file_check.check_band_count(gdalinfo)
+
+    assert not file_check.errors
 
 
 def test_check_band_count_invalid() -> None:
@@ -23,10 +22,11 @@ def test_check_band_count_invalid() -> None:
     """
     gdalinfo = {}
     gdalinfo["bands"] = [{"band": 1}, {"band": 2}]
-    errors: Dict[str, str] = {}
 
-    check_band_count(gdalinfo, errors)
-    assert errors
+    file_check = FileCheck("test", b"srs")
+    file_check.check_band_count(gdalinfo)
+
+    assert file_check.errors
 
 
 def test_check_color_interpretation_valid() -> None:
@@ -45,10 +45,11 @@ def test_check_color_interpretation_valid() -> None:
             "colorInterpretation": "Blue",
         },
     ]
-    errors: Dict[str, str] = {}
 
-    check_color_interpretation(gdalinfo, errors)
-    assert not errors
+    file_check = FileCheck("test", b"srs")
+    file_check.check_color_interpretation(gdalinfo)
+
+    assert not file_check.errors
 
 
 def test_check_color_interpretation_invalid() -> None:
@@ -70,10 +71,11 @@ def test_check_color_interpretation_invalid() -> None:
             "colorInterpretation": "Undefined",
         },
     ]
-    errors: Dict[str, str] = {}
 
-    check_color_interpretation(gdalinfo, errors)
-    assert errors
+    file_check = FileCheck("test", b"srs")
+    file_check.check_color_interpretation(gdalinfo)
+
+    assert file_check.errors
 
 
 def test_check_no_data_valid() -> None:
@@ -86,10 +88,11 @@ def test_check_no_data_valid() -> None:
             "noDataValue": 255,
         }
     ]
-    errors: Dict[str, str] = {}
 
-    check_no_data(gdalinfo, errors)
-    assert not errors
+    file_check = FileCheck("test", b"srs")
+    file_check.check_no_data(gdalinfo)
+
+    assert not file_check.errors
 
 
 def test_check_no_data_no_value() -> None:
@@ -98,10 +101,11 @@ def test_check_no_data_no_value() -> None:
     """
     gdalinfo = {}
     gdalinfo["bands"] = [{"test": 1}]
-    errors: Dict[str, str] = {}
 
-    check_no_data(gdalinfo, errors)
-    assert errors
+    file_check = FileCheck("test", b"srs")
+    file_check.check_no_data(gdalinfo)
+
+    assert file_check.errors
 
 
 def test_check_no_data_invalid_value() -> None:
@@ -114,10 +118,11 @@ def test_check_no_data_invalid_value() -> None:
             "noDataValue": 0,
         }
     ]
-    errors: Dict[str, str] = {}
 
-    check_no_data(gdalinfo, errors)
-    assert errors
+    file_check = FileCheck("test", b"srs")
+    file_check.check_no_data(gdalinfo)
+
+    assert file_check.errors
 
 
 def test_check_srs_valid() -> None:
@@ -126,10 +131,11 @@ def test_check_srs_valid() -> None:
     """
     srs_to_test_against = b"SRS Test"
     srs_tif = b"SRS Test"
-    errors: Dict[str, str] = {}
 
-    check_srs(srs_to_test_against, srs_tif, errors)
-    assert not errors
+    file_check = FileCheck("test", srs_to_test_against)
+    file_check.check_srs(srs_tif)
+
+    assert not file_check.errors
 
 
 def test_check_srs_invalid() -> None:
@@ -138,7 +144,8 @@ def test_check_srs_invalid() -> None:
     """
     srs_to_test_against = b"SRS Test"
     srs_tif = b"SRS Different"
-    errors: Dict[str, str] = {}
 
-    check_srs(srs_to_test_against, srs_tif, errors)
-    assert errors
+    file_check = FileCheck("test", srs_to_test_against)
+    file_check.check_srs(srs_tif)
+
+    assert file_check.errors


### PR DESCRIPTION
## Description
In order to facilitate the loggin in Elastic Search, the Non Visual QA error report should be in a JSON format.

## Changes

- Create a `dictionnary`
```json
{"file": "path/to/the/file", "errors": [{"type": "error_type", "message": "error_message"}]}
```

## Example
```json
{"file": "s3://linz-imagery-staging/RGBi4/tasman_rural_2020_0.3m_a_RGBI/tif/2020_BQ24_5000_0601.tif", "errors": [{"type": "gdalinfo", "message": "error(s): b'Warning 1: The definition of projected CRS EPSG:2193 got from GeoTIFF keys is not the same as the one from the EPSG registry, which may cause issues during reprojection operations. Set GTIFF_SRS_SOURCE configuration option to EPSG to use official parameters (overriding the ones from GeoTIFF keys), or to GEOKEYS to use custom values from GeoTIFF keys and drop the EPSG code.\\n'"}, {"type": "nodata", "message": "noDataValue not set"}, {"type": "bands", "message": "bands count is not 3", "count": "4"}, {"type": "color", "message": "unexpected color interpretation bands", "missing": "band 4 Undefined"}, {"type": "srs", "message": "different srs"}]}
```