### PR TITLE
fix: handle already existing collection.json

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -55,7 +55,7 @@ def main() -> None:
     ):
         item_stac = json.loads(result["Body"].read().decode("utf-8"))
 
-        if not arguments.collection_id == item_stac["collection"]:
+        if not arguments.collection_id == item_stac.get("collection"):
             get_log().trace(
                 "skipping: item.collection != collection.id",
                 file=key,


### PR DESCRIPTION
If the `collection_from_items.py` is run with a `--uri` source of an S3 path which already contains a `collection.json` file which is the output of a previous run of the script, it will fail.

This is because of a KeyError exception for `"collection"`, which all the item STAC files have, but which the resulting `collection.json` file does not, as the collection ID is instead stored in the `"id"` key.

Swapping from `item_stac["collection"]` to `item_stac.get("collection")` eliminates this KeyError exception, and allows the script to run happily with a previously existing `collection.json` file, as it will be skipped and then overwritten.