### PR TITLE
fix: not logging source as a list of string

### DIFF
--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -5,6 +5,8 @@ from typing import List
 
 from linz_logger import get_log
 
+from scripts.logging.formatter import list_to_str
+
 
 def format_source(source: List[str]) -> List[str]:
     """Due to Argo constraints if using the basemaps cli list command
@@ -16,7 +18,7 @@ def format_source(source: List[str]) -> List[str]:
             source_json: List[str] = json.loads(source[0])
             return source_json
         except json.JSONDecodeError as e:
-            get_log().debug("Decoding Json Failed", source=source, msg=e)
+            get_log().debug("Decoding Json Failed", msg=e)
     return source
 
 

--- a/scripts/create_polygons.py
+++ b/scripts/create_polygons.py
@@ -12,6 +12,7 @@ from osgeo import gdal  # pylint: disable=import-error
 from scripts.cli.cli_helper import parse_source
 from scripts.files.files_helper import is_tiff
 from scripts.files.fs import read, write
+from scripts.logging.formatter import list_to_str
 from scripts.logging.time_helper import time_in_ms
 
 
@@ -77,13 +78,13 @@ def main() -> None:
 
                 output_files.append(temp_file_path)
         except Exception as e:  # pylint:disable=broad-except
-            get_log().error("create_polygon_file_skipped", path=file, error=str(e))
+            get_log().error("create_polygon_file_skipped", file=file, error=str(e))
             is_error = True
 
     with open("/tmp/file_list.json", "w", encoding="utf-8") as jf:
         json.dump(output_files, jf)
 
-    get_log().info("create_polygons_end", source=source, duration=time_in_ms() - start_time)
+    get_log().info("create_polygons_end", duration=time_in_ms() - start_time)
     if is_error:
         get_log().info("create_polygons_warn", warning="At least one file has been skipped")
         sys.exit(1)

--- a/scripts/non_visual_qa.py
+++ b/scripts/non_visual_qa.py
@@ -6,6 +6,7 @@ from linz_logger import get_log
 from scripts.cli.cli_helper import parse_source
 from scripts.files.files_helper import is_tiff
 from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
+from scripts.logging.formatter import list_to_str
 from scripts.logging.time_helper import time_in_ms
 
 
@@ -125,7 +126,7 @@ class FileCheck:
 def non_visual_qa(files: List[str]) -> None:
     start_time = time_in_ms()
 
-    get_log().info("non_visual_qa_start", source=files)
+    get_log().info("non_visual_qa_start")
 
     # Get srs
     gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", "EPSG:2193"]
@@ -140,6 +141,7 @@ def non_visual_qa(files: List[str]) -> None:
         if not is_tiff(file):
             get_log().trace("non_visual_qa_file_not_tiff_skipped", file=file)
             continue
+        get_log().info(f"Non Visual QA {file}", file=file)
         file_check = FileCheck(file, srs)
         file_check.run()
 
@@ -148,7 +150,7 @@ def non_visual_qa(files: List[str]) -> None:
         else:
             get_log().info("non_visual_qa_passed", file=file_check.path)
 
-    get_log().info("non_visual_qa_end", source=files, duration=time_in_ms() - start_time)
+    get_log().info("non_visual_qa_end", duration=time_in_ms() - start_time)
 
 
 def main() -> None:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -19,7 +19,7 @@ def start_standardising(files: List[str], preset: str, concurrency: int) -> List
     tiff_files = []
     output_files = []
 
-    get_log().info("standardising_start", source=files)
+    get_log().info("standardising_start")
 
     for file in files:
         if is_tiff(file):
@@ -32,7 +32,7 @@ def start_standardising(files: List[str], preset: str, concurrency: int) -> List
         p.close()
         p.join()
 
-    get_log().info("standardising_end", source=files, duration=time_in_ms() - start_time)
+    get_log().info("standardising_end", duration=time_in_ms() - start_time)
 
     return output_files
 
@@ -40,7 +40,7 @@ def start_standardising(files: List[str], preset: str, concurrency: int) -> List
 def standardising(file: str, preset: str) -> str:
     output_folder = "/tmp/"
 
-    get_log().info("standardising_start", source=file)
+    get_log().info(f"standardising {file}", source=file)
 
     _, src_file_path = parse_path(file)
     standardized_file_name = f"{get_file_name_from_path(src_file_path)}.tiff"


### PR DESCRIPTION
## Description
We should not log the `source` as `list` of `str`: it can be very long, and also Elastic Search is not parsing it correctly.

## Change
Remove logging the full source and keeping only logging single file path when needed.