### PR TITLE
refactor: single location for gdalinfo, refactor standardise_validate.py TDE-483

### DIFF
--- a/scripts/files/file_check.py
+++ b/scripts/files/file_check.py
@@ -89,8 +89,8 @@ class FileCheck:
     def validate(self, gdalinfo_result: Dict[Any, Any]) -> None:
         if self.is_valid():
             self.check_no_data(gdalinfo_result)
-            self.check_band_count(gdalinfo_result)
-            self.check_color_interpretation(gdalinfo_result)
+            # self.check_band_count(gdalinfo_result)
+            # self.check_color_interpretation(gdalinfo_result)
             gdalsrsinfo_tif_command = ["gdalsrsinfo", "-o", "wkt"]
             try:
                 gdalsrsinfo_tif_result = run_gdal(gdalsrsinfo_tif_command, self.path)

--- a/scripts/files/file_check.py
+++ b/scripts/files/file_check.py
@@ -1,0 +1,99 @@
+from typing import Any, Dict, List, Optional
+
+from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
+
+
+class FileCheck:
+    def __init__(self, path: str, srs: bytes) -> None:
+        self.path = path
+        self.global_srs = srs
+        self.errors: List[Dict[str, Any]] = []
+        self._valid = True
+
+    def add_error(self, error_type: str, error_message: str, custom_fields: Optional[Dict[str, str]] = None) -> None:
+        if not custom_fields:
+            custom_fields = {}
+        self.errors.append({"type": error_type, "message": error_message, **custom_fields})
+        self._valid = False
+
+    def is_valid(self) -> bool:
+        return self._valid
+
+    def check_no_data(self, gdalinfo: Dict[str, Any]) -> None:
+        """Add an error if there is no "noDataValue" or the "noDataValue" is not equal to 255 in the "bands".
+
+        Args:
+            gdalinfo (Dict[str, Any]): JSON return of gdalinfo in a Python Dictionary.
+        """
+        bands = gdalinfo["bands"]
+        if "noDataValue" in bands[0]:
+            current_nodata_val = bands[0]["noDataValue"]
+            if current_nodata_val != 255:
+                self.add_error(
+                    error_type="nodata",
+                    error_message="noDataValue is not 255",
+                    custom_fields={"current": f"{int(current_nodata_val)}"},
+                )
+        else:
+            self.add_error(error_type="nodata", error_message="noDataValue not set")
+
+    def check_band_count(self, gdalinfo: Dict[str, Any]) -> None:
+        """Add an error if there is no exactly 3 bands found.
+
+        Args:
+            gdalinfo (Dict[str, Any]): JSON returned by gdalinfo as a Python Dictionary.
+        """
+        bands = gdalinfo["bands"]
+        bands_num = len(bands)
+        if bands_num != 3:
+            self.add_error(
+                error_type="bands", error_message="bands count is not 3", custom_fields={"count": f"{int(bands_num)}"}
+            )
+
+    def check_srs(self, gdalsrsinfo_tif: bytes) -> None:
+        """Add an error if gdalsrsinfo and gdalsrsinfo_tif values are different.
+
+        Args:
+            gdalsrsinfo (str): Value returned by gdalsrsinfo as a string.
+            gdalsrsinfo_tif (str): Value returned by gdalsrsinfo for the tif as a string.
+        """
+        if gdalsrsinfo_tif != self.global_srs:
+            self.add_error(error_type="srs", error_message="different srs")
+
+    def check_color_interpretation(self, gdalinfo: Dict[str, Any]) -> None:
+        """Add an error if the colors don't match RGB.
+
+        Args:
+            gdalinfo (Dict[str, Any]): JSON returned by gdalinfo as a Python Dictionary.
+        """
+        bands = gdalinfo["bands"]
+        missing_bands = []
+        band_colour_ints = {1: "Red", 2: "Green", 3: "Blue"}
+        n = 1
+        for band in bands:
+            colour_int = band["colorInterpretation"]
+            if n in band_colour_ints:
+                if colour_int != band_colour_ints[n]:
+                    missing_bands.append(f"band {n} {colour_int}")
+            else:
+                missing_bands.append(f"band {n} {colour_int}")
+            n += 1
+        if missing_bands:
+            missing_bands.sort()
+            self.add_error(
+                error_type="color",
+                error_message="unexpected color interpretation bands",
+                custom_fields={"missing": f"{', '.join(missing_bands)}"},
+            )
+
+    def validate(self, gdalinfo_result: Dict[Any, Any]) -> None:
+        if self.is_valid():
+            self.check_no_data(gdalinfo_result)
+            self.check_band_count(gdalinfo_result)
+            self.check_color_interpretation(gdalinfo_result)
+            gdalsrsinfo_tif_command = ["gdalsrsinfo", "-o", "wkt"]
+            try:
+                gdalsrsinfo_tif_result = run_gdal(gdalsrsinfo_tif_command, self.path)
+                self.check_srs(gdalsrsinfo_tif_result.stdout)
+            except GDALExecutionException as gee:
+                self.add_error(error_type="srs", error_message=f"not checked: {str(gee)}")

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -1,25 +1,36 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from linz_logger import get_log
 
