### PR TITLE
feat: add --producer-list to allow multiple producers TDE-781

### DIFF
--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -86,3 +86,23 @@ def parse_list(list_s: str, separator: Optional[str] = ";") -> List[str]:
     if list_s:
         return [s.strip() for s in list_s.split(separator) if s != ""]
     return []
+
+
+def coalesce_multi_single(multi_items: Optional[str], single_item: Optional[str]) -> List[str]:
+    """Coalesce strings containing either semicolon delimited values or a single
+    value into a list. `single_item` is used only if `multi_items` is falsy.
+    If both are falsy, an empty list is returned.
+
+    Args:
+        multi_items: string with semicolon delimited values
+        single_item: string with a single value
+
+    Returns:
+        a list of values
+    """
+    output = []
+    if multi_items:
+        output.extend(parse_list(multi_items))
+    elif single_item:
+        output.append(single_item)
+    return output

--- a/scripts/cli/tests/cli_helper_test.py
+++ b/scripts/cli/tests/cli_helper_test.py
@@ -1,4 +1,4 @@
-from scripts.cli.cli_helper import format_source, parse_list
+from scripts.cli.cli_helper import coalesce_multi_single, format_source, parse_list
 
 
 def test_format_source_from_basemaps_cli_file() -> None:
@@ -50,3 +50,27 @@ def test_parse_list() -> None:
 def test_parse_list_empty() -> None:
     list_parsed = parse_list("")
     assert list_parsed == []
+
+
+def test_coalesce_multi_no_single() -> None:
+    multi_items = "foo; bar baz"
+    single_item = ""
+    coalesced_list = coalesce_multi_single(multi_items, single_item)
+    assert isinstance(coalesced_list, list)
+    assert coalesced_list == ["foo", "bar baz"]
+
+
+def test_coalesce_single_no_multi() -> None:
+    multi_items = ""
+    single_item = "foo"
+    coalesced_list = coalesce_multi_single(multi_items, single_item)
+    assert isinstance(coalesced_list, list)
+    assert coalesced_list == ["foo"]
+
+
+def test_coalesce_nothing() -> None:
+    multi_items = ""
+    single_item = ""
+    coalesced_list = coalesce_multi_single(multi_items, single_item)
+    assert isinstance(coalesced_list, list)
+    assert coalesced_list == []

--- a/scripts/cli/tests/cli_helper_test.py
+++ b/scripts/cli/tests/cli_helper_test.py
@@ -56,7 +56,6 @@ def test_coalesce_multi_no_single() -> None:
     multi_items = "foo; bar baz"
     single_item = ""
     coalesced_list = coalesce_multi_single(multi_items, single_item)
-    assert isinstance(coalesced_list, list)
     assert coalesced_list == ["foo", "bar baz"]
 
 
@@ -64,13 +63,12 @@ def test_coalesce_single_no_multi() -> None:
     multi_items = ""
     single_item = "foo"
     coalesced_list = coalesce_multi_single(multi_items, single_item)
-    assert isinstance(coalesced_list, list)
     assert coalesced_list == ["foo"]
 
 
 def test_coalesce_nothing() -> None:
+    # pylint: disable-msg=use-implicit-booleaness-not-comparison
     multi_items = ""
     single_item = ""
     coalesced_list = coalesce_multi_single(multi_items, single_item)
-    assert isinstance(coalesced_list, list)
     assert coalesced_list == []

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -19,23 +19,34 @@ def main() -> None:
     parser.add_argument("--collection-id", dest="collection_id", help="Collection ID", required=True)
     parser.add_argument("--title", dest="title", help="Collection title", required=True)
     parser.add_argument("--description", dest="description", help="Collection description", required=True)
-    parser.add_argument("--producer", dest="producer", help="Imagery producer", required=True)
+    parser.add_argument("--producer", dest="producer", help="Imagery producer")
+    parser.add_argument("--producer-list", dest="producer_list", help="Semicolon delimited list of imagery producers")
     parser.add_argument("--licensor", dest="licensor", help="Imagery licensor")
-    parser.add_argument("--licensor-list", dest="licensor_list", help="Imagery licensor list")
+    parser.add_argument("--licensor-list", dest="licensor_list", help="Semicolon delimited list of imagery licensors")
     parser.add_argument(
         "--concurrency", dest="concurrency", help="The number of files to limit concurrent reads", required=True, type=int
     )
 
     arguments = parser.parse_args()
     uri = arguments.uri
-    licensors: List[str] = parse_list(arguments.licensor_list)
-    if len(licensors) <= 1:
-        licensors = [arguments.licensor]
+
+    producers: List[str] = []
+    if arguments.producer:
+        producers.append(arguments.producer)
+    if arguments.producer_list and ";" in arguments.producer_list:
+        producers.extend(parse_list(arguments.producer_list))
+
+    licensors: List[str] = []
+    if arguments.licensor:
+        licensors.append(arguments.licensor)
+    if arguments.licensor_list and ";" in arguments.licensor_list:
+        licensors.extend(parse_list(arguments.licensor_list))
 
     providers: List[Provider] = []
+    for producer_name in producers:
+        providers.append({"name": producer_name, "roles": [ProviderRole.PRODUCER]})
     for licensor_name in licensors:
         providers.append({"name": licensor_name, "roles": [ProviderRole.LICENSOR]})
