### PR TITLE
fix: add 'certifi' lib to temporary fix poetry install issue TDE-451

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -774,7 +774,7 @@ python-versions = ">=3.4"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.10"
-content-hash = "f7b4b71e6ddc0b7c91aa2b4ea29d4b9ff7f4b477a61f4470ff45747ef04f6d61"
+content-hash = "f0c00002fe66be4bb7b0a32b63e8e06969466a44723ad8f62ed242ac7841bee4"
 
 [metadata.files]
 arrow = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ authors = [
 python = "^3.8.10"
 boto3 = "^1.24.12"
 linz-logger = "^0.9.0"
+certifi = "^2022.6.15"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
## Description
This is a temporary solution to fix the build that fails on `poetry install` because of a dependency issue. See https://github.com/python-poetry/poetry/issues/5977 & https://github.com/python-poetry/poetry/issues/1889