### PR TITLE
fix: NoSuchFileError is stopping multiprocessing sidecar files TDE-1007

### DIFF
--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -75,7 +75,7 @@ def test_write_sidecars_one_found(capsys: CaptureFixture[str]) -> None:
     write(path, content)
     non_existing_path = os.path.join(target, "test.prj")
     # Write the sidecar files with one unexisting
-    write_sidecars([path_unexisting, path], os.path.join(target, "/tmp"))
+    write_sidecars([non_existing_path, path], os.path.join(target, "/tmp"))
     logs = capsys.readouterr().out
     # One has not been found
     assert "No sidecar file found; skipping" in logs

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -73,7 +73,7 @@ def test_write_sidecars_one_found(capsys: CaptureFixture[str]) -> None:
     content = b"test content"
     path = os.path.join(target, "test.tfw")
     write(path, content)
-    path_unexisting = os.path.join(target, "test.prj")
+    non_existing_path = os.path.join(target, "test.prj")
     # Write the sidecar files with one unexisting
     write_sidecars([path_unexisting, path], os.path.join(target, "/tmp"))
     logs = capsys.readouterr().out

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -32,8 +32,7 @@ def test_write_all_file_not_found_local(capsys: CaptureFixture[str]) -> None:
     # Raises an exception as all files are not writte·
     with raises(Exception):
         write_all(["/test.prj"], "/tmp")
-        logs = json.loads(capsys.readouterr().out.strip())
-        assert logs["error"] == NoSuchFileError()
+    assert '"error": "NoSuchFileError()"' in capsys.readouterr().out
 
 
 def test_write_sidecars_file_not_found_local(capsys: CaptureFixture[str]) -> None:
@@ -51,8 +50,7 @@ def test_write_all_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
     # Raises an exception as all files are not written
     with raises(Exception):
         write_all(["s3://testbucket/test.tif"], "/tmp")
-        logs = json.loads(capsys.readouterr().out.strip())
-        assert logs["error"] == NoSuchFileError()
+    assert '"error": "NoSuchFileError()"' in capsys.readouterr().out
 
 
 @mock_s3  # type: ignore

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -1,11 +1,14 @@
 import json
+import os
+from shutil import rmtree
+from tempfile import mkdtemp
 
 from boto3 import resource
 from moto import mock_s3
 from moto.s3.responses import DEFAULT_REGION_NAME
 from pytest import CaptureFixture, raises
 
-from scripts.files.fs import NoSuchFileError, read, write_all, write_sidecars
+from scripts.files.fs import NoSuchFileError, read, write, write_all, write_sidecars
 
 
 def test_read_key_not_found_local() -> None:
@@ -25,9 +28,12 @@ def test_read_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
     assert logs["msg"] == "s3_key_not_found"
 
 
-def test_write_all_file_not_found_local() -> None:
-    with raises(NoSuchFileError):
+def test_write_all_file_not_found_local(capsys: CaptureFixture[str]) -> None:
+    # Raises an exception as all files are not writte·
+    with raises(Exception):
         write_all(["/test.prj"], "/tmp")
+        logs = json.loads(capsys.readouterr().out.strip())
+        assert logs["error"] == NoSuchFileError()
 
 
 def test_write_sidecars_file_not_found_local(capsys: CaptureFixture[str]) -> None:
@@ -38,12 +44,15 @@ def test_write_sidecars_file_not_found_local(capsys: CaptureFixture[str]) -> Non
 
 
 @mock_s3  # type: ignore
-def test_write_all_key_not_found_s3() -> None:
+def test_write_all_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
     s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="testbucket")
 
-    with raises(NoSuchFileError):
+    # Raises an exception as all files are not written
+    with raises(Exception):
         write_all(["s3://testbucket/test.tif"], "/tmp")
+        logs = json.loads(capsys.readouterr().out.strip())
+        assert logs["error"] == NoSuchFileError()
 
 
 @mock_s3  # type: ignore
@@ -56,3 +65,20 @@ def test_write_sidecars_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
     # capsys.readouterr().out json string format is not valid which implies
     # we can't parse it to find the actual `msg`
     assert "No sidecar file found; skipping" in capsys.readouterr().out
+
+
+def test_write_sidecars_one_found(capsys: CaptureFixture[str]) -> None:
+    target = mkdtemp()
+    # Add a file to read
+    content = b"test content"
+    path = os.path.join(target, "test.tfw")
+    write(path, content)
+    path_unexisting = os.path.join(target, "test.prj")
+    # Write the sidecar files with one unexisting
+    write_sidecars([path_unexisting, path], os.path.join(target, "/tmp"))
+    logs = capsys.readouterr().out
+    # One has not been found
+    assert "No sidecar file found; skipping" in logs
+    # One has been found
+    assert "wrote_sidecar_file" in logs
+    rmtree(target)


### PR DESCRIPTION
#### Motivation

Downloading sidecar files process currently stop as soon as one of them does not exist, without looking for the others.

#### Modification

Catch and add the `NoSuchFileError` to the `Future` exception and look for the exceptions once the downloading process (of all sidecar files) is completed, rather than stopping it as soon as one exception is raised.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated N/A
- [x] Issue linked in Title
