### PR TITLE
feat: rename files TDE-497

### DIFF
--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -4,10 +4,6 @@ from scripts.aws.aws_helper import is_s3
 from scripts.files import fs_local, fs_s3
 
 
-class FsException(Exception):
-    pass
-
-
 def write(destination: str, source: bytes) -> None:
     """Write a file from its source to a destination path.
 

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -44,7 +44,7 @@ def rename(path: str, new_path: str) -> None:
         new_path (str): the path of which the file should be renamed to.
 
     Raises:
-        FsException: an exception if the path are not on the same file system.
+        Exception: an exception if the path are not on the same file system.
     """
     if path == new_path:
         get_log().info("rename_skipped_same_name", path=path, destination=new_path)
@@ -54,4 +54,4 @@ def rename(path: str, new_path: str) -> None:
         elif not is_s3(path) and not is_s3(new_path):
             fs_local.rename(path, new_path)
         else:
-            raise FsException("The files to rename have to be on the same file system.")
+            raise Exception("The files to rename have to be on the same file system.")

--- a/scripts/files/fs_local.py
+++ b/scripts/files/fs_local.py
@@ -1,5 +1,7 @@
 import os
 
+from linz_logger import get_log
+
 
 def write(destination: str, source: bytes) -> None:
     """Write the source to the local destination file.
@@ -32,4 +34,21 @@ def rename(path: str, new_path: str) -> None:
         path (str): original path
         new_path (str): path to be renamed with
     """
+    if not os.path.exists(path):
+        get_log().error(
+            "rename_local_not_exists",
+            path=path,
+            destination=new_path,
+            error="The file to rename does not exist.",
+        )
+        raise Exception(f"{path} does not exist.")
+    if os.path.exists(new_path):
+        get_log().error(
+            "rename_local_already_exists",
+            path=path,
+            destination=new_path,
+            error="The destination file already exists.",
+        )
+        raise Exception(f"{new_path} already exists.")
+
     os.rename(src=path, dst=new_path)

--- a/scripts/files/fs_local.py
+++ b/scripts/files/fs_local.py
@@ -1,3 +1,6 @@
+import os
+
+
 def write(destination: str, source: bytes) -> None:
     """Write the source to the local destination file.
 
@@ -20,3 +23,13 @@ def read(path: str) -> bytes:
     """
     with open(path, "rb") as file:
         return file.read()
+
+
+def rename(path: str, new_path: str) -> None:
+    """Rename a file.
+
+    Args:
+        path (str): original path
+        new_path (str): path to be renamed with
+    """
+    os.rename(src=path, dst=new_path)

--- a/scripts/files/fs_local.py
+++ b/scripts/files/fs_local.py
@@ -34,21 +34,13 @@ def rename(path: str, new_path: str) -> None:
         path (str): original path
         new_path (str): path to be renamed with
     """
-    if not os.path.exists(path):
+    try:
+        os.rename(src=path, dst=new_path)
+    except FileNotFoundError as fnfe:
         get_log().error(
-            "rename_local_not_exists",
+            "rename_local_file_not_found",
             path=path,
             destination=new_path,
-            error="The file to rename does not exist.",
+            error=f"The specified file to rename does not seem to exist: {fnfe}",
         )
-        raise Exception(f"{path} does not exist.")
-    if os.path.exists(new_path):
-        get_log().error(
-            "rename_local_already_exists",
-            path=path,
-            destination=new_path,
-            error="The destination file already exists.",
-        )
-        raise Exception(f"{new_path} already exists.")
-
-    os.rename(src=path, dst=new_path)
+        raise fnfe

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -6,6 +6,10 @@ from scripts.aws.aws_helper import get_session, parse_path
 from scripts.logging.time_helper import time_in_ms
 
 
+class FsS3Exception(Exception):
+    pass
+
+
 def write(destination: str, source: bytes) -> None:
     """Write a source (bytes) in a AWS s3 destination (path in a bucket).
 
