### PR TITLE
feat: use -expand option for paletted tiffs

### DIFF
--- a/scripts/gdal/gdal_bands.py
+++ b/scripts/gdal/gdal_bands.py
@@ -60,6 +60,7 @@ def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None) -> List[str
                 "unknown_palette_band_type",
                 palette_channels=palette_channels,
                 first_entry=colour_table["entries"][0],
+                path=file,
             )
         get_log().error("palette_band_missing_colorTable")
         raise UnknownBandsException
@@ -70,7 +71,11 @@ def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None) -> List[str
 
     if band_red is None or band_green is None or band_blue is None:
         get_log().warn(
-            "gdal_info_bands_failed", band_red=band_red is None, band_green=band_green is None, band_blue=band_blue is None
+            "gdal_info_bands_failed",
+            band_red=band_red is None,
+            band_green=band_green is None,
+            band_blue=band_blue is None,
+            path=file,
         )
 
         # Not enough bands for RGB assume it is grey scale

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -1,24 +1,41 @@
 import json
 import re
-from typing import Any, Dict, List, Optional, TypedDict, cast
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union, cast
 
 from linz_logger import get_log
 
 from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
 
+SingleBandColours = Literal["Red", "Green", "Blue", "Alpha", "Gray"]
+PaletteBandColours = Literal["Palette"]
+BandColours = Literal[SingleBandColours, PaletteBandColours]
 
-class GdalInfoBand(TypedDict):
+
+class GdalInfoBandBase(TypedDict):
     band: int
     """band offset, starting at 1
     """
     block: List[int]
     type: str
-    colorInterpretation: str
-    """Color
-    Examples:
-        "Red", "Green", "Blue", "Alpha", "Gray"
-    """
     noDataValue: Optional[int]
+
+
+class GdalInfoBandSingle(GdalInfoBandBase):
+    colorInterpretation: SingleBandColours
+
+
+class GdalInfoBandColorTable(TypedDict):
+    palette: str
+    count: int
+    entries: List[List[int]]
+
+
+class GdalInfoBandPalette(GdalInfoBandBase):
+    colorInterpretation: PaletteBandColours
+    colorTable: GdalInfoBandColorTable
+
+
+GdalInfoBand = Union[GdalInfoBandSingle, GdalInfoBandPalette]
 
 
 class GdalInfo(TypedDict):

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -1,27 +1,10 @@
 import json
 import re
-from typing import Any, Dict, List, Literal, Optional, TypedDict, Union, cast
+from typing import Any, Dict, List, Optional, TypedDict, cast
 
 from linz_logger import get_log
 
 from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
-
-SingleBandColours = Literal["Red", "Green", "Blue", "Alpha", "Gray"]
-PaletteBandColours = Literal["Palette"]
-BandColours = Literal[SingleBandColours, PaletteBandColours]
-
-
-class GdalInfoBandBase(TypedDict):
-    band: int
-    """band offset, starting at 1
-    """
-    block: List[int]
-    type: str
-    noDataValue: Optional[int]
-
-
-class GdalInfoBandSingle(GdalInfoBandBase):
-    colorInterpretation: SingleBandColours
 
 
 class GdalInfoBandColorTable(TypedDict):
@@ -30,12 +13,19 @@ class GdalInfoBandColorTable(TypedDict):
     entries: List[List[int]]
 
 
-class GdalInfoBandPalette(GdalInfoBandBase):
-    colorInterpretation: PaletteBandColours
-    colorTable: GdalInfoBandColorTable
-
-
-GdalInfoBand = Union[GdalInfoBandSingle, GdalInfoBandPalette]
+class GdalInfoBand(TypedDict):
+    band: int
+    """band offset, starting at 1
+    """
+    block: List[int]
+    type: str
+    colorInterpretation: str
+    """Color
+    Examples:
+        "Red", "Green", "Blue", "Alpha", "Gray", "Palette"
+    """
+    noDataValue: Optional[int]
+    colorTable: Optional[GdalInfoBandColorTable]
 
 
 class GdalInfo(TypedDict):

--- a/scripts/gdal/tests/gdal_bands_test.py
+++ b/scripts/gdal/tests/gdal_bands_test.py
@@ -1,5 +1,5 @@
 from scripts.gdal.gdal_bands import get_gdal_band_offset
-from scripts.gdal.tests.gdalinfo import add_band, fake_gdal_info
+from scripts.gdal.tests.gdalinfo import add_band, add_palette_band, fake_gdal_info
 
 
 def test_gdal_grey_bands() -> None:
@@ -44,13 +44,22 @@ def test_gdal_rgb_bands_detection() -> None:
     assert " ".join(bands) == "-b 1 -b 2 -b 3"
 
 
-def test_gdal_default_grey_scale() -> None:
+def test_gdal_rgba_palette_detection() -> None:
     gdalinfo = fake_gdal_info()
-    add_band(gdalinfo, color_interpretation="Pallette")
+    add_palette_band(gdalinfo, colour_table_entries=[[x, x, x, 255] for x in reversed(range(256))])
 
     bands = get_gdal_band_offset("some_file.tiff", gdalinfo)
 
-    assert " ".join(bands) == "-b 1 -b 1 -b 1"
+    assert " ".join(bands) == "-expand rgba"
+
+
+def test_gdal_rgb_palette_detection() -> None:
+    gdalinfo = fake_gdal_info()
+    add_palette_band(gdalinfo, colour_table_entries=[[x, x, x] for x in reversed(range(256))])
+
+    bands = get_gdal_band_offset("some_file.tiff", gdalinfo)
+
+    assert " ".join(bands) == "-expand rgb"
 
 
 def test_gdal_default_rgb() -> None:

--- a/scripts/gdal/tests/gdalinfo.py
+++ b/scripts/gdal/tests/gdalinfo.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, cast
 
-from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand, GdalInfoBandPalette
+from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
 
 
 def fake_gdal_info() -> GdalInfo:
@@ -25,7 +25,7 @@ def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: List[List[int]], 
 
     gdalinfo["bands"].append(
         cast(
-            GdalInfoBandPalette,
+            GdalInfoBand,
             {
                 "band": len(gdalinfo["bands"]) + 1,
                 "colorInterpretation": "Palette",

--- a/scripts/gdal/tests/gdalinfo.py
+++ b/scripts/gdal/tests/gdalinfo.py
@@ -1,6 +1,6 @@
-from typing import Optional, cast
+from typing import List, Optional, cast
 
-from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
+from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand, GdalInfoBandPalette
 
 
 def fake_gdal_info() -> GdalInfo:
@@ -15,5 +15,22 @@ def add_band(gdalinfo: GdalInfo, color_interpretation: Optional[str] = None, no_
         cast(
             GdalInfoBand,
             {"band": len(gdalinfo["bands"]) + 1, "colorInterpretation": color_interpretation, "noDataValue": no_data_value},
+        )
+    )
+
+
+def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: List[List[int]], no_data_value: Optional[int] = None) -> None:
+    if gdalinfo.get("bands", None) is None:
+        gdalinfo["bands"] = []
+
+    gdalinfo["bands"].append(
+        cast(
+            GdalInfoBandPalette,
+            {
+                "band": len(gdalinfo["bands"]) + 1,
+                "colorInterpretation": "Palette",
+                "noDataValue": no_data_value,
+                "colorTable": {"palette": "RGB", "count": len(colour_table_entries), "entries": colour_table_entries},
+            },
         )
     )

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -22,7 +22,6 @@ from scripts.logging.time_helper import time_in_ms
 def run_standardising(files: List[str], preset: str, cutline: Optional[str], concurrency: int) -> List[FileTiff]:
     start_time = time_in_ms()
     actual_tiffs = []
-    standardized_tiffs: List[FileTiff] = []
 
     for file in files:
         if is_tiff(file) or is_vrt(file):
@@ -37,10 +36,10 @@ def run_standardising(files: List[str], preset: str, cutline: Optional[str], con
         standardized_tiffs = p.map(partial(standardising, preset=preset, cutline=cutline), actual_tiffs)
         p.close()
         p.join()
-    standardized_tiffs = [tiff for tiff in standardized_tiffs if tiff is not None]
-    get_log().info("standardising_end", duration=time_in_ms() - start_time, fileCount=len(standardized_tiffs))
+    successfully_standardized_tiffs = [tiff for tiff in standardized_tiffs if tiff is not None]
+    get_log().info("standardising_end", duration=time_in_ms() - start_time, fileCount=len(successfully_standardized_tiffs))
 
-    return standardized_tiffs
+    return successfully_standardized_tiffs
 
 
 def download_tiff_file(input_file: str, tmp_path: str) -> str:


### PR DESCRIPTION
These changes handle TIFFs with a band of `Palette` colour interpretation type, using the [`-expand`](https://gdal.org/programs/gdal_translate.html#cmdoption-gdal_translate-expand) argument to `gdal_translate`. This takes the contents of the colour palette and applies it to the rgb/rgba bands in the output file.

This resolves the following error encountered when standardising historical imagery survey SN9911:

> `ERROR 6: GTIFFBuildOverviews() doesn't support building overviews of multiple colormapped bands.`

which used the band arguements `-b 1 -b 1 -b 1`.

It seems plausible that there could be malformed paletted TIFFs which would not be able to be standardised using this change, but it resolves the direct issue for SN9911.