### PR TITLE
fix: Elastic Search is expecting an object in 'source'

### DIFF
--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -40,7 +40,7 @@ def start_standardising(files: List[str], preset: str, concurrency: int) -> List
 def standardising(file: str, preset: str) -> str:
     output_folder = "/tmp/"
 
-    get_log().info(f"standardising {file}", source=file)
+    get_log().info(f"standardising {file}", path=file)
 
     _, src_file_path = parse_path(file)
     standardized_file_name = f"{get_file_name_from_path(src_file_path)}.tiff"


### PR DESCRIPTION
## Description
```
﻿object mapping for [data.source] tried to parse field [source] as object, but found a concrete value
```
To avoid Elastic Search not parsing this log, use `path` attribute instead.
