### PR TITLE
revert: "chore: upgrade gdal from 3.6.1 to 3.7.0 (#479)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.0
+FROM osgeo/gdal:ubuntu-small-3.6.1
 
 RUN apt-get update
 # Install pip

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -20,6 +20,10 @@ BASE_COG = [
     # Ensure all CPUs are used for gdal translate
     "-co",
     "num_threads=all_cpus",
+    # Until GDAL 3.7.x this needs to be set as well as num_threads (https://github.com/OSGeo/gdal/issues/7478)
+    "--config",
+    "gdal_num_threads",
+    "all_cpus",
     # If not all tiles are needed in the tiff, instead of writing empty images write a null byte
     # this significantly reduces the size of tiffs which are very sparse
     "-co",


### PR DESCRIPTION
This reverts commit 82e0b5ee2d610203e0dfed9e1eec4fafbda459e3.
This is a temporary fix to workaround https://github.com/OSGeo/gdal/issues/8038.