### PR TITLE
Feat: tde-421 remove destination arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ Python version is set to `3.8.10` as it is the current version used by `osgeo/gd
 ```bash
 docker run -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE='your-aws-profile' 'image-id'  python create_polygons.py --uri 's3://path-to-the-tiff/image.tif' --destination 'destination-bucket'
 ```
+
+docker run -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE=li-topo-imagery-prod topo-imagery:latest python standardising.py --source s3://linz-imagery-staging/test/sample/BX24_5000_0405.tif --destination s3://linz-imagery-staging/test/cog-test-out/

--- a/README.md
+++ b/README.md
@@ -39,5 +39,3 @@ Python version is set to `3.8.10` as it is the current version used by `osgeo/gd
 ```bash
 docker run -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE='your-aws-profile' 'image-id'  python create_polygons.py --uri 's3://path-to-the-tiff/image.tif' --destination 'destination-bucket'
 ```
-
-docker run -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE=li-topo-imagery-prod topo-imagery:latest python standardising.py --source s3://linz-imagery-staging/test/sample/BX24_5000_0405.tif --destination s3://linz-imagery-staging/test/cog-test-out/

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import List
+from typing import List, Optional
 
 from aws_helper import get_bucket_name_from_path, get_credentials, is_s3
 from linz_logger import get_log
@@ -34,7 +34,6 @@ def run_gdal(
     command: List[str],
     input_file: Optional[str] = None,
     output_file: Optional[str] = None,
-    input_file_index: Optional[int] = None,
 ) -> "subprocess.CompletedProcess[bytes]":
     """Run the GDAL command. The permissions to access to the input file are applied to the gdal environment.
 

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -58,12 +58,16 @@ def run_gdal(command: List[str], input_file: str = "", output_file: str = "") ->
 
     if output_file:
         command.append(output_file)
+
     try:
         get_log().debug("run_gdal", command=command_to_string(command))
-        proc = subprocess.run(command, env=gdal_env, check=True, capture_output=True)
+        proc = subprocess.run(command, env=gdal_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as cpe:
         get_log().error("run_gdal_failed", command=command_to_string(command), error=str(cpe.stderr, "utf-8"))
         raise cpe
-    get_log().debug("run_gdal_translate_succeded", command=command_to_string(command))
+    if proc.stderr:
+        get_log().error("run_gdal_error", command=command_to_string(command), error=proc.stderr.decode())
+        raise Exception(proc.stderr.decode())
+    get_log().debug("run_gdal_succeded", command=command_to_string(command))
 
     return proc

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -31,7 +31,10 @@ def command_to_string(command: List[str]) -> str:
 
 
 def run_gdal(
-    command: List[str], input_file: Optional[str] = None, output_file: Optional[str] = None, input_file_index: Optional[int] = None
+    command: List[str],
+    input_file: Optional[str] = None,
+    output_file: Optional[str] = None,
+    input_file_index: Optional[int] = None,
 ) -> "subprocess.CompletedProcess[bytes]":
     """Run the GDAL command. The permissions to access to the input file are applied to the gdal environment.
 

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import List
+from typing import List, Optional
 
 from aws_helper import get_bucket_name_from_path, get_credentials, is_s3
 from linz_logger import get_log
@@ -30,7 +30,7 @@ def command_to_string(command: List[str]) -> str:
     return " ".join(command)
 
 
-def run_gdal(command: List[str], input_file: str = "", output_file: str = "") -> "subprocess.CompletedProcess[bytes]":
+def run_gdal(command: List[str] = [], input_file: str = "", output_file: str = "", input_file_index: Optional[int] = None) -> "subprocess.CompletedProcess[bytes]":
     """Run the GDAL command. The permissions to access to the input file are applied to the gdal environment.
 
     Args:
@@ -53,7 +53,11 @@ def run_gdal(command: List[str], input_file: str = "", output_file: str = "") ->
             gdal_env["AWS_ACCESS_KEY_ID"] = credentials.access_key
             gdal_env["AWS_SECRET_ACCESS_KEY"] = credentials.secret_key
             gdal_env["AWS_SESSION_TOKEN"] = credentials.token
-        command.append(get_vfs_path(input_file))
+            input_file = get_vfs_path(input_file)
+    if input_file_index:
+        command.insert(input_file_index, input_file)
+    else:
+        command.append(input_file)
 
     if output_file:
         command.append(output_file)

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -30,13 +30,15 @@ def command_to_string(command: List[str]) -> str:
     return " ".join(command)
 
 
-def run_gdal(command: List[str], input_file: str = "", output_file: str = "") -> "subprocess.CompletedProcess[bytes]":
+def run_gdal(
+    command: List[str], input_file: Optional[str] = None, output_file: Optional[str] = None, input_file_index: Optional[int] = None
+) -> "subprocess.CompletedProcess[bytes]":
     """Run the GDAL command. The permissions to access to the input file are applied to the gdal environment.
 
     Args:
         command (List[str]): each arguments of the GDAL command.
-        input_file (str, optional): the input file path. Defaults to "".
-        output_file (str, optional): the output file path. Defaults to "".
+        input_file (str, optional): the input file path.
+        output_file (str, optional): the output file path.
 
     Raises:
         cpe: CalledProcessError is raised if something goes wrong during the execution of the command.

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -30,7 +30,9 @@ def command_to_string(command: List[str]) -> str:
     return " ".join(command)
 
 
