### PR TITLE
ci: use env vars TDE-704

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Publish Containers to ECR
         if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }/esk
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }/eks
           TAG: topo-imagery
         run: |
           docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-latest

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -27,14 +27,16 @@ jobs:
 
       - name: Publish Containers to GHCR
         if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        env:
+          TAG: topo-imagery
         run: |
           GIT_VERSION=$(git describe --tags --always --match 'v*')
           echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
 
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:latest
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION}
+          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:latest
+          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION}
 
-          docker push --all-tags ghcr.io/linz/topo-imagery
+          docker push --all-tags ghcr.io/linz/${{ env.TAG }}
 
       - name: Configure AWS Credentials
         if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
@@ -52,13 +54,10 @@ jobs:
       - name: Publish Containers to ECR
         if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: eks
-          IMAGE_TAG: ${{ github.sha }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }/esk
+          TAG: topo-imagery
         run: |
-          docker pull ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }}
+          docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
+          docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
 
-          docker tag ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }} ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-latest
-          docker tag ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }} ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-${{ env.GIT_VERSION }}
-
-          docker push --all-tags ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks
+          docker push --all-tags ${{ env.REGISTRY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,8 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Publish Containers to GHCR
+        env:
+          TAG: topo-imagery
         run: |
           GIT_VERSION=$(git describe --tags --always --match 'v*')
           GIT_VERSION_MAJOR=$(echo $GIT_VERSION | cut -d. -f1)
@@ -47,12 +49,12 @@ jobs:
           echo "GIT_VERSION_MAJOR=$GIT_VERSION_MAJOR" >> $GITHUB_ENV
           echo "GIT_VERSION_MAJOR_MINOR=$GIT_VERSION_MAJOR_MINOR" >> $GITHUB_ENV
 
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:latest
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION_MAJOR}
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION_MAJOR_MINOR}
-          docker tag topo-imagery ghcr.io/linz/topo-imagery:${GIT_VERSION}
+          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:latest
+          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION_MAJOR}
+          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION_MAJOR_MINOR}
+          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION}
 
-          docker push --all-tags ghcr.io/linz/topo-imagery
+          docker push --all-tags ghcr.io/linz/${{ env.TAG }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -67,16 +69,12 @@ jobs:
 
       - name: Publish Containers to ECR
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: eks
-          IMAGE_TAG: ${{ github.sha }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}/eks
+          TAG: topo-imagery
         run: |
+          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
+          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION_MAJOR }}
+          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION_MAJOR_MINOR }}
+          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
 
-          docker pull ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }}
-
-          docker tag ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }} ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-latest
-          docker tag ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }} ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-${{ env.GIT_VERSION_MAJOR }}
-          docker tag ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }} ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-${{ env.GIT_VERSION_MAJOR_MINOR }}
-          docker tag ghcr.io/linz/topo-imagery:${{ env.GIT_VERSION }} ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks:topo-imagery-${{ env.GIT_VERSION }}
-
-          docker push --all-tags ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.ap-southeast-2.amazonaws.com/eks
+          docker push --all-tags ${{ env.REGISTRY }}


### PR DESCRIPTION
this tidies the workflow, removes the need for a secret and makes the workflow easier to copy between repos