### PR TITLE
fix: re-standardising TileByteCounts error TDE-850

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -55,5 +55,5 @@ jobs:
 
       - name: End to end test - Restandardise Aerial Imagery
         run: |
-          docker run  -v ${HOME}/tmp/:/tmp/ topo-imagery python3 standardise_validate.py --from-file ./tests/data/restandardise.json --preset webp --target-epsg 2193 --source-epsg 2193 --target /tmp/ --collection-id 123 --start-datetime 2023-01-01 --end-datetime 2023-01-01
-          cmp --silent ${HOME}/tmp/BG35_1000_4829.tiff ./scripts/tests/data/output/BG35_1000_4829.tiff
+          docker run  -v ${HOME}/tmp/:/tmp/ topo-imagery python3 standardise_validate.py --from-file ./tests/data/restandardise.json --preset webp --target-epsg 2193 --source-epsg 2193 --target /tmp/restandardise/ --collection-id 123 --start-datetime 2023-01-01 --end-datetime 2023-01-01
+          cmp --silent ${HOME}/tmp/restandardise/BG35_1000_4829.tiff ./scripts/tests/data/output/BG35_1000_4829.tiff

--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -52,3 +52,8 @@ jobs:
           docker run  -v ${HOME}/tmp/:/tmp/ topo-imagery python3 thumbnails.py --from-file ./tests/data/thumbnails.json --target /tmp/
           cmp --silent ${HOME}/tmp/CB07_GeoTifv1-02-thumbnail.jpg ./scripts/tests/data/output/CB07_GeoTifv1-02-thumbnail.jpg
           cmp --silent ${HOME}/tmp/CB07_TIFFv1-02-thumbnail.jpg ./scripts/tests/data/output/CB07_TIFFv1-02-thumbnail.jpg
+
+      - name: End to end test - Restandardise Aerial Imagery
+        run: |
+          docker run  -v ${HOME}/tmp/:/tmp/ topo-imagery python3 standardise_validate.py --from-file ./tests/data/restandardise.json --preset webp --target-epsg 2193 --source-epsg 2193 --target /tmp/ --collection-id 123 --start-datetime 2023-01-01 --end-datetime 2023-01-01
+          cmp --silent ${HOME}/tmp/BG35_1000_4829.tiff ./scripts/tests/data/output/BG35_1000_4829.tiff

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -131,7 +131,7 @@ def standardising(
     with tempfile.TemporaryDirectory() as tmp_path:
         standardized_working_path = os.path.join(tmp_path, standardized_file_name)
         sidecars = find_sidecars(files.inputs, [".prj", ".tfw"])
-        source_files = write_all(files.inputs + sidecars, tmp_path)
+        source_files = write_all(files.inputs + sidecars, f"{tmp_path}/source/")
         source_tiffs = [file for file in source_files if is_tiff(file)]
 
         vrt_add_alpha = True

--- a/scripts/tests/data/restandardise.json
+++ b/scripts/tests/data/restandardise.json
@@ -1,0 +1,6 @@
+[
+  {
+    "output": "BG35_1000_4829",
+    "input": ["./tests/data/output/BG35_1000_4829.tiff"]
+  }
+]


### PR DESCRIPTION
For a 1:1 (non-retile) re-standardise of already processed imagery, the input filepath was the same as the output filepath.