+from scripts.files.file_check import FileCheck
 from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
 
 
-def gdal_info(path: str) -> Dict[Any, Any]:
+def gdal_info(path: str, file_check: Optional[FileCheck] = None) -> Dict[Any, Any]:
+    # Set GDAL_PAM_ENABLED to NO to temporarily diable PAM support and prevent creation of auxiliary XML file.
     gdalinfo_command = ["gdalinfo", "-stats", "-json", "--config", "GDAL_PAM_ENABLED", "NO"]
+    gdalinfo_result = {}
     try:
         gdalinfo_process = run_gdal(gdalinfo_command, path)
-        gdalinfo_result = {}
         try:
             gdalinfo_result = json.loads(gdalinfo_process.stdout)
         except json.JSONDecodeError as e:
             get_log().error("load_gdalinfo_result_error", file=path, error=e)
-            raise e
+            if file_check:
+                file_check.add_error(error_type="gdalinfo", error_message=f"parsing result issue: {str(e)}")
+            else:
+                raise e
         if gdalinfo_process.stderr:
             get_log().error("Gdalinfo_error", file=path, error=str(gdalinfo_process.stderr))
-            raise Exception(f"Gdalinfo Error {str(gdalinfo_process.stderr)}")
+            if file_check:
+                file_check.add_error(error_type="gdalinfo", error_message=f"error(s): {str(gdalinfo_process.stderr)}")
+            else:
+                raise Exception(f"Gdalinfo Error {str(gdalinfo_process.stderr)}")
         return gdalinfo_result
     except GDALExecutionException as gee:
         get_log().error("gdalinfo_failed", file=path, error=str(gee))
+        if file_check:
+            file_check.add_error(error_type="gdalinfo", error_message=f"failed: {str(gee)}")
+            return gdalinfo_result
         raise gee

--- a/scripts/non_visual_qa.py
+++ b/scripts/non_visual_qa.py
@@ -1,126 +1,13 @@
-import json
 from typing import Any, Dict, List, Optional
 
 from linz_logger import get_log
 
 from scripts.cli.cli_helper import parse_source
+from scripts.files.file_check import FileCheck
 from scripts.files.files_helper import is_tiff
-from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
+from scripts.gdal.gdal_helper import run_gdal
+from scripts.gdal.gdalinfo import gdal_info
 from scripts.logging.time_helper import time_in_ms
