### PR TITLE
feat: use a fixed version of osgeo/gdal container TDE-555

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osgeo/gdal:ubuntu-small-latest
+FROM osgeo/gdal@sha256:452da485c574fe040a5748b73932d3ec7334913197744b550d13ce80493ef3c4
 
 RUN apt-get update
 # Install pip


### PR DESCRIPTION
## Description
We are using an unstable version of the `osgeo/gdal` Docker container by using the `latest` tag. Using `latest` is problematic as the version can change when the container is re-build. We currently can't use a stable version as we would have to downgrade from a `gdal-3.6-dev` version with Python `3.10` to `gdal-3.5.3` with Python `3.8.10` leading to some Poetry/pip/Python issues (from few tests that we've done).

## Change
Fixed the `osgeo/gdal` container version to `osgeo/gdal@sha256:452da485c574fe040a5748b73932d3ec7334913197744b550d13ce80493ef3c4` until a `gdal-3.6` stable container is released so we can use it.