### PR TITLE
feat: provide content type to S3 objects TDE-859

### DIFF
--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -1,7 +1,13 @@
 import os
+from enum import Enum
 from typing import Optional
 
 from scripts.gdal.gdalinfo import GdalInfo, gdal_info
+
+
+class ContentType(str, Enum):
+    TIFF = "image/tiff; application=geotiff; profile=cloud-optimized"
+    JSON = "application/json"
 
 
 def get_file_name_from_path(path: str) -> str:

--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -6,7 +6,7 @@ from scripts.gdal.gdalinfo import GdalInfo, gdal_info
 
 
 class ContentType(str, Enum):
-    TIFF = "image/tiff; application=geotiff; profile=cloud-optimized"
+    GEOTIFF = "image/tiff; application=geotiff; profile=cloud-optimized"
     JSON = "application/json"
     # https://www.iana.org/assignments/media-types/application/geo+json
     GEOJSON = "application/geo+json"

--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -8,6 +8,7 @@ from scripts.gdal.gdalinfo import GdalInfo, gdal_info
 class ContentType(str, Enum):
     TIFF = "image/tiff; application=geotiff; profile=cloud-optimized"
     JSON = "application/json"
+    JPEG = "image/jpeg"
 
 
 def get_file_name_from_path(path: str) -> str:

--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -8,6 +8,8 @@ from scripts.gdal.gdalinfo import GdalInfo, gdal_info
 class ContentType(str, Enum):
     TIFF = "image/tiff; application=geotiff; profile=cloud-optimized"
     JSON = "application/json"
+    # https://www.iana.org/assignments/media-types/application/geo+json
+    GEOJSON = "application/geo+json"
     JPEG = "image/jpeg"
 
 

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -8,15 +8,16 @@ from scripts.aws.aws_helper import is_s3
 from scripts.files import fs_local, fs_s3
 
 
-def write(destination: str, source: bytes) -> str:
+def write(destination: str, source: bytes, content_type: Optional[str] = None) -> str:
     """Write a file from its source to a destination path.
 
     Args:
         destination: A path to where the file will be written.
         source: The source file in bytes.
+        content_type: A standard MIME type describing the format of the contents.
     """
     if is_s3(destination):
-        fs_s3.write(destination, source)
+        fs_s3.write(destination, source, content_type)
     else:
         fs_local.write(destination, source)
     return destination

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -14,7 +14,7 @@ def write(destination: str, source: bytes, content_type: Optional[str] = None) -
     Args:
         destination: A path to where the file will be written.
         source: The source file in bytes.
-        content_type: A standard MIME type describing the format of the contents.
+        content_type: A standard Media Type describing the format of the contents.
     """
     if is_s3(destination):
         fs_s3.write(destination, source, content_type)

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -11,12 +11,13 @@ from scripts.files.files_helper import is_json
 from scripts.logging.time_helper import time_in_ms
 
 
-def write(destination: str, source: bytes) -> None:
+def write(destination: str, source: bytes, content_type: Optional[str] = None) -> None:
     """Write a source (bytes) in a AWS s3 destination (path in a bucket).
 
     Args:
         destination: The AWS S3 path to the file to write.
         source: The source file in bytes.
+        content_type: A standard MIME type describing the format of the contents.
     """
     start_time = time_in_ms()
     if source is None:
@@ -28,7 +29,10 @@ def write(destination: str, source: bytes) -> None:
 
     try:
         s3_object = s3.Object(s3_path.bucket, key)
-        s3_object.put(Body=source)
+        if content_type:
+            s3_object.put(Body=source, ContentType=content_type)
+        else:
+            s3_object.put(Body=source)
         get_log().debug("write_s3_success", path=destination, duration=time_in_ms() - start_time)
     except botocore.exceptions.ClientError as ce:
         get_log().error("write_s3_error", path=destination, error=f"Unable to write the file: {ce}")

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -17,7 +17,7 @@ def write(destination: str, source: bytes, content_type: Optional[str] = None) -
     Args:
         destination: The AWS S3 path to the file to write.
         source: The source file in bytes.
-        content_type: A standard MIME type describing the format of the contents.
+        content_type: A standard Media Type describing the format of the contents.
     """
     start_time = time_in_ms()
     if source is None:

