### PR TITLE
fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The input can be passed through a `json` file containing a list of one or severa
 docker run -v ${HOME}/tmp/:/tmp/:rw topo-imagery python standardise_validate.py --preset webp --from-file ./tests/data/aerial.json --collection-id 123 --start-datetime 2023-01-01 --end-datetime 2023-01-01 --target /tmp/ --source-epsg 2193 --target-epsg 2193
 ```
 
-To use an AWS test data (input located in an AWS S3 bucket), log into the AWS account and add the following arguments to the `docker run` command:
+To use an AWS test dataset (input located in an AWS S3 bucket), log into the AWS account and add the following arguments to the `docker run` command:
 
 ```bash
 -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE=your-profile


### PR DESCRIPTION
in order to create a release as https://github.com/linz/topo-imagery/pull/678 did not work