### PR TITLE
refactor: use consistent case for json logs

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -58,14 +58,14 @@ def main() -> None:
         if not arguments.collection_id == item_stac["collection"]:
             get_log().trace(
                 "skipping: item.collection != collection.id",
-                file=key,
+                path=key,
                 action="collection_from_items",
                 reason="skip",
             )
             continue
 
         collection.add_item(item_stac)
-        get_log().info("item added to collection", item=item_stac["id"], file=key)
+        get_log().info("item added to collection", item=item_stac["id"], path=key)
 
     get_log().info(
         "Matching items added to collection",

--- a/scripts/create_polygons.py
+++ b/scripts/create_polygons.py
@@ -50,7 +50,7 @@ def main() -> None:
     for file in source:
         try:
             if not is_tiff(file):
-                get_log().trace("create_polygon_file_not_tiff_skipped", file=file)
+                get_log().trace("create_polygon_file_not_tiff_skipped", path=file)
                 continue
             with tempfile.TemporaryDirectory() as tmp_dir:
                 source_file_name = os.path.basename(file)
@@ -77,7 +77,7 @@ def main() -> None:
 
                 output_files.append(temp_file_path)
         except Exception as e:  # pylint:disable=broad-except
-            get_log().error("create_polygon_file_skipped", file=file, error=str(e))
+            get_log().error("create_polygon_file_skipped", path=file, error=str(e))
             is_error = True
 
     with open("/tmp/file_list.json", "w", encoding="utf-8") as jf:
@@ -85,7 +85,7 @@ def main() -> None:
 
     get_log().info("create_polygons_end", duration=time_in_ms() - start_time)
     if is_error:
-        get_log().info("create_polygons_warn", warning="At least one file has been skipped")
+        get_log().warn("create_polygons_some_file_skipped")
         sys.exit(1)
 
 

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -75,10 +75,10 @@ def gdal_info(path: str, stats: bool = True) -> GdalInfo:
         gdalinfo_process = run_gdal(gdalinfo_command, path)
         return cast(GdalInfo, json.loads(gdalinfo_process.stdout))
     except json.JSONDecodeError as e:
-        get_log().error("load_gdalinfo_result_error", file=path, error=e)
+        get_log().error("load_gdalinfo_result_error", path=path, error=e)
         raise e
     except GDALExecutionException as e:
-        get_log().error("gdalinfo_failed", file=path, error=str(e))
+        get_log().error("gdalinfo_failed", path=path, error=str(e))
         raise e
 
 

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -36,7 +36,7 @@ def main() -> None:
     # Standardize the tiffs
     tiff_files = run_standardising(source, arguments.preset, arguments.cutline, concurrency)
     if len(tiff_files) == 0:
-        get_log().info("no_tiff_file", action="standardise_validate", reason="skipped")
+        get_log().info("standardising_no_file_processed")
         return
 
     # SRS needed for FileCheck (non visual QA)
@@ -63,8 +63,8 @@ def main() -> None:
                 original_path = get_vfs_path(file.get_path_original())
             get_log().info(
                 "non_visual_qa_errors",
-                originalPath=original_path,
-                standardisedPath=standardised_path,
+                original_path=original_path,
+                standardised_path=standardised_path,
                 errors=file.get_errors(),
             )
         else:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -29,17 +29,17 @@ def run_standardising(files: List[str], preset: str, cutline: Optional[str], con
         if is_tiff(file) or is_vrt(file):
             actual_tiffs.append(file)
         else:
-            get_log().info("standardising_file_not_tiff_skipped", file=file)
+            get_log().info("standardising_file_not_tiff_skipped", path=file)
 
     gdal_version = get_gdal_version()
-    get_log().info("standardising_start", gdalVersion=gdal_version, fileCount=len(actual_tiffs))
+    get_log().info("standardising_start", gdal_version=gdal_version, file_count=len(actual_tiffs))
 
     with Pool(concurrency) as p:
         standardized_tiffs = p.map(partial(standardising, preset=preset, cutline=cutline), actual_tiffs)
         p.close()
         p.join()
 
-    get_log().info("standardising_end", duration=time_in_ms() - start_time, fileCount=len(standardized_tiffs))
+    get_log().info("standardising_end", duration=time_in_ms() - start_time, file_count=len(standardized_tiffs))
 
     return standardized_tiffs
 


### PR DESCRIPTION
- Some of the JSON attributes in the logs were not consistent. This PR aligns all of them in a snake_case which follows Python conventions.
- Renamed `file` to `path`
- Might need to update Kibana Non Visual QA Dashboard for `original_path` and `standardised_path`