### PR TITLE
revert: "revert: "chore: upgrade gdal from 3.6.1 to 3.7.0"" TDE-810

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.6.4
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.0
 
 RUN apt-get update
 # Install pip

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -20,10 +20,6 @@ BASE_COG = [
     # Ensure all CPUs are used for gdal translate
     "-co",
     "num_threads=all_cpus",
-    # Until GDAL 3.7.x this needs to be set as well as num_threads (https://github.com/OSGeo/gdal/issues/7478)
-    "--config",
-    "gdal_num_threads",
-    "all_cpus",
     # If not all tiles are needed in the tiff, instead of writing empty images write a null byte
     # this significantly reduces the size of tiffs which are very sparse
     "-co",


### PR DESCRIPTION
This reverts commit 810b73c566e482b3caf29a73c1ffaccc32a6a1b4. 
We don't need to revert the previous commit anymore.