### PR TITLE
refactor: improve processing time of collection creation TDE-258

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -17,6 +17,9 @@ def main() -> None:
     parser.add_argument("--collection-id", dest="collection_id", required=True)
     parser.add_argument("--title", dest="title", help="collection title", required=True)
     parser.add_argument("--description", dest="description", help="collection description", required=True)
+    parser.add_argument(
+        "--concurrency", dest="concurrency", help="The number of files to limit concurrent reads", required=True, type=int
+    )
 
     arguments = parser.parse_args()
     uri = arguments.uri
@@ -34,7 +37,9 @@ def main() -> None:
     files_to_read = list_json_in_uri(uri, s3_client)
 
     start_time = time_in_ms()
-    for key, result in get_object_parallel_multithreading(bucket_name_from_path(uri), files_to_read, s3_client):
+    for key, result in get_object_parallel_multithreading(
+        bucket_name_from_path(uri), files_to_read, s3_client, arguments.concurrency
+    ):
         item_stac = json.loads(result["Body"].read().decode("utf-8"))
 
         if not arguments.collection_id == item_stac["collection"]:

--- a/scripts/create_stac.py
+++ b/scripts/create_stac.py
@@ -1,61 +1,11 @@
-import argparse
-import json
-import os
 from typing import Any, Dict, Optional
 
 from linz_logger import get_log
 
-from scripts.cli.cli_helper import format_date, format_source, valid_date
-from scripts.files.files_helper import get_file_name_from_path, is_tiff
-from scripts.files.fs import write
+from scripts.files.files_helper import get_file_name_from_path
 from scripts.files.geotiff import get_extents
 from scripts.gdal.gdalinfo import gdal_info