--- a/scripts/files/tests/fs_s3_test.py
+++ b/scripts/files/tests/fs_s3_test.py
@@ -7,6 +7,7 @@ from moto import mock_s3
 from moto.s3.responses import DEFAULT_REGION_NAME
 from pytest import CaptureFixture
 
+from scripts.files.files_helper import ContentType
 from scripts.files.fs_s3 import exists, read, write
 
 
@@ -20,6 +21,19 @@ def test_write() -> None:
 
     resp = client.get_object(Bucket="testbucket", Key="test.file")
     assert resp["Body"].read() == b"test content"
+    assert resp["ContentType"] == "binary/octet-stream"
+
+
+@mock_s3  # type: ignore
+def test_write_content_type() -> None:
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="testbucket")
+
+    write("s3://testbucket/test.tiff", b"test content", ContentType.TIFF.value)
+    resp = client.get_object(Bucket="testbucket", Key="test.tiff")
+    assert resp["Body"].read() == b"test content"
+    assert resp["ContentType"] == ContentType.TIFF.value
 
 
 @mock_s3  # type: ignore

--- a/scripts/files/tests/fs_s3_test.py
+++ b/scripts/files/tests/fs_s3_test.py
@@ -30,10 +30,10 @@ def test_write_content_type() -> None:
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="testbucket")
 
-    write("s3://testbucket/test.tiff", b"test content", ContentType.TIFF.value)
+    write("s3://testbucket/test.tiff", b"test content", ContentType.GEOTIFF.value)
     resp = client.get_object(Bucket="testbucket", Key="test.tiff")
     assert resp["Body"].read() == b"test content"
-    assert resp["ContentType"] == ContentType.TIFF.value
+    assert resp["ContentType"] == ContentType.GEOTIFF.value
 
 
 @mock_s3  # type: ignore

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 import ulid
 
+from scripts.files.files_helper import ContentType
 from scripts.files.fs import write
 from scripts.stac.imagery.provider import Provider, ProviderRole
 from scripts.stac.util.STAC_VERSION import STAC_VERSION
