### PR TITLE
feat: standardising TIFF bands from 16 bits to 8 bits TDE-628

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,17 +15,15 @@ jobs:
 
       - name: Build containers
         run: |
-          docker build . --tag topo-imagery --label "github_run_id=${GITHUB_RUN_ID}"
-
+          docker build . --tag topo-imagery-test --label "github_run_id=${GITHUB_RUN_ID}"
       - name: Log in to registry
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{(github.ref == 'refs/heads/master') && !(contains(github.event.head_commit.message, 'release'))}}
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Publish Containers
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{(github.ref == 'refs/heads/master') && !(contains(github.event.head_commit.message, 'release'))}}
         run: |
           GIT_VERSION=$(git describe --tags --always --match 'v*')
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:latest
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION}
-
-          docker push --all-tags ghcr.io/linz/topo-imagery
+          docker tag topo-imagery-test ghcr.io/paulfouquet/topo-imagery-test:latest
+          docker tag topo-imagery-test ghcr.io/paulfouquet/topo-imagery-test:${GIT_VERSION}
+          docker push --all-tags ghcr.io/paulfouquet/topo-imagery-test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           release-type: python
           token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-title-pattern: "release: ${version}"
 
   publish-release:
     needs: release-please
@@ -29,8 +28,7 @@ jobs:
 
       - name: Build containers
         run: |
-          docker build . --tag topo-imagery --label "github_run_id=${GITHUB_RUN_ID}"
-
+          docker build . --tag topo-imagery-test --label "github_run_id=${GITHUB_RUN_ID}"
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
@@ -39,10 +37,8 @@ jobs:
           GIT_VERSION=$(git describe --tags --always --match 'v*')
           GIT_VERSION_MAJOR=$(echo $GIT_VERSION | cut -d. -f1)
           GIT_VERSION_MAJOR_MINOR=$(echo $GIT_VERSION | cut -d. -f1,2)
-
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:latest
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION_MAJOR}
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION_MAJOR_MINOR}
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION}
-
-          docker push --all-tags ghcr.io/linz/topo-imagery
+          docker tag topo-imagery-test ghcr.io/paulfouquet/topo-imagery-test:latest
+          docker tag topo-imagery-test ghcr.io/paulfouquet/topo-imagery-test:${GIT_VERSION_MAJOR_MINOR}
+          docker tag topo-imagery-test ghcr.io/paulfouquet/topo-imagery-test:${GIT_VERSION_MAJOR}
+          docker tag topo-imagery-test ghcr.io/paulfouquet/topo-imagery-test:${GIT_VERSION}
+          docker push --all-tags ghcr.io/paulfouquet/topo-imagery-test