-def run_gdal(command: List[str] = [], input_file: str = "", output_file: str = "", input_file_index: Optional[int] = None) -> "subprocess.CompletedProcess[bytes]":
+def run_gdal(
+    command: List[str], input_file: str = "", output_file: str = "", input_file_index: Optional[int] = None
+) -> "subprocess.CompletedProcess[bytes]":
     """Run the GDAL command. The permissions to access to the input file are applied to the gdal environment.
 
     Args:

--- a/scripts/gdal_helper.py
+++ b/scripts/gdal_helper.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import List, Optional
+from typing import List
 
 from aws_helper import get_bucket_name_from_path, get_credentials, is_s3
 from linz_logger import get_log
@@ -30,9 +30,7 @@ def command_to_string(command: List[str]) -> str:
     return " ".join(command)
 
 
-def run_gdal(
-    command: List[str], input_file: str = "", output_file: str = "", input_file_index: Optional[int] = None
-) -> "subprocess.CompletedProcess[bytes]":
+def run_gdal(command: List[str], input_file: str = "", output_file: str = "") -> "subprocess.CompletedProcess[bytes]":
     """Run the GDAL command. The permissions to access to the input file are applied to the gdal environment.
 
     Args:
@@ -56,9 +54,6 @@ def run_gdal(
             gdal_env["AWS_SECRET_ACCESS_KEY"] = credentials.secret_key
             gdal_env["AWS_SESSION_TOKEN"] = credentials.token
             input_file = get_vfs_path(input_file)
-    if input_file_index:
-        command.insert(input_file_index, input_file)
-    else:
         command.append(input_file)
 
     if output_file:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -10,12 +10,9 @@ from linz_logger import get_log
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--source", dest="source", nargs="+", required=True)
-
 arguments = parser.parse_args()
-source = arguments.source
 
-
-source = format_source(source)
+source = format_source(arguments.source)
 
 get_log().info("standardising", source=source)
 gdal_env = os.environ.copy()

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -58,7 +58,7 @@ for file in source:
             "-co",
             "overview_compress=webp",
             "-co",
-            "biggtiff=yes",
+            "bigtiff=yes",
             "-co",
             "overview_resampling=lanczos",
             "-co",

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import tempfile
 
-from aws_helper import get_bucket, parse_path
+from aws_helper import parse_path
 from file_helper import get_file_name_from_path
 from format_source import format_source
 from gdal_helper import run_gdal
@@ -10,17 +10,14 @@ from linz_logger import get_log
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--source", dest="source", nargs="+", required=True)
-parser.add_argument("--destination", dest="destination", required=True)
+
 arguments = parser.parse_args()
 source = arguments.source
-destination = arguments.destination
+
 
 source = format_source(source)
 
-get_log().info("standardising", source=source, destination=destination)
-dst_bucket_name, dst_path = parse_path(destination)
-get_log().debug("destination", bucket=dst_bucket_name, file_path=dst_path)
-dst_bucket = get_bucket(dst_bucket_name)
+get_log().info("standardising", source=source)
 gdal_env = os.environ.copy()
 
 for file in source:
@@ -69,8 +66,3 @@ for file in source:
             "sparse_ok=true",
         ]
         run_gdal(command, input_file=file, output_file=tmp_file_path)
-
-        # Upload the standardized file to destination
-        dst_file_path = os.path.join(dst_path, standardized_file_name).strip("/")
-        get_log().debug("upload_file", path=dst_file_path)
-        dst_bucket.upload_file(tmp_file_path, dst_file_path)

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -66,7 +66,7 @@ for file in source:
             "-co",
             "overview_quality=90",
             "-co",
-            "sparse_ok=true"
+            "sparse_ok=true",
         ]
         run_gdal(command, input_file=file, output_file=tmp_file_path, input_file_index=17)
 

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -68,7 +68,7 @@ for file in source:
             "-co",
             "sparse_ok=true",
         ]
-        run_gdal(command, input_file=file, output_file=tmp_file_path, input_file_index=17)
+        run_gdal(command, input_file=file, output_file=tmp_file_path)
 
         # Upload the standardized file to destination
         dst_file_path = os.path.join(dst_path, standardized_file_name).strip("/")

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -47,10 +47,28 @@ for file in source:
             "2",
             "-b",
             "3",
+            "-of",
+            "COG",
             "-co",
             "compress=lzw",
+            "-co",
+            "num_threads=all_cpus",
+            "-co",
+            "predictor=2",
+            "-co",
+            "overview_compress=webp",
+            "-co",
+            "biggtiff=yes",
+            "-co",
+            "overview_resampling=lanczos",
+            "-co",
+            "blocksize=512",
+            "-co",
+            "overview_quality=90",
+            "-co",
+            "sparse_ok=true"
         ]
-        run_gdal(command, file, tmp_file_path)
+        run_gdal(command, input_file=file, output_file=tmp_file_path, input_file_index=17)
 
         # Upload the standardized file to destination
         dst_file_path = os.path.join(dst_path, standardized_file_name).strip("/")


### PR DESCRIPTION
the destination arguement has been removed therefore the output of standardardisation will only be written to the tmp directory in the docker container. combined with https://github.com/linz/topo-workflows/pull/7 the tmp folder will then be written to the artifacts bucket. 

note: this branch includes COG work, it needs to be rebased once https://github.com/linz/topo-imagery/pull/60 is merged