### PR TITLE
refactor: common source parser

### DIFF
--- a/scripts/cli_helper.py
+++ b/scripts/cli_helper.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 from typing import List
 
@@ -16,3 +17,16 @@ def format_source(source: List[str]) -> List[str]:
         except json.JSONDecodeError as e:
             get_log().debug("Decoding Json Failed", source=source, msg=e)
     return source
+
+
+def parse_source() -> List[str]:
+    """Parse the CLI argument '--source' and format it to a list of paths.
+
+    Returns:
+        List[str]: A list of paths.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", dest="source", nargs="+", required=True)
+    arguments = parser.parse_args()
+
+    return format_source(arguments.source)

--- a/scripts/non_visual_qa.py
+++ b/scripts/non_visual_qa.py
@@ -1,9 +1,8 @@
-import argparse
 import json
 from typing import Any, Dict, List, Optional
 
+from cli_helper import parse_source
 from file_helper import is_tiff
-from format_source import format_source
 from gdal_helper import GDALExecutionException, run_gdal
 from linz_logger import get_log
 
@@ -121,13 +120,8 @@ class FileCheck:
                 self.add_error(error_type="srs", error_message=f"not checked: {str(gee)}")
 
 
-def main() -> None:  # pylint: disable=too-many-locals
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--source", dest="source", nargs="+", required=True)
-    arguments = parser.parse_args()
-    source = arguments.source
-
-    source = format_source(source)
+def main() -> None:
+    source = parse_source()
 
     # Get srs
     gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", "EPSG:2193"]

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -1,17 +1,12 @@
-import argparse
 import os
 
 from aws_helper import parse_path
+from cli_helper import parse_source
 from file_helper import get_file_name_from_path, is_tiff
-from format_source import format_source
 from gdal_helper import run_gdal
 from linz_logger import get_log
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--source", dest="source", nargs="+", required=True)
-arguments = parser.parse_args()
-
-source = format_source(arguments.source)
+source = parse_source()
 
 get_log().info("standardising", source=source)
 gdal_env = os.environ.copy()

--- a/scripts/tests/cli_helper_test.py
+++ b/scripts/tests/cli_helper_test.py
@@ -1,4 +1,4 @@
-from format_source import format_source
+from cli_helper import format_source
 
 
 def test_format_source_from_basemaps_cli_file() -> None:


### PR DESCRIPTION
## Description
Parsing the `--source` argument code was duplicated in every scripts. Also `pylint` was complaining.

## Change
- Create a single method which parse the argument `--source` and return a list of path (using `format_source` #36)