@@ -177,4 +178,4 @@ class ImageryCollection:
         Args:
             destination: path of the destination
         """
-        write(destination, json.dumps(self.stac, ensure_ascii=False).encode("utf-8"))
+        write(destination, json.dumps(self.stac, ensure_ascii=False).encode("utf-8"), content_type=ContentType.JSON.value)

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -7,6 +7,7 @@ from typing import List
 from linz_logger import get_log
 
 from scripts.cli.cli_helper import InputParameterError, format_date, is_argo, load_input_files, valid_date
+from scripts.files.files_helper import ContentType
 from scripts.files.fs import exists, write
 from scripts.gdal.gdal_helper import get_srs, get_vfs_path
 from scripts.stac.imagery.create_stac import create_item
@@ -105,7 +106,7 @@ def main() -> None:
             item = create_item(
                 file.get_path_standardised(), start_datetime, end_datetime, arguments.collection_id, file.get_gdalinfo()
             )
-            write(stac_item_path, json.dumps(item.stac).encode("utf-8"))
+            write(stac_item_path, json.dumps(item.stac).encode("utf-8"), content_type=ContentType.JSON.value)
             get_log().info("stac_saved", path=stac_item_path)
 
 

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -106,7 +106,7 @@ def main() -> None:
             item = create_item(
                 file.get_path_standardised(), start_datetime, end_datetime, arguments.collection_id, file.get_gdalinfo()
             )
-            write(stac_item_path, json.dumps(item.stac).encode("utf-8"), content_type=ContentType.JSON.value)
+            write(stac_item_path, json.dumps(item.stac).encode("utf-8"), content_type=ContentType.GEOJSON.value)
             get_log().info("stac_saved", path=stac_item_path)
 
 

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -9,7 +9,7 @@ from linz_logger import get_log
 from scripts.aws.aws_helper import is_s3
 from scripts.cli.cli_helper import TileFiles
 from scripts.files.file_tiff import FileTiff, FileTiffType
-from scripts.files.files_helper import is_tiff
+from scripts.files.files_helper import ContentType, is_tiff
 from scripts.files.fs import exists, find_sidecars, read, write, write_all
 from scripts.gdal.gdal_bands import get_gdal_band_offset
 from scripts.gdal.gdal_helper import get_gdal_version, run_gdal
@@ -195,5 +195,5 @@ def standardising(
         # Need GDAL to write to temporary location so no broken files end up in the done folder.
         run_gdal(command, input_file=input_file, output_file=standardized_working_path)
 
-        write(standardized_file_path, read(standardized_working_path))
+        write(standardized_file_path, read(standardized_working_path), content_type=ContentType.TIFF.value)
         return tiff

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -195,5 +195,5 @@ def standardising(
         # Need GDAL to write to temporary location so no broken files end up in the done folder.
         run_gdal(command, input_file=input_file, output_file=standardized_working_path)
 
-        write(standardized_file_path, read(standardized_working_path), content_type=ContentType.TIFF.value)
+        write(standardized_file_path, read(standardized_working_path), content_type=ContentType.GEOTIFF.value)
         return tiff

--- a/scripts/thumbnails.py
+++ b/scripts/thumbnails.py
@@ -7,7 +7,7 @@ from multiprocessing import Pool
 
 from linz_logger import get_log
 
-from scripts.files.files_helper import get_file_name_from_path, is_GTiff, is_tiff
+from scripts.files.files_helper import ContentType, get_file_name_from_path, is_GTiff, is_tiff
 from scripts.files.fs import exists, read, write
 from scripts.gdal import gdalinfo
 from scripts.gdal.gdal_helper import run_gdal
@@ -70,7 +70,7 @@ def thumbnails(path: str, target: str) -> str | None:
             run_gdal(get_thumbnail_command("jpeg", transitional_jpg, tmp_thumbnail, "30%", "30%", None, gdalinfo_data))
 
         # Upload to target
-        write(target_thumbnail, read(tmp_thumbnail))
+        write(target_thumbnail, read(tmp_thumbnail), content_type=ContentType.JPEG.value)
     return target_thumbnail
 
 


### PR DESCRIPTION
Allows `fs_s3.write()` to specify a content type to the object pushed into a S3 bucket.

TIFF:
``` bash
aws s3api head-object --bucket linz-workflow-artifacts --key 2023-09/05-test-imagery-standardising-paul-84xsp/flat/BX24_5000_0405.tiff
{
    "AcceptRanges": "bytes",
    "Expiration": "expiry-date=\"Tue, 05 Dec 2023 00:00:00 GMT\", rule-id=\"OWVkZjBkNWMtZDIwNC00ZjI3LWEzOTUtODU0ZGJiYmFkZmFm\"",
    "LastModified": "2023-09-05T23:40:49+00:00",
    "ContentLength": 1725950,
    "ETag": "\"9c6af70db952ceef70ea6d5a0651abf9\"",
    "ContentType": "image/tiff; application=geotiff; profile=cloud-optimized",
    "ServerSideEncryption": "AES256",
    "Metadata": {}
}
```

JSON:
``` bash
aws s3api head-object --bucket linz-workflow-artifacts --key 2023-09/05-test-imagery-standardising-paul-84xsp/flat/BX24_5000_0405.json
{
    "AcceptRanges": "bytes",
    "Expiration": "expiry-date=\"Tue, 05 Dec 2023 00:00:00 GMT\", rule-id=\"OWVkZjBkNWMtZDIwNC00ZjI3LWEzOTUtODU0ZGJiYmFkZmFm\"",
    "LastModified": "2023-09-05T23:41:13+00:00",
    "ContentLength": 1023,
    "ETag": "\"dfe4946f7987921b8fc65621261eadff\"",
    "ContentType": "application/json",
    "ServerSideEncryption": "AES256",
    "Metadata": {}
}
```