### PR TITLE
fix: TDE-454 remove `standardise` from file name

### DIFF
--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -2,7 +2,8 @@ import os
 
 
 def get_file_name_from_path(path: str) -> str:
-    return os.path.basename(path)
+    filename, _ = os.path.splitext(os.path.basename(path))
+    return filename
 
 
 def is_tiff(path: str) -> bool:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -40,7 +40,7 @@ def standardising(file: str) -> str:
     get_log().info("standardising_start", source=file)
 
     _, src_file_path = parse_path(file)
-    standardized_file_name = f"{get_file_name_from_path(s3_path.key)}.tiff"
+    standardized_file_name = f"{get_file_name_from_path(src_file_path)}.tiff"
     tmp_file_path = os.path.join(output_folder, standardized_file_name)
 
     command = [

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -40,7 +40,7 @@ def standardising(file: str) -> str:
     get_log().info("standardising_start", source=file)
 
     _, src_file_path = parse_path(file)
-    standardized_file_name = f"standardized_{get_file_name_from_path(src_file_path)}"
+    standardized_file_name = f"{get_file_name_from_path(s3_path.key)}.tiff"
     tmp_file_path = os.path.join(output_folder, standardized_file_name)
 
     command = [


### PR DESCRIPTION
So that we can get the stac item id from the filename