### PR TITLE
feat: log the gdal version when run standardising TDE-559

### DIFF
--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -49,11 +49,10 @@ def get_gdal_version() -> str:
     gdalinfo_version = ["gdalinfo", "--version"]
     try:
         proc = subprocess.run(gdalinfo_version, env=gdal_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        return proc.stdout.decode().strip()
     except subprocess.CalledProcessError as cpe:
         get_log().error("get_gdal_version_failed", command=command_to_string(gdalinfo_version), error=str(cpe.stderr, "utf-8"))
         raise GDALExecutionException(f"GDAL {str(cpe.stderr, 'utf-8')}") from cpe
-
-    return proc.stdout.decode().strip()
 
 
 def run_gdal(

--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -36,6 +36,26 @@ def command_to_string(command: List[str]) -> str:
     return " ".join(command)
 
 
+def get_gdal_version() -> str:
+    """Return the GDAL version assuming all GDAL commands are in the same version of gdalinfo.
+
+    Raises:
+        GDALExecutionException: If the GDAL command fails.
+
+    Returns:
+        str: The GDAL version returned by GDAL.
+    """
+    gdal_env = os.environ.copy()
+    gdalinfo_version = ["gdalinfo", "--version"]
+    try:
+        proc = subprocess.run(gdalinfo_version, env=gdal_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    except subprocess.CalledProcessError as cpe:
+        get_log().error("get_gdal_version_failed", command=command_to_string(gdalinfo_version), error=str(cpe.stderr, "utf-8"))
+        raise GDALExecutionException(f"GDAL {str(cpe.stderr, 'utf-8')}") from cpe
+
+    return proc.stdout.decode().strip()
+
+
 def run_gdal(
     command: List[str],
     input_file: Optional[str] = None,

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -9,7 +9,7 @@ from linz_logger import get_log
 from scripts.aws.aws_helper import parse_path
 from scripts.cli.cli_helper import format_source, is_argo
 from scripts.files.files_helper import get_file_name_from_path, is_tiff
-from scripts.gdal.gdal_helper import run_gdal
+from scripts.gdal.gdal_helper import get_gdal_version, run_gdal
 from scripts.gdal.gdal_preset import get_gdal_command
 from scripts.logging.time_helper import time_in_ms
 
@@ -19,7 +19,8 @@ def start_standardising(files: List[str], preset: str, concurrency: int) -> List
     tiff_files = []
     output_files = []
 
-    get_log().info("standardising_start")
+    gdal_version = get_gdal_version()
+    get_log().info("standardising_start", gdalVersion=gdal_version)
 
     for file in files:
         if is_tiff(file):


### PR DESCRIPTION
## Description
Assuming that our container has the same GDAL version for the different command we run, logging the result of `gdalinfo --version` to get the GDAL version we use in our logs.