### PR TITLE
fix: log gdal stderr instead of raising an exception TDE-557

### DIFF
--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -81,8 +81,7 @@ def run_gdal(
         get_log().info("run_gdal_end", command=command_to_string(temp_command), duration=time_in_ms() - start_time)
 
     if proc.stderr:
-        get_log().error("run_gdal_error", command=command_to_string(temp_command), error=proc.stderr.decode())
-        raise GDALExecutionException(proc.stderr.decode())
+        get_log().warning("run_gdal_stderr", command=command_to_string(temp_command), stderr=proc.stderr.decode())
 
     get_log().debug("run_gdal_succeeded", command=command_to_string(temp_command), stdout=proc.stdout.decode())
 

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -22,11 +22,9 @@ def gdal_info(path: str, file_check: Optional[FileCheck] = None) -> Dict[Any, An
             else:
                 raise e
         if gdalinfo_process.stderr:
-            get_log().error("Gdalinfo_error", file=path, error=str(gdalinfo_process.stderr))
             if file_check:
+                # FIXME: do we want this recorded as an error in the non_visual_qa report?
                 file_check.add_error(error_type="gdalinfo", error_message=f"error(s): {str(gdalinfo_process.stderr)}")
-            else:
-                raise Exception(f"Gdalinfo Error {str(gdalinfo_process.stderr)}")
         return gdalinfo_result
     except GDALExecutionException as gee:
         get_log().error("gdalinfo_failed", file=path, error=str(gee))


### PR DESCRIPTION
## Description
`stderr` from `gdal` should not be interpreted as an error. When `gdal` is on error, it returns an `exit code` <> 0. This behaviour is already captured by `subprocess.run` (with `check=True`) raising a `subprocess.CalledProcessError` in a case of _"a non-zero exit status"_. Any `stderr` should be `Warnings` or other messages <> error.

## Change
Log a warning instead of raising an exception when `gdal` `stderr` is not empty 