--- a/scripts/gdal/gdal_bands.py
+++ b/scripts/gdal/gdal_bands.py
@@ -64,3 +64,20 @@ def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None) -> List[str
         return ["-b", "1", "-b", "2", "-b", "3"] + alpha_band_info
 
     return ["-b", str(band_red["band"]), "-b", str(band_green["band"]), "-b", str(band_blue["band"])] + alpha_band_info
+
+
+def get_gdal_band_type(file: str, info: Optional[GdalInfo] = None) -> str:
+    """Get the band type to determine the bit number
+
+    Args:
+        file: file to check
+        info: optional precomputed gdalinfo
+
+    Returns:
+        band type
+    """
+    if info is None:
+        info = gdal_info(file, False)
+
+    bands = info["bands"]
+    return bands[0]["type"]

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -2,9 +2,6 @@ from typing import List, Optional
 
 from linz_logger import get_log
 
-from scripts.gdal.gdal_bands import get_gdal_band_type
-from scripts.gdal.gdalinfo import GdalInfo
-
 # Force the source projection as NZTM EPSG:2193
 NZTM_SOURCE = ["-a_srs", "EPSG:2193"]
 

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -2,6 +2,9 @@ from typing import List, Optional
 
 from linz_logger import get_log
 
+from scripts.gdal.gdal_bands import get_gdal_band_type
+from scripts.gdal.gdalinfo import GdalInfo
+
 # Force the source projection as NZTM EPSG:2193
 NZTM_SOURCE = ["-a_srs", "EPSG:2193"]
 
@@ -62,8 +65,21 @@ WEBP_OVERVIEWS = [
     "overview_quality=90",
 ]
 
+# Arguments to convert TIFF from 16 bits to 8 bits
+CONVERT_BYTE = [
+    "-ot",
+    "Byte",
+    "-scale",
+    # 16 bit --> 2^16 = 65536 values --> 0-65535
+    "0",
+    "65535",
+    # 8 bit --> 2^8 = 256 values --> 0-255
+    "0",
+    "255",
+]
 
-def get_gdal_command(preset: str) -> List[str]:
+
+def get_gdal_command(preset: str, convert_to_byte: Optional[bool] = False) -> List[str]:
     get_log().info("gdal_preset", preset=preset)
     gdal_command: List[str] = ["gdal_translate"]
 
@@ -78,6 +94,9 @@ def get_gdal_command(preset: str) -> List[str]:
         gdal_command.extend(COMPRESS_WEBP_LOSSLESS)
 
     gdal_command.extend(WEBP_OVERVIEWS)
+
+    if convert_to_byte:
+        gdal_command.extend(CONVERT_BYTE)
 
     return gdal_command
 

--- a/scripts/gdal/tests/gdal_bands_test.py
+++ b/scripts/gdal/tests/gdal_bands_test.py
@@ -1,4 +1,4 @@
-from scripts.gdal.gdal_bands import get_gdal_band_offset
+from scripts.gdal.gdal_bands import get_gdal_band_offset, get_gdal_band_type
 from scripts.gdal.tests.gdalinfo import add_band, fake_gdal_info
 
 
@@ -62,3 +62,14 @@ def test_gdal_default_rgb() -> None:
     bands = get_gdal_band_offset("some_file.tiff", gdalinfo)
 
     assert " ".join(bands) == "-b 1 -b 2 -b 3"
+
+
+def test_get_band_type() -> None:
+    gdalinfo = fake_gdal_info()
+    add_band(gdalinfo, band_type="UInt16")
+    add_band(gdalinfo, band_type="UInt16")
+    add_band(gdalinfo, band_type="UInt16")
+
+    band_type = get_gdal_band_type("some_file.tiff", gdalinfo)
+
+    assert band_type == "UInt16"

--- a/scripts/gdal/tests/gdalinfo.py
+++ b/scripts/gdal/tests/gdalinfo.py
@@ -7,13 +7,23 @@ def fake_gdal_info() -> GdalInfo:
     return cast(GdalInfo, {})
 
 
-def add_band(gdalinfo: GdalInfo, color_interpretation: Optional[str] = None, no_data_value: Optional[int] = None) -> None:
+def add_band(
+    gdalinfo: GdalInfo,
+    color_interpretation: Optional[str] = None,
+    no_data_value: Optional[int] = None,
+    band_type: Optional[str] = None,
+) -> None:
     if gdalinfo.get("bands", None) is None:
         gdalinfo["bands"] = []
 
     gdalinfo["bands"].append(
         cast(
             GdalInfoBand,
-            {"band": len(gdalinfo["bands"]) + 1, "colorInterpretation": color_interpretation, "noDataValue": no_data_value},
+            {
+                "band": len(gdalinfo["bands"]) + 1,
+                "colorInterpretation": color_interpretation,
+                "noDataValue": no_data_value,
+                "type": band_type,
+            },
         )
     )

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -13,9 +13,10 @@ from scripts.cli.cli_helper import format_source, is_argo
 from scripts.files.file_tiff import FileTiff
 from scripts.files.files_helper import get_file_name_from_path, is_tiff, is_vrt
 from scripts.files.fs import read, write
-from scripts.gdal.gdal_bands import get_gdal_band_offset
+from scripts.gdal.gdal_bands import get_gdal_band_offset, get_gdal_band_type
 from scripts.gdal.gdal_helper import get_gdal_version, run_gdal
 from scripts.gdal.gdal_preset import get_cutline_command, get_gdal_command
+from scripts.gdal.gdalinfo import gdal_info
 from scripts.logging.time_helper import time_in_ms
 
 
@@ -100,8 +101,14 @@ def standardising(file: str, preset: str, cutline: Optional[str]) -> FileTiff:
             run_gdal(get_cutline_command(input_cutline_path), input_file=input_file, output_file=target_vrt)
             input_file = target_vrt
 
-        command = get_gdal_command(preset)
-        command.extend(get_gdal_band_offset(input_file))
+        # gdalinfo to get band offset and band type
+        info = gdal_info(file, False)
+        convert_to_byte = False
+        if get_gdal_band_type(input_file, info) == "UInt16":
+            convert_to_byte = True
+
+        command = get_gdal_command(preset, convert_to_byte)
+        command.extend(get_gdal_band_offset(input_file, info))
 
         run_gdal(command, input_file=input_file, output_file=standardized_file_path)
 


### PR DESCRIPTION
We recently had a dataset with 16 bits TIFF (`band.type = UInt16`). `gdal_translate` with `webp` compression requires a 8 bits TIFF. The solution proposed here is to determine the number of bits of the first `band` of the TIFF, assuming all the bands have the same `type` and in the case of a `UInt16` type, apply the transformation from 16 to 8 bits.