### PR TITLE
chore: update osgeo/gdal container to 3.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osgeo/gdal:ubuntu-small-3.6.0
+FROM osgeo/gdal:ubuntu-small-3.6.1
 
 RUN apt-get update
 # Install pip


### PR DESCRIPTION
Increments the osgeo/gdal container version from `3.6.0` to `3.6.1`.

Version 3.6.1 is nominally a bug fix release, but includes changes made in [GDAL pull request 6907](https://github.com/OSGeo/gdal/pull/6907) to improve the performance of gdalwarp when supplying a cutline, as raised by @blacha in [GDAL issue 6905](https://github.com/OSGeo/gdal/issues/6905).