### PR TITLE
fix: recreate webp overviews TDE-869

### DIFF
--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -76,6 +76,8 @@ WEBP_OVERVIEWS = [
     # Reduce quality of overviews to 90%
     "-co",
     "overview_quality=90",
+    "-co",
+    "OVERVIEWS=IGNORE_EXISTING"
 ]
 
 

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -77,7 +77,7 @@ WEBP_OVERVIEWS = [
     "-co",
     "overview_quality=90",
     "-co",
-    "OVERVIEWS=IGNORE_EXISTING"
+    "OVERVIEWS=IGNORE_EXISTING",
 ]
 
 

--- a/scripts/gdal/tests/gdal_preset_test.py
+++ b/scripts/gdal/tests/gdal_preset_test.py
@@ -18,6 +18,7 @@ def test_preset_webp() -> None:
     assert "overview_compress=webp" in gdal_command
     assert "overview_resampling=lanczos" in gdal_command
     assert "overview_quality=90" in gdal_command
+    assert "OVERVIEWS=IGNORE_EXISTING" in gdal_command
 
     assert "EPSG:2193" in gdal_command
 
@@ -39,6 +40,7 @@ def test_preset_lzw() -> None:
     assert "overview_compress=webp" in gdal_command
     assert "overview_resampling=lanczos" in gdal_command
     assert "overview_quality=90" in gdal_command
+    assert "OVERVIEWS=IGNORE_EXISTING" in gdal_command
 
     assert "EPSG:2193" in gdal_command
 
@@ -59,6 +61,7 @@ def test_preset_dem_lerc() -> None:
     assert "overview_compress=webp" not in gdal_command
     assert "overview_resampling=lanczos" not in gdal_command
     assert "overview_quality=90" not in gdal_command
+    assert "OVERVIEWS=IGNORE_EXISTING" not in gdal_command
 
     assert "EPSG:2193" in gdal_command
 


### PR DESCRIPTION
When standardising a COG with overviews, the existing webp overviews were used to create the overviews with further lossy compression.
This change forces creation of overviews from the base image.