### PR TITLE
fix: minor changes to be consistent with current data TDE-955

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -213,7 +213,7 @@ class ImageryCollection:
         if self.title_metadata["start_datetime"].year == self.title_metadata["end_datetime"].year:
             date = str(self.title_metadata["start_datetime"].year)
         else:
-            date = f"{self.title_metadata['start_datetime'].year} - {self.title_metadata['end_datetime'].year}"
+            date = f"{self.title_metadata['start_datetime'].year}-{self.title_metadata['end_datetime'].year}"
 
         # determine dataset name
         if location:
@@ -223,7 +223,7 @@ class ImageryCollection:
 
         # determine if dataset is preview
         if self.title_metadata.get("lifecycle") == "preview":
-            preview = "- preview"
+            preview = "- Preview"
         else:
             preview = None
 
@@ -268,7 +268,7 @@ class ImageryCollection:
         if self.title_metadata["start_datetime"].year == self.title_metadata["end_datetime"].year:
             date = str(self.title_metadata["start_datetime"].year)
         else:
-            date = f"{self.title_metadata['start_datetime'].year} - {self.title_metadata['end_datetime'].year}"
+            date = f"{self.title_metadata['start_datetime'].year}-{self.title_metadata['end_datetime'].year}"
 
         # format location for metadata description
         if location:

--- a/scripts/stac/tests/generate_title_test.py
+++ b/scripts/stac/tests/generate_title_test.py
@@ -78,7 +78,7 @@ def test_generate_title_long_date(metadata: Tuple[CollectionTitleMetadata, Colle
     metadata_auck, _ = metadata
     metadata_auck["end_datetime"] = datetime(2024, 1, 1)
     collection = ImageryCollection(metadata_auck)
-    title = "Auckland 0.3m Rural Aerial Photos (2023 - 2024)"
+    title = "Auckland 0.3m Rural Aerial Photos (2023-2024)"
     assert collection.stac["title"] == title
 
 
@@ -121,7 +121,7 @@ def test_generate_dsm_title_preview(metadata: Tuple[CollectionTitleMetadata, Col
     metadata_auck["category"] = "DSM"
     metadata_auck["lifecycle"] = "preview"
     collection = ImageryCollection(metadata_auck)
-    title = "Auckland LiDAR 0.3m DSM (2023) - preview"
+    title = "Auckland LiDAR 0.3m DSM (2023) - Preview"
     assert collection.stac["title"] == title
 
 


### PR DESCRIPTION
#### Motivation

The dataset titles and descriptions should be consistent with current datasets. 

#### Modification

- remove spaces between years `(2022 - 2023)` -> `(2022-2023)`
- Capitalise preview `- preview` -> `- Preview`

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated - n/a
- [x] Issue linked in Title

nb: should be merged and release ASAP to avoid inconsistencies
