### PR TITLE
fix: fs_s3.read() exceptions are not caught properly

### DIFF
--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -39,11 +39,14 @@ def read(path: str, needs_credentials: bool = False) -> bytes:
     """Read a file on a AWS S3 bucket.
 
     Args:
-        path (str): The AWS S3 path to the file to read.
-        needs_credentials (bool, optional):  Tells if credentials are needed. Defaults to False.
+        path: The AWS S3 path to the file to read.
+        needs_credentials:  Tells if credentials are needed. Defaults to False.
+
+    Raises:
+        ce: botocore ClientError
 
     Returns:
-        bytes: The file in bytes.
+        The file in bytes.
     """
     start_time = time_in_ms()
     s3_path = parse_path(path)
@@ -57,16 +60,15 @@ def read(path: str, needs_credentials: bool = False) -> bytes:
         s3_object = s3.Object(s3_path.bucket, key)
         file: bytes = s3_object.get()["Body"].read()
     except s3.meta.client.exceptions.ClientError as ce:
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services
         if not needs_credentials and ce.response["Error"]["Code"] == "AccessDenied":
             get_log().debug("read_s3_needs_credentials", path=path)
             return read(path, True)
+        if ce.response["Error"]["Code"] == "NoSuchBucket":
+            get_log().error("s3_bucket_not_found", path=path, error=f"The specified bucket does not seem to exist: {ce}")
+        if ce.response["Error"]["Code"] == "NoSuchKey":
+            get_log().error("s3_key_not_found", path=path, error=f"The specified key does not seem to exist: {ce}")
         raise ce
-    except s3.meta.client.exceptions.NoSuchBucket as nsb:
-        get_log().error("read_s3_bucket_not_found", path=path, error=f"The specified bucket does not seem to exist: {nsb}")
-        raise nsb
-    except s3.meta.client.exceptions.NoSuchKey as nsk:
-        get_log().error("read_s3_file_not_found", path=path, error=f"The specified file does not seem to exist: {nsk}")
-        raise nsk
 
     get_log().debug("read_s3_success", path=path, duration=time_in_ms() - start_time)
     return file


### PR DESCRIPTION
Looking into fixing the `fs_s3` unit tests, noticed that the exceptions were not caught properly.