### PR TITLE
fix: tidy up geometry and bbox TDE-522

### DIFF
--- a/scripts/files/geotiff.py
+++ b/scripts/files/geotiff.py
@@ -5,7 +5,7 @@ from shapely.geometry import Polygon
 
 def get_extents(gdalinfo_result: Dict[Any, Any]) -> Tuple[List[List[float]], List[float]]:
 
-    geometry = gdalinfo_result["wgs84Extent"]["coordinates"][0]
-    bbox = list(Polygon(geometry).bounds)
+    geometry = gdalinfo_result["wgs84Extent"]
+    bbox = Polygon(geometry["coordinates"][0]).bounds
 
     return geometry, bbox

--- a/scripts/stac/imagery/item.py
+++ b/scripts/stac/imagery/item.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from scripts.stac.util import checksum
 from scripts.stac.util.STAC_VERSION import STAC_VERSION
@@ -34,8 +34,8 @@ class ImageryItem:
             "datetime": None,
         }
 
-    def update_spatial(self, geometry: List[List[float]], bbox: List[float]) -> None:
-        self.stac["geometry"] = {"type": "Polygon", "coordinates": [geometry]}
+    def update_spatial(self, geometry: Dict[str, List[float]], bbox: Tuple[float]) -> None:
+        self.stac["geometry"] = geometry
         self.stac["bbox"] = bbox
 
     def add_collection(self, collection_id: str) -> None:

--- a/scripts/stac/tests/item_test.py
+++ b/scripts/stac/tests/item_test.py
@@ -5,7 +5,7 @@ from scripts.stac.imagery.item import ImageryItem
 
 def test_imagery_stac_item(mocker) -> None:  # type: ignore
     # mock functions that interact with files
-    geometry = [[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]]
+    geometry = {'type': 'Polygon', 'coordinates': [[[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]]]}
     bbox = [1799667.5, 5815977.0, 1800422.5, 5814986.0]
     checksum = "1220cdef68d62fb912110b810e62edc53de07f7a44fb2b310db700e9d9dd58baa6b4"
     mocker.patch("scripts.stac.util.checksum.multihash_as_hex", return_value=checksum)
@@ -23,7 +23,8 @@ def test_imagery_stac_item(mocker) -> None:  # type: ignore
     assert item.stac["properties"]["start_datetime"] == start_datetime
     assert item.stac["properties"]["end_datetime"] == end_datetime
     assert item.stac["properties"]["datetime"] is None
-    assert item.stac["geometry"]["coordinates"] == [geometry]
+    assert item.stac["geometry"]["coordinates"] == geometry["coordinates"]
+    assert item.stac["geometry"] == geometry
     assert item.stac["bbox"] == bbox
     assert item.stac["assets"]["visual"]["file:checksum"] == checksum
     assert {"rel": "self", "href": f"./{id_}.json", "type": "application/json"} in item.stac["links"]

--- a/scripts/stac/tests/item_test.py
+++ b/scripts/stac/tests/item_test.py
@@ -5,7 +5,10 @@ from scripts.stac.imagery.item import ImageryItem
 
 def test_imagery_stac_item(mocker) -> None:  # type: ignore
     # mock functions that interact with files
-    geometry = {'type': 'Polygon', 'coordinates': [[[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]]]}
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]]],
+    }
     bbox = [1799667.5, 5815977.0, 1800422.5, 5814986.0]
     checksum = "1220cdef68d62fb912110b810e62edc53de07f7a44fb2b310db700e9d9dd58baa6b4"
     mocker.patch("scripts.stac.util.checksum.multihash_as_hex", return_value=checksum)


### PR DESCRIPTION
The bbox and geometry were coerced into the existing code when TDE-502 was done, this is to tidy that up.