@@ -65,6 +69,72 @@ def read(path: str, needs_credentials: bool = False) -> bytes:
 
     get_log().debug("read_s3_success", path=path, duration=time_in_ms() - start_time)
     return file
+
+
+def rename(path: str, new_path: str, needs_credentials: bool = False) -> None:
+    """'Rename' an s3 object: copy an existing object to another with the new key name and delete the old object.
+        The objects have to be in the same bucket.
+
+    Args:
+        path (str): the path of the object to rename.
+        new_path (str): the path with the new name.
+        needs_credentials (bool, optional): Tells if credentials are needed. Defaults to False.
+
+    Raises:
+        FsS3Exception: an exception if the path are not in the same bucket
+        ce: a client exception
+        nsb: a no such bucket exception
+        nsk: a no such key exception
+    """
+    start_time = time_in_ms()
+    src_s3_path = parse_path(path)
+    dst_s3_path = parse_path(new_path)
+
+    if src_s3_path.bucket != dst_s3_path.bucket:
+        get_log().error(
+            "rename_s3_different_buckets",
+            path=path,
+            destination=new_path,
+            error="The source and destination path are not in the same bucket",
+        )
+        raise FsS3Exception(f"Files {path} and {new_path} are not on the same S3 bucket.")
+
+    src_key = src_s3_path.key
+    dst_key = dst_s3_path.key
+    copy_source = {"Bucket": src_s3_path.bucket, "Key": src_key}
+    s3 = boto3.resource("s3")
+    try:
+        if needs_credentials:
+            s3 = get_session(path).client("s3")
+
+        dst_s3_object = s3.Object(dst_s3_path.bucket, dst_key)
+        dst_s3_object.copy(copy_source)
+
+        # delete the source
+        src_s3_object = s3.Object(src_s3_path.bucket, src_key)
+        src_s3_object.delete()
+        get_log().debug("rename_s3_success", path=path, destination=new_path, duration=time_in_ms() - start_time)
+    except s3.meta.client.exceptions.ClientError as ce:
+        if not needs_credentials and ce.response["Error"]["Code"] == "AccessDenied":
+            get_log().debug("rename_s3_needs_credentials", path=path, destination=new_path)
+            return rename(path, new_path, True)
+        raise ce
+    except s3.meta.client.exceptions.NoSuchBucket as nsb:
+        get_log().error(
+            "rename_s3_bucket_not_found",
+            path=path,
+            destination=new_path,
+            error=f"The specified bucket does not seem to exist: {nsb}",
+        )
+        raise nsb
+    except s3.meta.client.exceptions.NoSuchKey as nsk:
+        get_log().error(
+            "rename_s3_file_not_found",
+            path=path,
+            destination=new_path,
+            error=f"The specified file does not seem to exist: {nsk}",
+        )
+        raise nsk
 
 
 def bucket_name_from_path(path: str) -> str:

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -104,11 +104,9 @@ def rename(path: str, new_path: str, needs_credentials: bool = False) -> None:
             s3 = get_session(path).client("s3")
 
         dst_s3_object = s3.Object(dst_s3_path.bucket, dst_key)
-        # check if the original file exists
-
-        # check if the destination file already exists
         src_s3_object = s3.Object(src_s3_path.bucket, src_key)
         try:
+            # check if the original file exists
             src_s3_object.load()
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "404":
@@ -121,6 +119,7 @@ def rename(path: str, new_path: str, needs_credentials: bool = False) -> None:
             raise Exception(f"{path} does not exists.") from e
 
         try:
+            # check if the destination file already exists
             dst_s3_object.load()
             get_log().error(
                 "rename_s3_already_exists",

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -113,7 +113,6 @@ def rename(path: str, new_path: str, needs_credentials: bool = False) -> None:
         # delete the source
         src_s3_object = s3.Object(src_s3_path.bucket, src_key)
         src_s3_object.delete()
-        get_log().debug("rename_s3_success", path=path, destination=new_path, duration=time_in_ms() - start_time)
     except s3.meta.client.exceptions.ClientError as ce:
         if not needs_credentials and ce.response["Error"]["Code"] == "AccessDenied":
             get_log().debug("rename_s3_needs_credentials", path=path, destination=new_path)
@@ -135,6 +134,8 @@ def rename(path: str, new_path: str, needs_credentials: bool = False) -> None:
             error=f"The specified file does not seem to exist: {nsk}",
         )
         raise nsk
