### PR TITLE
fix: gdalbuildvrt fails when different coordinate system desc TDE-818

### DIFF
--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -146,7 +146,9 @@ def get_build_vrt_command(files: List[str], output: str = "output.vrt", add_alph
     Returns:
         The GDAL command to build the VRT.
     """
-    gdal_command = ["gdalbuildvrt", "-strict"]
+    # `-allow_projection_difference` is passed to workaround different coordinate system descriptions within the same EPSG
+    # Having the same EPSG code for all images is already checked by `linz/argo-tasks` `tile-index-validate`
+    gdal_command = ["gdalbuildvrt", "-strict", "-allow_projection_difference"]
     if add_alpha:
         gdal_command.append("-addalpha")
     gdal_command.append(output)


### PR DESCRIPTION
## Description
This is to fix the `gdalbuildvrt does not support heterogenous projection` error when the coordinate system description is different (for tiffs having the same EPSG). This also allows to build a VRT file with tiffs having different EPSG, which is not what we want. However, in our workflow, the `argo-task` `tile-index-validate` verify that all the images have the same EPSG code.

## Tests
I've been testing this fix retiling `DEM_BA32_2016_1000_4032.tif` and `DEM_BA32_2016_1000_4031.tif` which was failing without this fix.
I could not generate a test case from the production case having this issue we had. The process to create a lighter tiff does modify this coordinate system description removing the slight difference that was present before generating "smaller" tiffs.