-    providers.append({"name": arguments.producer, "roles": [ProviderRole.PRODUCER]})
 
     collection = ImageryCollection(
         title=arguments.title, description=arguments.description, collection_id=arguments.collection_id, providers=providers

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -6,7 +6,7 @@ from typing import List
 from boto3 import client
 from linz_logger import get_log
 
-from scripts.cli.cli_helper import parse_list
+from scripts.cli.cli_helper import coalesce_multi_single
 from scripts.files.fs_s3 import bucket_name_from_path, get_object_parallel_multithreading, list_json_in_uri
 from scripts.logging.time_helper import time_in_ms
 from scripts.stac.imagery.collection import ImageryCollection
@@ -14,7 +14,6 @@ from scripts.stac.imagery.provider import Provider, ProviderRole
 
 
 def main() -> None:
-    # pylint: disable-msg=too-many-locals
     parser = argparse.ArgumentParser()
     parser.add_argument("--uri", dest="uri", help="s3 path to items and collection.json write location", required=True)
     parser.add_argument("--collection-id", dest="collection_id", help="Collection ID", required=True)
@@ -39,22 +38,10 @@ def main() -> None:
     arguments = parser.parse_args()
     uri = arguments.uri
 
-    producers: List[str] = []
-    if arguments.producer_list and ";" in arguments.producer_list:
-        producers.extend(parse_list(arguments.producer_list))
-    elif arguments.producer:
-        producers.append(arguments.producer)
-
-    licensors: List[str] = []
-    if arguments.licensor_list and ";" in arguments.licensor_list:
-        licensors.extend(parse_list(arguments.licensor_list))
-    elif arguments.licensor:
-        licensors.append(arguments.licensor)
-
     providers: List[Provider] = []
-    for producer_name in producers:
+    for producer_name in coalesce_multi_single(arguments.producer_list, arguments.producer):
         providers.append({"name": producer_name, "roles": [ProviderRole.PRODUCER]})
-    for licensor_name in licensors:
+    for licensor_name in coalesce_multi_single(arguments.licensor_list, arguments.licensor):
         providers.append({"name": licensor_name, "roles": [ProviderRole.LICENSOR]})
 
     collection = ImageryCollection(

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -14,14 +14,23 @@ from scripts.stac.imagery.provider import Provider, ProviderRole
 
 
 def main() -> None:
+    # pylint: disable-msg=too-many-locals
     parser = argparse.ArgumentParser()
     parser.add_argument("--uri", dest="uri", help="s3 path to items and collection.json write location", required=True)
     parser.add_argument("--collection-id", dest="collection_id", help="Collection ID", required=True)
     parser.add_argument("--title", dest="title", help="Collection title", required=True)
     parser.add_argument("--description", dest="description", help="Collection description", required=True)
-    parser.add_argument("--producer", dest="producer", help="Imagery producer")
+    parser.add_argument(
+        "--producer",
+        dest="producer",
+        help="Imagery producer. Ignored if --producer-list passed with a semicolon delimited list.",
+    )
     parser.add_argument("--producer-list", dest="producer_list", help="Semicolon delimited list of imagery producers")
-    parser.add_argument("--licensor", dest="licensor", help="Imagery licensor")
+    parser.add_argument(
+        "--licensor",
+        dest="licensor",
+        help="Imagery licensor. Ignored if --licensor-list passed with a semicolon delimited list.",
+    )
     parser.add_argument("--licensor-list", dest="licensor_list", help="Semicolon delimited list of imagery licensors")
     parser.add_argument(
         "--concurrency", dest="concurrency", help="The number of files to limit concurrent reads", required=True, type=int
@@ -31,16 +40,16 @@ def main() -> None:
     uri = arguments.uri
 
     producers: List[str] = []
-    if arguments.producer:
-        producers.append(arguments.producer)
     if arguments.producer_list and ";" in arguments.producer_list:
         producers.extend(parse_list(arguments.producer_list))
+    elif arguments.producer:
+        producers.append(arguments.producer)
 
     licensors: List[str] = []
-    if arguments.licensor:
-        licensors.append(arguments.licensor)
     if arguments.licensor_list and ";" in arguments.licensor_list:
         licensors.extend(parse_list(arguments.licensor_list))
+    elif arguments.licensor:
+        licensors.append(arguments.licensor)
 
     providers: List[Provider] = []
     for producer_name in producers:


### PR DESCRIPTION
Adds `--producer-list` argument to `collection_from_items.py` to allow passing multiple producers to the STAC metadata.

There is a slight change to how both `--licensor-list` and `--producer-list` are handled, which resolves what I think is an edge case that is currently not handled.

Currently, if `--licensor-list` is passed a value without `;`, and `--licensor` is not passed, the output STAC file will include `{ "name": null, "roles": ["licensor"] }`. This PR fixes that, so that it will just not be present in the output.

Alternatively, it could be included as a single un-split item by removing the `and ";" in arguments.licensor_list` checks.

*Edit:* Which now that I've looked at where it's used in the standardising workflow I see would never eventuate in practice, as `--licensor` gets a default value of "Unknown" so `--licensor` is never not passed a value as the script is used in the standardising workflow (though could be if used elsewhere).