### PR TITLE
fix: update permissions

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,10 @@ jobs:
   publish-release:
     needs: release-please
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - name: Checkout


### PR DESCRIPTION
publishing to Github CR requires:
https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
```
permissions:
  contents: read
  packages: write
```
configuring aws credentials requires:
https://github.com/aws-actions/configure-aws-credentials#usage
```
permissions:
  id-token: write
  contents: read
```
