### PR TITLE
feat: accept only hyphen named categories TDE-985

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -24,7 +24,7 @@ def main() -> None:
         dest="category",
         help="Dataset category description",
         required=True,
-        choices=list(DATA_CATEGORIES.keys()) + list(DATA_CATEGORIES.values()),
+        choices=DATA_CATEGORIES.keys(),
     )
     parser.add_argument(
         "--region",
@@ -91,17 +91,8 @@ def main() -> None:
     for licensor_name in coalesce_multi_single(arguments.licensor_list, arguments.licensor):
         providers.append({"name": licensor_name, "roles": [ProviderRole.LICENSOR]})
 
-    # category can also be passed as human readable name (e.g. "Aerial Photos")
-    # Get the corresponding identifier to simplify the process
-    category = arguments.category
-    if not DATA_CATEGORIES.get(category):
-        for key, value in DATA_CATEGORIES.items():
-            if value == category:
-                category = key
-                break
-
     collection_metadata: CollectionMetadata = {
-        "category": category,
+        "category": arguments.category,
         "region": arguments.region,
         "gsd": arguments.gsd,
         "start_datetime": arguments.start_date,


### PR DESCRIPTION
#### Motivation

Being able to still use the human readable name for the categories have been kept in order to avoid a breaking change. Meanwhile, another breaking change has been pushed resulting in a new major version of `topo-imagery`. This workaround to avoid breaking change does not need to exist anymore.

#### Modification

Remove the possibility of using human readable names for the `--category` argument.

#### Checklist

- [ ] Tests updated NA
- [ ] Docs updated NA
- [x] Issue linked in Title
