### PR TITLE
ci: use docker push --all-tags to avoid multiple push TDE-626

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -27,5 +27,5 @@ jobs:
           GIT_VERSION=$(git describe --tags --always --match 'v*')
           docker tag topo-imagery ghcr.io/linz/topo-imagery:latest
           docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION}
-          docker push ghcr.io/linz/topo-imagery:latest
-          docker push ghcr.io/linz/topo-imagery:${GIT_VERSION}
+
+          docker push --all-tags ghcr.io/linz/topo-imagery

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,7 +45,4 @@ jobs:
           docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION_MAJOR_MINOR}
           docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION}
 
-          docker push ghcr.io/linz/topo-imagery:latest
-          docker push ghcr.io/linz/topo-imagery:${GIT_VERSION_MAJOR}
-          docker push ghcr.io/linz/topo-imagery:${GIT_VERSION_MAJOR_MINOR}
-          docker push ghcr.io/linz/topo-imagery:${GIT_VERSION}
+          docker push --all-tags ghcr.io/linz/topo-imagery


### PR DESCRIPTION
Use `--all-tags` flag in order to avoid falling into a rate limit by pushing multiple tags in sequence
Same change for `argo-tasks` https://github.com/linz/argo-tasks/pull/214