-from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
-
-
-def main() -> None:
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--source", dest="source", nargs="+", required=True)
-    parser.add_argument("--collection-id", dest="collection_id", help="Unique id for collection", required=False)
-    parser.add_argument(
-        "--start-datetime", dest="start_datetime", help="start datetime in format YYYY-MM-DD", type=valid_date, required=True
-    )
-    parser.add_argument(
-        "--end-datetime", dest="end_datetime", help="end datetime in format YYYY-MM-DD", type=valid_date, required=True
-    )
-    parser.add_argument("--title", dest="title", help="collection title", required=True)
-    parser.add_argument("--description", dest="description", help="collection description", required=True)
-
-    arguments = parser.parse_args()
-
-    source = format_source(arguments.source)
-    title = arguments.title
-    description = arguments.description
-    collection_id = arguments.collection_id
-    start_datetime = format_date(arguments.start_datetime)
-    end_datetime = format_date(arguments.end_datetime)
-
-    if arguments.collection_id:
-        collection = ImageryCollection(title=title, description=description, collection_id=collection_id)
-    else:
-        collection = ImageryCollection(title=title, description=description)
-
-    for file in source:
-        if not is_tiff(file):
-            get_log().trace("file_not_tiff_skipped", file=file)
-            continue
-        gdalinfo_result = gdal_info(file)
-        item = create_item(file, start_datetime, end_datetime, collection_id, gdalinfo_result)
-        tmp_file_path = os.path.join("/tmp/", f"{item.stac['id']}.json")
-        write(tmp_file_path, json.dumps(item.stac).encode("utf-8"))
-        get_log().info("stac item written to tmp", location=tmp_file_path)
-
-        collection.add_item(item.stac)
-
-        tmp_file_path = os.path.join("/tmp/", "collection.json")
-        write(tmp_file_path, json.dumps(collection.stac).encode("utf-8"))
 
 
 def create_item(
@@ -79,7 +29,3 @@ def create_item(
 
     get_log().info("imagery stac item created", file=file)
     return item
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -106,11 +106,11 @@ def _get_object(bucket: str, file_name: str, s3_client: boto3.client) -> Any:
 
 
 def get_object_parallel_multithreading(
-    bucket: str, files_to_read: List[str], s3_client: Optional[boto3.client]
+    bucket: str, files_to_read: List[str], s3_client: Optional[boto3.client], concurrency: int
 ) -> Generator[Any, Union[Any, BaseException], None]:
     if not s3_client:
         s3_client = boto3.client("s3")
-    with ThreadPoolExecutor(max_workers=50) as executor:
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
         future_to_key = {executor.submit(_get_object, bucket, key, s3_client): key for key in files_to_read}
 
         for future in futures.as_completed(future_to_key):

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -1,8 +1,13 @@
+from concurrent import futures
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Generator, List, Optional, Union
+
 import boto3
 import botocore
 from linz_logger import get_log
 
 from scripts.aws.aws_helper import get_session, parse_path
+from scripts.files.files_helper import is_json
 from scripts.logging.time_helper import time_in_ms
 
 
@@ -75,3 +80,44 @@ def bucket_name_from_path(path: str) -> str:
 def prefix_from_path(path: str) -> str:
     bucket_name = bucket_name_from_path(path)
     return path.replace(f"s3://{bucket_name}/", "")
+
+
+def list_json_in_uri(uri: str, s3_client: Optional[boto3.client]) -> List[str]:
+    if not s3_client:
+        s3_client = boto3.client("s3")
+    files = []
+    paginator = s3_client.get_paginator("list_objects_v2")
+    response_iterator = paginator.paginate(Bucket=bucket_name_from_path(uri), Prefix=prefix_from_path(uri))
+
+    for response in response_iterator:
+        for contents_data in response["Contents"]:
+            key = contents_data["Key"]
+            if not is_json(key):
+                get_log().trace("skipping file not json", file=key, action="collection_from_items", reason="skip")
+                continue
+            files.append(key)
+    get_log().info("Files Listed", number_of_files=len(files))
+    return files
+
+
+def _get_object(bucket: str, file_name: str, s3_client: boto3.client) -> Any:
+    get_log().info("Retrieving File", path=f"s3://{bucket}/{file_name}")
+    return s3_client.get_object(Bucket=bucket, Key=file_name)
+
+
+def get_object_parallel_multithreading(
+    bucket: str, files_to_read: List[str], s3_client: Optional[boto3.client]
+) -> Generator[Any, Union[Any, BaseException], None]:
+    if not s3_client:
+        s3_client = boto3.client("s3")
+    with ThreadPoolExecutor(max_workers=50) as executor:
+        future_to_key = {executor.submit(_get_object, bucket, key, s3_client): key for key in files_to_read}
+
+        for future in futures.as_completed(future_to_key):
+            key = future_to_key[future]
+            exception = future.exception()
+
+            if not exception:
+                yield key, future.result()
+            else:
+                yield key, exception

--- a/scripts/stac/tests/collection_test.py
+++ b/scripts/stac/tests/collection_test.py
@@ -1,72 +1,92 @@
-from scripts.files.files_helper import get_file_name_from_path
+from typing import Generator
+
+import pytest
+
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 
 
-def test_imagery_stac_collection_initialise() -> None:
+@pytest.fixture(name="setup_collection", autouse=True)
+def setup() -> Generator[ImageryCollection, None, None]:
     title = "Test Urban Imagery"
     description = "Test Urban Imagery Description"
     collection = ImageryCollection(title, description)
-
-    assert collection.stac["title"] == title
-    assert collection.stac["description"] == description
+    yield collection
 
 
-def test_imagery_stac_collection_update() -> None:
+def test_title_description_id_created_on_init() -> None:
     title = "Test Urban Imagery"
     description = "Test Urban Imagery Description"
+    collection = ImageryCollection(title, description)
+    assert collection.stac["title"] == "Test Urban Imagery"
+    assert collection.stac["description"] == "Test Urban Imagery Description"
+    assert collection.stac["id"]
+
+
+def test_id_parsed_on_init() -> None:
+    title = "Test"
+    description = "Test"
+    id_ = "Parsed-Ulid"
+    collection = ImageryCollection(title, description, id_)
+    assert collection.stac["id"] == "Parsed-Ulid"
+
+
+def test_bbox_updated_from_none(setup_collection: ImageryCollection) -> None:
+    collection = setup_collection
     bbox = [1799667.5, 5815977.0, 1800422.5, 5814986.0]
-    start_datetime = "2021-01-27T00:00:00Z"
-    end_datetime = "2021-01-27T00:00:00Z"
-    collection = ImageryCollection(title, description)
     collection.update_spatial_extent(bbox)
-    collection.update_temporal_extent(start_datetime, end_datetime)
-    assert collection.stac["title"] == title
-    assert collection.stac["description"] == description
-    assert collection.stac["extent"]["temporal"]["interval"] == [[start_datetime, end_datetime]]
     assert collection.stac["extent"]["spatial"]["bbox"] == [bbox]
 
 
-def test_imagery_stac_collection_update_twice() -> None:
-    title = "Test Urban Imagery"
-    description = "Test Urban Imagery Description"
-    collection = ImageryCollection(title, description)
+def test_bbox_updated_from_existing(setup_collection: ImageryCollection) -> None:
+    collection = setup_collection
+    # init bbox
+    bbox = [174.889641, -41.217532, 174.902344, -41.203521]
+    collection.update_spatial_extent(bbox)
+    # update bbox
+    bbox = [174.917643, -41.211157, 174.922965, -41.205490]
+    collection.update_spatial_extent(bbox)
 
-    bbox_one = [174.889641, -41.217532, 174.902344, -41.203521]
-    start_datetime_one = "2021-01-27T00:00:00Z"
-    end_datetime_one = "2021-01-27T00:00:00Z"
-    collection.update_spatial_extent(bbox_one)
-    collection.update_temporal_extent(start_datetime_one, end_datetime_one)
-
-    bbox_two = [174.917643, -41.211157, 174.922965, -41.205490]
-    start_datetime_two = "2021-02-01T00:00:00Z"
-    end_datetime_two = "2021-02-20T00:00:00Z"
-    collection.update_temporal_extent(start_datetime_two, end_datetime_two)
-    collection.update_spatial_extent(bbox_two)
-
-    assert collection.stac["extent"]["temporal"]["interval"] == [[start_datetime_one, end_datetime_two]]
     assert collection.stac["extent"]["spatial"]["bbox"] == [[174.889641, -41.217532, 174.922965, -41.203521]]
 
 
-def test_add_item(mocker) -> None:  # type: ignore
-    title = "Collection Test"
-    description = "Collection Test Description"
-    ulid = "ulid"
-    collection = ImageryCollection(title=title, description=description, collection_id=ulid)
+def test_interval_updated_from_none(setup_collection: ImageryCollection) -> None:
+    collection = setup_collection
+    start_datetime = "2021-01-27T00:00:00Z"
+    end_datetime = "2021-01-27T00:00:00Z"
+    collection.update_temporal_extent(start_datetime, end_datetime)
+    assert collection.stac["extent"]["temporal"]["interval"] == [[start_datetime, end_datetime]]
 
-    path = "./test/BR34_5000_0304.tiff"
-    id_ = get_file_name_from_path(path)
+
+def test_interval_updated_from_existing(setup_collection: ImageryCollection) -> None:
+    collection = setup_collection
+    # init interval
+    start_datetime = "2021-01-27T00:00:00Z"
+    end_datetime = "2021-01-27T00:00:00Z"
+    collection.update_temporal_extent(start_datetime, end_datetime)
+    # update interval
+    start_datetime = "2021-02-01T00:00:00Z"
+    end_datetime = "2021-02-20T00:00:00Z"
+    collection.update_temporal_extent(start_datetime, end_datetime)
+
+    assert collection.stac["extent"]["temporal"]["interval"] == [["2021-01-27T00:00:00Z", "2021-02-20T00:00:00Z"]]
+
+
+def test_add_item(mocker, setup_collection: ImageryCollection) -> None:  # type: ignore
+    collection = setup_collection
     checksum = "1220cdef68d62fb912110b810e62edc53de07f7a44fb2b310db700e9d9dd58baa6b4"
     mocker.patch("scripts.stac.util.checksum.multihash_as_hex", return_value=checksum)
-    item = ImageryItem(id_, path)
+    item = ImageryItem("BR34_5000_0304", "./test/BR34_5000_0304.tiff")
+
     geometry = [[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]]
     bbox = [1799667.5, 5815977.0, 1800422.5, 5814986.0]
     start_datetime = "2021-01-27 00:00:00Z"
     end_datetime = "2021-01-27 00:00:00Z"
     item.update_spatial(geometry, bbox)
     item.update_datetime(start_datetime, end_datetime)
+
     collection.add_item(item.stac)
 
-    assert {"rel": "item", "href": f"./{id_}.json", "type": "application/json"} in collection.stac["links"]
+    assert {"rel": "item", "href": "./BR34_5000_0304.json", "type": "application/json"} in collection.stac["links"]
     assert collection.stac["extent"]["temporal"]["interval"] == [[start_datetime, end_datetime]]
     assert collection.stac["extent"]["spatial"]["bbox"] == [bbox]


### PR DESCRIPTION
(also includes: deletion of unused code in `create_stac.py` and a refactor of `collection_test.py`)

tested on: `s3://linz-workflow-artifacts/2022-11/03-imagery-standardising-v0.2.0-49-s46rd/flat/`
processes 2569 items in ~34449.404296875ms (a significant improvement!)

if you want, it is very satisfying to test in docker:
Comment out line 60 in collection_from_items.py and run on flat folder that doesn't have a collection, for example:
```
docker run -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE=li-topo-prod topo-imagery:latest python collection_from_items.py --uri s3://linz-workflow-artifacts/2022-11/03-imagery-standardising-v0.2.0-49-s46rd/flat/ --collection-id 01GGXEJG2YEM7SM6CC7KSWFM0S --title temp_title --description temp_description --concurrency 25 | pjl
```