-
-
-class FileCheck:
-    def __init__(self, path: str, srs: bytes) -> None:
-        self.path = path
-        self.global_srs = srs
-        self.errors: List[Dict[str, Any]] = []
-        self._valid = True
-
-    def add_error(self, error_type: str, error_message: str, custom_fields: Optional[Dict[str, str]] = None) -> None:
-        if not custom_fields:
-            custom_fields = {}
-        self.errors.append({"type": error_type, "message": error_message, **custom_fields})
-        self._valid = False
-
-    def is_valid(self) -> bool:
-        return self._valid
-
-    def check_no_data(self, gdalinfo: Dict[str, Any]) -> None:
-        """Add an error if there is no "noDataValue" or the "noDataValue" is not equal to 255 in the "bands".
-
-        Args:
-            gdalinfo (Dict[str, Any]): JSON return of gdalinfo in a Python Dictionary.
-        """
-        bands = gdalinfo["bands"]
-        if "noDataValue" in bands[0]:
-            current_nodata_val = bands[0]["noDataValue"]
-            if current_nodata_val != 255:
-                self.add_error(
-                    error_type="nodata",
-                    error_message="noDataValue is not 255",
-                    custom_fields={"current": f"{int(current_nodata_val)}"},
-                )
-        else:
-            self.add_error(error_type="nodata", error_message="noDataValue not set")
-
-    def check_band_count(self, gdalinfo: Dict[str, Any]) -> None:
-        """Add an error if there is no exactly 3 bands found.
-
-        Args:
-            gdalinfo (Dict[str, Any]): JSON returned by gdalinfo as a Python Dictionary.
-        """
-        bands = gdalinfo["bands"]
-        bands_num = len(bands)
-        if bands_num != 3:
-            self.add_error(
-                error_type="bands", error_message="bands count is not 3", custom_fields={"count": f"{int(bands_num)}"}
-            )
-
-    def check_srs(self, gdalsrsinfo_tif: bytes) -> None:
-        """Add an error if gdalsrsinfo and gdalsrsinfo_tif values are different.
-
-        Args:
-            gdalsrsinfo (str): Value returned by gdalsrsinfo as a string.
-            gdalsrsinfo_tif (str): Value returned by gdalsrsinfo for the tif as a string.
-        """
-        if gdalsrsinfo_tif != self.global_srs:
-            self.add_error(error_type="srs", error_message="different srs")
-
-    def check_color_interpretation(self, gdalinfo: Dict[str, Any]) -> None:
-        """Add an error if the colors don't match RGB.
-
-        Args:
-            gdalinfo (Dict[str, Any]): JSON returned by gdalinfo as a Python Dictionary.
-        """
-        bands = gdalinfo["bands"]
-        missing_bands = []
-        band_colour_ints = {1: "Red", 2: "Green", 3: "Blue"}
-        n = 1
-        for band in bands:
-            colour_int = band["colorInterpretation"]
-            if n in band_colour_ints:
-                if colour_int != band_colour_ints[n]:
-                    missing_bands.append(f"band {n} {colour_int}")
-            else:
-                missing_bands.append(f"band {n} {colour_int}")
-            n += 1
-        if missing_bands:
-            missing_bands.sort()
-            self.add_error(
-                error_type="color",
-                error_message="unexpected color interpretation bands",
-                custom_fields={"missing": f"{', '.join(missing_bands)}"},
-            )
-
-    def run(self) -> None:
-        gdalinfo_success = True
-        # Set GDAL_PAM_ENABLED to NO to temporarily disable PAM support and prevent creation of auxiliary XML file
-        gdalinfo_command = ["gdalinfo", "-stats", "-json", "--config", "GDAL_PAM_ENABLED", "NO"]
-        try:
-            gdalinfo_process = run_gdal(gdalinfo_command, self.path)
-            gdalinfo_result = {}
-            try:
-                gdalinfo_result = json.loads(gdalinfo_process.stdout)
-            except json.JSONDecodeError as e:
-                get_log().error("load_gdalinfo_result_error", file=self.path, error=e)
-                self.add_error(error_type="gdalinfo", error_message=f"parsing result issue: {str(e)}")
-                gdalinfo_success = False
-            if gdalinfo_process.stderr:
-                self.add_error(error_type="gdalinfo", error_message=f"error(s): {str(gdalinfo_process.stderr)}")
-        except GDALExecutionException as gee:
-            self.add_error(error_type="gdalinfo", error_message=f"failed: {str(gee)}")
-            gdalinfo_success = False
-
-        if gdalinfo_success:
-            self.check_no_data(gdalinfo_result)
-            # self.check_band_count(gdalinfo_result)
-            # self.check_color_interpretation(gdalinfo_result)
-            gdalsrsinfo_tif_command = ["gdalsrsinfo", "-o", "wkt"]
-            try:
-                gdalsrsinfo_tif_result = run_gdal(gdalsrsinfo_tif_command, self.path)
-                self.check_srs(gdalsrsinfo_tif_result.stdout)
-            except GDALExecutionException as gee:
-                self.add_error(error_type="srs", error_message=f"not checked: {str(gee)}")
 
 
 def non_visual_qa(files: List[str]) -> None:
@@ -128,29 +15,41 @@ def non_visual_qa(files: List[str]) -> None:
 
     get_log().info("non_visual_qa_start")
 
-    # Get srs
-    gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", "EPSG:2193"]
-    gdalsrsinfo_result = run_gdal(gdalsrsinfo_command)
-    if gdalsrsinfo_result.stderr:
-        raise Exception(
-            f"Error trying to retrieve srs from epsg code, no files have been checked\n{gdalsrsinfo_result.stderr!r}"
-        )
-    srs = gdalsrsinfo_result.stdout
+    srs = get_srs()
 
     for file in files:
         if not is_tiff(file):
             get_log().trace("non_visual_qa_file_not_tiff_skipped", file=file)
             continue
         get_log().info(f"Non Visual QA {file}", file=file)