+    get_log().debug("rename_s3_success", path=path, destination=new_path, duration=time_in_ms() - start_time)
+    return None
 
 
 def bucket_name_from_path(path: str) -> str:

--- a/scripts/files/tests/fs_local_test.py
+++ b/scripts/files/tests/fs_local_test.py
@@ -5,7 +5,7 @@ from typing import Generator
 
 import pytest
 
-from scripts.files.fs_local import read, write
+from scripts.files.fs_local import read, rename, write
 
 
 @pytest.fixture(name="setup", autouse=True)
@@ -36,3 +36,15 @@ def test_read(setup: str) -> None:
     write(path, content)
     file_content = read(path)
     assert file_content == content
+
+
+@pytest.mark.dependency(name="rename", depends=["write"])
+def test_rename(setup: str) -> None:
+    content = b"content"
+    target = setup
+    path = os.path.join(target, "testA.file")
+    write(path, content)
+    new_path = os.path.join(target, "testB.file")
+    rename(path, new_path)
+    assert os.path.exists(new_path)
+    assert not os.path.exists(path)

--- a/scripts/files/tests/fs_s3_test.py
+++ b/scripts/files/tests/fs_s3_test.py
@@ -52,7 +52,7 @@ def test_read_file_not_found(capsys: CaptureFixture[str]) -> None:
 
 
 @mock_s3  # type: ignore
-def test_rename(capsys: CaptureFixture[str]) -> None:
+def test_rename() -> None:
     s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="testbucket")

--- a/scripts/files/tests/fs_s3_test.py
+++ b/scripts/files/tests/fs_s3_test.py
@@ -5,7 +5,7 @@ from moto import mock_s3
 from moto.s3.responses import DEFAULT_REGION_NAME
 from pytest import CaptureFixture
 
-from scripts.files.fs_s3 import read, write
+from scripts.files.fs_s3 import FsS3Exception, read, rename, write
 
 
 @mock_s3  # type: ignore
@@ -49,3 +49,39 @@ def test_read_file_not_found(capsys: CaptureFixture[str]) -> None:
         read("s3://testbucket/test.file")
         sysout = capsys.readouterr()
         assert "read_s3_file_not_found" in sysout.out
+
+
+@mock_s3  # type: ignore
+def test_rename(capsys: CaptureFixture[str]) -> None:
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="testbucket")
+    client.put_object(Bucket="testbucket", Key="test.file", Body=b"test content")
+    src_path = "s3://testbucket/test.file"
+    dst_path = "s3://testbucket/testB.file"
+    rename(src_path, dst_path)
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        read("s3://testbucket/test.file")
+        sysout = capsys.readouterr()
+        assert "read_s3_file_not_found" in sysout.out
+
+    content = read("s3://testbucket/testB.file")
+
+    assert content == b"test content"
+
+
+@mock_s3  # type: ignore
+def test_rename_different_bucket(capsys: CaptureFixture[str]) -> None:
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="testbucket")
+    client.put_object(Bucket="testbucket", Key="test.file", Body=b"test content")
+    src_path = "s3://testbucket/test.file"
+    dst_path = "s3://testbucket2/testB.file"
+
+    with pytest.raises(FsS3Exception):
+        rename(src_path, dst_path)
+        read("s3://testbucket/test.file")
+        sysout = capsys.readouterr()
+        assert "rename_s3_different_buckets" in sysout.out


### PR DESCRIPTION
## Description
This PR implements the ability of renaming a file in both local and `s3` file system. The functionality is renaming a path to another, not only the file name. For `s3` the files have to be on the same bucket.

_**EDIT:** We don't need that at the moment. Keep this as a Draft for a bit._