### PR TITLE
fix: a couple of bugs in get_session_credentials

### DIFF
--- a/scripts/aws/aws_helper.py
+++ b/scripts/aws/aws_helper.py
@@ -100,9 +100,9 @@ def get_session_credentials(prefix: str, retry_count: int = 3) -> AwsFrozenCrede
     for retry in range(1, retry_count + 1):
         try:
             # Get credentials may give differing access_key and secret_key
-            credentials: AwsFrozenCredentials = get_session(prefix).get_frozen_credentials()
+            credentials: AwsFrozenCredentials = get_session(prefix).get_credentials().get_frozen_credentials()
             return credentials
-        except client_sts.meta.client.exceptions.InvalidIdentityTokenException as e:
+        except client_sts.exceptions.InvalidIdentityTokenException as e:
             get_log().warn("bucket_load_retry", retry_count=retry)
             sleep(0.5 * retry)
             last_error = e


### PR DESCRIPTION
```
File "/app/scripts/aws/aws_helper.py", line 103, in get_session_credentials
    credentials: AwsFrozenCredentials = get_session(prefix).get_frozen_credentials()
AttributeError: 'Session' object has no attribute 'get_frozen_credentials'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/scripts/non_visual_qa.py", line 161, in <module>
    main()
  File "/app/scripts/non_visual_qa.py", line 157, in main
    non_visual_qa(source)
  File "/app/scripts/non_visual_qa.py", line 145, in non_visual_qa
    file_check.run()
  File "/app/scripts/non_visual_qa.py", line 99, in run
    gdalinfo_process = run_gdal(gdalinfo_command, self.path)
  File "/app/scripts/gdal/gdal_helper.py", line 63, in run_gdal
    credentials = get_session_credentials(input_file)
  File "/app/scripts/aws/aws_helper.py", line 105, in get_session_credentials
    except client_sts.meta.client.exceptions.InvalidIdentityTokenException as e:
AttributeError: 'ClientMeta' object has no attribute 'client'