### PR TITLE
fix: log wrong vsis3 path non visual qa TDE-563

### DIFF
--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -7,7 +7,7 @@ from linz_logger import get_log
 from scripts.cli.cli_helper import format_date, format_source, is_argo, valid_date
 from scripts.create_stac import create_item
 from scripts.files.fs import write
-from scripts.gdal.gdal_helper import get_srs
+from scripts.gdal.gdal_helper import get_srs, get_vfs_path
 from scripts.standardising import run_standardising
 
 
@@ -55,11 +55,12 @@ def main() -> None:
                 argo_template = json.loads(env_argo_template)
                 s3_information = argo_template["archiveLocation"]["s3"]
                 standardised_path = os.path.join(
-                    "/vsis3", s3_information["bucket"], s3_information["key"], file.get_path_standardised()
+                    "/vsis3",
+                    s3_information["bucket"],
+                    s3_information["key"],
+                    *file.get_path_standardised().split("/"),
                 )
-                original_path = os.path.join(
-                    "/vsis3", s3_information["bucket"], s3_information["key"], file.get_path_original()
-                )
+                original_path = get_vfs_path(file.get_path_original())
             get_log().info(
                 "non_visual_qa_errors",
                 originalPath=original_path,


### PR DESCRIPTION
The `vsis3` path were wrong for both `standardised_path` and `original_path`