-        file_check = FileCheck(file, srs)
-        file_check.run()
 
-        if not file_check.is_valid():
-            get_log().info("non_visual_qa_errors", file=file_check.path, errors=file_check.errors)
-        else:
-            get_log().info("non_visual_qa_passed", file=file_check.path)
+        qa_file(file, srs)
 
     get_log().info("non_visual_qa_end", duration=time_in_ms() - start_time)
+
+
+def get_srs() -> bytes:
+    gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", "EPSG:2193"]
+    gdalsrsinfo_result = run_gdal(gdalsrsinfo_command)
+    if gdalsrsinfo_result.stderr:
+        raise Exception(
+            f"Error trying to retrieve srs from epsg code, no files have been checked\n{gdalsrsinfo_result.stderr!r}"
+        )
+    return gdalsrsinfo_result.stdout
+
+
+def qa_file(file: str, srs: bytes, gdalinfo_result: Optional[Dict[Any, Any]] = None) -> None:
+    file_check = FileCheck(file, srs)
+
+    if not gdalinfo_result:
+        gdalinfo_result = gdal_info(path=file, file_check=file_check)
+
+    file_check.validate(gdalinfo_result)
+
+    if not file_check.is_valid():
+        get_log().info("non_visual_qa_errors", file=file_check.path, errors=file_check.errors)
+    else:
+        get_log().info("non_visual_qa_passed", file=file_check.path)
 
 
 def main() -> None:

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -11,15 +11,15 @@ from scripts.standardising import start_standardising
 
 def main() -> None:
 
-    concurrency: int = 1
-
     parser = argparse.ArgumentParser()
-    parser.add_argument("--preset", dest="preset", required=True)
     parser.add_argument("--source", dest="source", nargs="+", required=True)
+    parser.add_argument("--preset", dest="preset", required=True)
 
     arguments = parser.parse_args()
 
     source = format_source(arguments.source)
+
+    concurrency: int = 1
 
     if is_argo():
         concurrency = 4

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -3,17 +3,21 @@ import argparse
 from linz_logger import get_log
 
 from scripts.cli.cli_helper import format_source, is_argo
-from scripts.non_visual_qa import non_visual_qa
+from scripts.files.files_helper import is_tiff
+from scripts.gdal.gdalinfo import gdal_info
+from scripts.non_visual_qa import get_srs, qa_file
 from scripts.standardising import start_standardising
 
 
 def main() -> None:
 
     concurrency: int = 1
-    parse_args = argparse.ArgumentParser()
-    parse_args.add_argument("--preset", dest="preset", required=True)
-    parse_args.add_argument("--source", dest="source", nargs="+", required=True)
-    arguments = parse_args.parse_args()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preset", dest="preset", required=True)
+    parser.add_argument("--source", dest="source", nargs="+", required=True)
+
+    arguments = parser.parse_args()
 
     source = format_source(arguments.source)
 
@@ -21,12 +25,17 @@ def main() -> None:
         concurrency = 4
 
     standardised_files = start_standardising(source, arguments.preset, concurrency)
-    if standardised_files:
-        non_visual_qa(standardised_files)
-    else:
-        get_log().info(
-            "Non Visual QA skipped because no file has been standardised", action="standardise_validate", reason="skip"
-        )
+    if not standardised_files:
+        get_log().info("Process skipped because no file has been standardised", action="standardise_validate", reason="skip")
+        return
+    srs = get_srs()
+
+    for file in standardised_files:
+        if not is_tiff(file):
+            get_log().trace("file_not_tiff_skipped", file=file)
+            continue
+        gdalinfo_result = gdal_info(file)
+        qa_file(file, srs, gdalinfo_result)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/non_visual_qa_test.py
+++ b/scripts/tests/non_visual_qa_test.py
@@ -1,4 +1,4 @@
-from scripts.non_visual_qa import FileCheck
+from scripts.files.file_check import FileCheck
 
 
 def test_check_band_count_valid() -> None:


### PR DESCRIPTION
1

Code still runs as usual, should see no changes needed in topo workflows other than updating the version number. 

refactored to have gdalinfo in one location some changes have been done (splitting functions) in preparation to add stac item creation to standardise_validate.py

to run:
`docker run -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE=**profile** **container**:latest python standardise_validate.py --preset "webp" --source "[\"**s3://lpath/to.tif**\", \"**s3://path/to.tif**\"]"`