### PR TITLE
chore: upgrade gdal from 3.6.1 to 3.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osgeo/gdal:ubuntu-small-3.6.1
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.0
 
 RUN apt-get update
 # Install pip

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -18,10 +18,6 @@ BASE_COG = [
     # Ensure all CPUs are used for gdal translate
     "-co",
     "num_threads=all_cpus",
-    # Until GDAL 3.7.x this needs to be set as well as num_threads (https://github.com/OSGeo/gdal/issues/7478)
-    "--config",
-    "gdal_num_threads",
-    "all_cpus",
     # If not all tiles are needed in the tiff, instead of writing empty images write a null byte
     # this significantly reduces the size of tiffs which are very sparse
     "-co",


### PR DESCRIPTION
- GDAL is not publishing on `docker.io` anymore
- Remove workaround for https://github.com/OSGeo/gdal/issues/7478 since it's included in `3.7.0`
