### PR TITLE
ci: refactor container publishing and use Docker metadata

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -11,53 +11,79 @@ jobs:
       id-token: write
       contents: read
       packages: write
+    env:
+      AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Build containers
-        run: |
-          docker build . --tag topo-imagery --label "github_run_id=${GITHUB_RUN_ID}"
-
-      - name: Log in to Registry
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
-      - name: Publish Containers to GHCR
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        env:
-          TAG: topo-imagery
+      - name: Setup GIT version
+        id: version
         run: |
           GIT_VERSION=$(git describe --tags --always --match 'v*')
-          echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
+          GIT_VERSION_MAJOR=$(echo $GIT_VERSION | cut -d. -f1)
+          GIT_VERSION_MAJOR_MINOR=$(echo $GIT_VERSION | cut -d. -f1,2)
+          echo "version=${GIT_VERSION}" >> $GITHUB_OUTPUT
+          echo "version_major=${GIT_VERSION_MAJOR}" >> $GITHUB_OUTPUT
+          echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}" >> $GITHUB_OUTPUT
 
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:latest
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-          docker push --all-tags ghcr.io/linz/${{ env.TAG }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
+      - name: Login to GitHub Container Registry
+        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ap-southeast-2
           mask-aws-account-id: true
-          role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+          role-to-assume: ${{ env.AWS_CI_ROLE }}
 
       - name: Login to Amazon ECR
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Publish Containers to ECR
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}/eks
-          TAG: topo-imagery
-        run: |
-          docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
-          docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
+      - name: Setup docker tags
+        id: tags
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const tags = [];
+            tags.push('ghcr.io/${{ github.repository }}:latest');
+            tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
+            if ("${{ steps.login-ecr.outputs.registry }}") {
+            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-latest');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version }}');
+            }
+            return tags.join(', ')
 
-          docker push --all-tags ${{ env.REGISTRY }}
+      - name: Build and push container
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: ${{ steps.tags.outputs.result }}
+          push: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_HASH=${{ github.sha }}
+            GIT_VERSION=${{ steps.version.outputs.version }} 
+            GITHUB_RUN_ID=${{ github.run_id}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,8 @@ jobs:
       id-token: write
       contents: read
       packages: write
+    env:
+      AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - name: Checkout
@@ -70,53 +72,35 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        if: ${{env.AWS_CI_ROLE != ''}}
 
-    
-
-      - name: Build containers
-        run: |
-          docker build . --tag topo-imagery --label "github_run_id=${GITHUB_RUN_ID}"
-
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
-      - name: Publish Containers to GHCR
-        env:
-          TAG: topo-imagery
-        run: |
-          GIT_VERSION=$(git describe --tags --always --match 'v*')
-          GIT_VERSION_MAJOR=$(echo $GIT_VERSION | cut -d. -f1)
-          GIT_VERSION_MAJOR_MINOR=$(echo $GIT_VERSION | cut -d. -f1,2)
-          echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
-          echo "GIT_VERSION_MAJOR=$GIT_VERSION_MAJOR" >> $GITHUB_ENV
-          echo "GIT_VERSION_MAJOR_MINOR=$GIT_VERSION_MAJOR_MINOR" >> $GITHUB_ENV
-
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:latest
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION_MAJOR}
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION_MAJOR_MINOR}
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION}
-
-          docker push --all-tags ghcr.io/linz/${{ env.TAG }}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Setup docker tags
+        id: tags
+        uses: actions/github-script@v6
         with:
-          aws-region: ap-southeast-2
-          mask-aws-account-id: true
-          role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+          result-encoding: string
+          script: |
+            const tags = [];
+            tags.push('ghcr.io/${{ github.repository }}:latest');
+            tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version_major }}');
+            tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version_major_minor }}');
+            tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
+            if ("${{ steps.login-ecr.outputs.registry }}") {
+            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-latest');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version_major }}');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version_major_minor }}');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version }}');
+            }
+            return tags.join(', ')
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Publish Containers to ECR
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}/eks
-          TAG: topo-imagery
-        run: |
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION_MAJOR }}
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION_MAJOR_MINOR }}
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
-
-          docker push --all-tags ${{ env.REGISTRY }}
+      - name: Build and push container
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: ${{ steps.tags.outputs.result }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_HASH=${{ github.sha }}
+            GIT_VERSION=${{ steps.version.outputs.version }} 
+            GITHUB_RUN_ID=${{ github.run_id}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,48 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup GIT version
+        id: version
+        run: |
+          GIT_VERSION=$(git describe --tags --always --match 'v*')
+          GIT_VERSION_MAJOR=$(echo $GIT_VERSION | cut -d. -f1)
+          GIT_VERSION_MAJOR_MINOR=$(echo $GIT_VERSION | cut -d. -f1,2)
+          echo "version=${GIT_VERSION}" >> $GITHUB_OUTPUT
+          echo "version_major=${GIT_VERSION_MAJOR}" >> $GITHUB_OUTPUT
+          echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        if: ${{env.AWS_CI_ROLE != ''}}
+        with:
+          aws-region: ap-southeast-2
+          mask-aws-account-id: true
+          role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+    
+
       - name: Build containers
         run: |
           docker build . --tag topo-imagery --label "github_run_id=${GITHUB_RUN_ID}"


### PR DESCRIPTION
This PR is following the same change that has been made in https://github.com/linz/argo-tasks/pull/544
Additionnaly manage not pushing container on AWS if credentials are not present (using a fork for example). This additional change will be added to `linz/argo-tasks` in a future PR.