### PR TITLE
fix: upgrade gdal to 3.7.2 for webp CVE fix TDE-897

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.0
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.2
 
 RUN apt-get update
 # Install pip


### PR DESCRIPTION
There has been a high rated CVE for webp that was fixed in a re-release of GDAL 3.7.2 

ref: https://github.com/OSGeo/gdal/issues/8501