### PR TITLE
feat: handle standardising paletted tiffs

### DIFF
--- a/scripts/gdal/gdal_bands.py
+++ b/scripts/gdal/gdal_bands.py
@@ -21,6 +21,7 @@ def find_band(bands: List[GdalInfoBand], color: str) -> Optional[GdalInfoBand]:
     return None
 
 
+# pylint: disable-msg=too-many-return-statements
 def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None, preset: Optional[str] = None) -> List[str]:
     """Get the banding parameters for a `gdal_translate` command.
 

--- a/scripts/gdal/gdal_bands.py
+++ b/scripts/gdal/gdal_bands.py
@@ -60,8 +60,11 @@ def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None, preset: Opt
                 "unknown_palette_band_type",
                 palette_channels=palette_channels,
                 first_entry=colour_table["entries"][0],
+                path=file,
             )
-        get_log().error("palette_band_missing_colorTable")
+            raise RuntimeError("unknown_palette_band_type")
+        get_log().error("palette_band_missing_colorTable", path=file)
+        raise RuntimeError("palette_band_missing_colorTable")
 
     band_red = find_band(bands, "Red")
     band_green = find_band(bands, "Green")

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -8,6 +8,12 @@ from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
 from scripts.tile.tile_index import Point
 
 
+class GdalInfoBandColorTable(TypedDict):
+    palette: str
+    count: int
+    entries: List[List[int]]
+
+
 class GdalInfoBand(TypedDict):
     band: int
     """band offset, starting at 1
@@ -17,9 +23,10 @@ class GdalInfoBand(TypedDict):
     colorInterpretation: str
     """Color
     Examples:
-        "Red", "Green", "Blue", "Alpha", "Gray"
+        "Red", "Green", "Blue", "Alpha", "Gray", "Palette"
     """
     noDataValue: Optional[int]
+    colorTable: Optional[GdalInfoBandColorTable]
 
 
 class GdalInfo(TypedDict):

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -10,8 +10,23 @@ from scripts.tile.tile_index import Point
 
 class GdalInfoBandColorTable(TypedDict):
     palette: str
+    """Colour palette type
+    Example: "RGB" """
     count: int
+    """Count of entries in the colour palette
+    Example: 256"""
     entries: List[List[int]]
+    """List of colour palette entries. Each is a list of colour channel values
+    Example:
+    [
+        [255,255,255,255],
+        [254,254,254,255],
+        [253,253,253,255],
+        [252,252,252,255],
+        [251,251,251,255],
+        [250,250,250,255]
+        ...
+    ]"""
 
 
 class GdalInfoBand(TypedDict):

--- a/scripts/gdal/tests/gdal_bands_test.py
+++ b/scripts/gdal/tests/gdal_bands_test.py
@@ -1,5 +1,5 @@
 from scripts.gdal.gdal_bands import get_gdal_band_offset, get_gdal_band_type
-from scripts.gdal.tests.gdalinfo import add_band, fake_gdal_info
+from scripts.gdal.tests.gdalinfo import add_band, add_palette_band, fake_gdal_info
 
 
 def test_gdal_grey_bands() -> None:
@@ -51,6 +51,24 @@ def test_gdal_rgb_bands_detection() -> None:
     bands = get_gdal_band_offset("some_file.tiff", gdalinfo)
 
     assert " ".join(bands) == "-b 1 -b 2 -b 3"
+
+
+def test_gdal_rgba_palette_detection() -> None:
+    gdalinfo = fake_gdal_info()
+    add_palette_band(gdalinfo, colour_table_entries=[[x, x, x, 255] for x in reversed(range(256))])
+
+    bands = get_gdal_band_offset("some_file.tiff", gdalinfo)
+
+    assert " ".join(bands) == "-expand rgba"
+
+
+def test_gdal_rgb_palette_detection() -> None:
+    gdalinfo = fake_gdal_info()
+    add_palette_band(gdalinfo, colour_table_entries=[[x, x, x] for x in reversed(range(256))])
+
+    bands = get_gdal_band_offset("some_file.tiff", gdalinfo)
+
+    assert " ".join(bands) == "-expand rgb"
 
 
 def test_gdal_default_grey_scale() -> None:

--- a/scripts/gdal/tests/gdalinfo.py
+++ b/scripts/gdal/tests/gdalinfo.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
 
@@ -24,6 +24,23 @@ def add_band(
                 "colorInterpretation": color_interpretation,
                 "noDataValue": no_data_value,
                 "type": band_type,
+            },
+        )
+    )
+
+
+def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: List[List[int]], no_data_value: Optional[int] = None) -> None:
+    if gdalinfo.get("bands", None) is None:
+        gdalinfo["bands"] = []
+
+    gdalinfo["bands"].append(
+        cast(
+            GdalInfoBand,
+            {
+                "band": len(gdalinfo["bands"]) + 1,
+                "colorInterpretation": "Palette",
+                "noDataValue": no_data_value,
+                "colorTable": {"palette": "RGB", "count": len(colour_table_entries), "entries": colour_table_entries},
             },
         )
     )


### PR DESCRIPTION
These changes handle TIFFs with a band of Palette colour interpretation type, using the [-expand](https://gdal.org/programs/gdal_translate.html#cmdoption-gdal_translate-expand) argument to gdal_translate. This takes the contents of the colour palette and applies it to the rgb/rgba bands in the output file.

This resolves the following error encountered when standardising historical imagery survey SN9911:

    ERROR 6: GTIFFBuildOverviews() doesn't support building overviews of multiple colormapped bands.

which used the band arguements -b 1 -b 1 -b 1.

This PR supersedes https://github.com/linz/topo-imagery/pull/310 which was proposed when previously processing historical imagery. I've made a new PR mainly to simplify having to rebase 6 months worth of changes from master onto that branch. 

Changes from the earlier PR are that I have now removed the raising of an exception and the handling to catch it, which were the aspects still under discussion preventing it being merged.