### PR TITLE
refactor: title & description TDE-955

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -210,12 +210,10 @@ class ImageryCollection:
 
     def _title(self) -> str:
         """Generates the title for imagery and elevation datasets.
-        Satellite Imagery / Urban Aerial Photos / Rural Aerial Photos:
+        Satellite Imagery / Urban Aerial Photos / Rural Aerial Photos / Scanned Aerial Photos:
           https://github.com/linz/imagery/blob/master/docs/naming.md
         DEM / DSM:
           https://github.com/linz/elevation/blob/master/docs/naming.md
-        If Historic Survey Number:
-          [geographic_description / Region] [GSD] [Survey Number] ([Year(s)]) [?- Preview]
         Returns:
             Dataset Title
         """
@@ -224,27 +222,27 @@ class ImageryCollection:
         historic_survey_number = self.metadata.get("historic_survey_number")
 
         # format date for metadata
+        date = f"{self.metadata['start_datetime'].year}-{self.metadata['end_datetime'].year}"
         if self.metadata["start_datetime"].year == self.metadata["end_datetime"].year:
             date = str(self.metadata["start_datetime"].year)
-        else:
-            date = f"{self.metadata['start_datetime'].year}-{self.metadata['end_datetime'].year}"
 
         # determine dataset name
+        region = HUMAN_READABLE_REGIONS[self.metadata["region"]]
+        imagery_name = region
+        elevation_description = None
         if geographic_description:
-            name = geographic_description
-        else:
-            name = HUMAN_READABLE_REGIONS[self.metadata["region"]]
+            imagery_name = geographic_description
+            elevation_description = f"- {geographic_description}"
 
         # determine if dataset is preview
+        preview = None
         if self.metadata.get("lifecycle") == "preview":
             preview = "- Preview"
-        else:
-            preview = None
 
         if self.metadata["category"] == SCANNED_AERIAL_PHOTOS:
             if not historic_survey_number:
                 raise MissingMetadataError("historic_survey_number")
-            return " ".join(f"{name} {self.metadata['gsd']} {historic_survey_number} ({date}) {preview or ''}".split())
+            return " ".join(f"{imagery_name} {self.metadata['gsd']} {historic_survey_number} ({date}) {preview or ''}".split())
 
         if self.metadata["category"] in [
             SATELLITE_IMAGERY,
@@ -252,11 +250,11 @@ class ImageryCollection:
             RURAL_AERIAL_PHOTOS,
         ]:
             return " ".join(
-                f"{name} {self.metadata['gsd']} {DATA_CATEGORIES[self.metadata['category']]} ({date}) {preview or ''}".split()  # pylint: disable=line-too-long
+                f"{imagery_name} {self.metadata['gsd']} {DATA_CATEGORIES[self.metadata['category']]} ({date}) {preview or ''}".split()  # pylint: disable=line-too-long
             )
         if self.metadata["category"] in [DEM, DSM]:
             return " ".join(
-                f"{name} LiDAR {self.metadata['gsd']} {DATA_CATEGORIES[self.metadata['category']]} ({date}) {preview or ''}".split()  # pylint: disable=line-too-long
+                f"{region} {elevation_description or ''} LiDAR {self.metadata['gsd']} {DATA_CATEGORIES[self.metadata['category']]} ({date}) {preview or ''}".split()  # pylint: disable=line-too-long
             )
         raise SubtypeParameterError(self.metadata["category"])
 
@@ -266,19 +264,16 @@ class ImageryCollection:
           Orthophotography within the [Region] region captured in the [Year(s)] flying season.
         DEM / DSM:
           [Digital Surface Model / Digital Elevation Model] within the [Region] region in [year(s)].
-        Satellite Imagery:
-          Satellite imagery within the [Region] region captured in [Year(s)].
-        Historical Imagery:
-          Scanned aerial imagery within the [Region] region captured in [Year(s)].
+        Satellite Imagery / Scanned Aerial Photos:
+          [Satellite imagery | Scanned Aerial Photos] within the [Region] region captured in [Year(s)].
 
         Returns:
             Dataset Description
         """
         # format date for metadata
+        date = f"{self.metadata['start_datetime'].year}-{self.metadata['end_datetime'].year}"
         if self.metadata["start_datetime"].year == self.metadata["end_datetime"].year:
             date = str(self.metadata["start_datetime"].year)
-        else:
-            date = f"{self.metadata['start_datetime'].year}-{self.metadata['end_datetime'].year}"
 
         region = HUMAN_READABLE_REGIONS[self.metadata["region"]]
 

--- a/scripts/stac/imagery/metadata_constants.py
+++ b/scripts/stac/imagery/metadata_constants.py
@@ -4,6 +4,8 @@ from typing import Optional, TypedDict
 
 class CollectionMetadata(TypedDict):
     """
+    Used to generate dataset collection titles and descriptions.
+
     region: Region of Dataset
     gsd: Dataset Ground Sample Distance
     start_date: Dataset capture start date

--- a/scripts/stac/tests/collection_test.py
+++ b/scripts/stac/tests/collection_test.py
@@ -24,24 +24,24 @@ def setup() -> Generator[CollectionMetadata, None, None]:
         "start_datetime": datetime(2022, 2, 2),
         "end_datetime": datetime(2022, 2, 2),
         "lifecycle": "completed",
-        "event_name": "Forest assessment",
+        "event_name": "Forest Assessment",
         "historic_survey_number": None,
-        "geographic_description": "Auckland North",
+        "geographic_description": "Auckland North Forest Assessment",
     }
     yield metadata
 
 
 def test_title_description_id_created_on_init(metadata: CollectionMetadata) -> None:
     collection = ImageryCollection(metadata)
-    assert collection.stac["title"] == "Auckland North 0.3m Forest assessment Urban Aerial Photos (2022)"
+    assert collection.stac["title"] == "Auckland North Forest Assessment 0.3m Urban Aerial Photos (2022)"
     assert (
         collection.stac["description"]
-        == "Orthophotography within the Auckland region captured in the 2022 flying season, published as a record of the Forest assessment event."  # pylint: disable=line-too-long
+        == "Orthophotography within the Auckland region captured in the 2022 flying season, published as a record of the Forest Assessment event."  # pylint: disable=line-too-long
     )
     assert collection.stac["id"]
     assert collection.stac["linz:region"] == "auckland"
-    assert collection.stac["linz:geographic_description"] == "Auckland North"
-    assert collection.stac["linz:event_name"] == "Forest assessment"
+    assert collection.stac["linz:geographic_description"] == "Auckland North Forest Assessment"
+    assert collection.stac["linz:event_name"] == "Forest Assessment"
     assert collection.stac["linz:lifecycle"] == "completed"
     assert collection.stac["linz:geospatial_category"] == "urban-aerial-photos"
 
@@ -179,9 +179,9 @@ def test_default_provider_is_present(metadata: CollectionMetadata) -> None:
 
 def test_event_name_is_present(metadata: CollectionMetadata) -> None:
     collection = ImageryCollection(metadata)
-    assert "Forest assessment" == collection.stac["linz:event_name"]
+    assert "Forest Assessment" == collection.stac["linz:event_name"]
 
 
 def test_geographic_description_is_present(metadata: CollectionMetadata) -> None:
     collection = ImageryCollection(metadata)
-    assert "Auckland North" == collection.stac["linz:geographic_description"]
+    assert "Auckland North Forest Assessment" == collection.stac["linz:geographic_description"]

--- a/scripts/stac/tests/generate_description_test.py
+++ b/scripts/stac/tests/generate_description_test.py
@@ -57,7 +57,7 @@ def test_generate_description_elevation_geographic_description_input(
     metadata_auck["category"] = "dem"
     metadata_auck["geographic_description"] = "Central"
     collection = ImageryCollection(metadata_auck)
-    description = "Digital Elevation Model within the Auckland - Central region in 2023."
+    description = "Digital Elevation Model within the Auckland region in 2023."
     assert collection.stac["description"] == description
 
 

--- a/scripts/stac/tests/generate_title_test.py
+++ b/scripts/stac/tests/generate_title_test.py
@@ -116,7 +116,7 @@ def test_generate_title_event_elevation(metadata: Tuple[CollectionMetadata, Coll
     metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     metadata_hb["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(metadata_hb)
-    title = "Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
+    title = "Hawke's Bay - Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 

--- a/scripts/stac/tests/generate_title_test.py
+++ b/scripts/stac/tests/generate_title_test.py
@@ -103,27 +103,30 @@ def test_generate_title_geographic_description(metadata: Tuple[CollectionMetadat
 
 def test_generate_title_event_imagery(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
+    metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     metadata_hb["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(metadata_hb)
-    title = "Hawke's Bay 0.3m Cyclone Gabrielle Rural Aerial Photos (2023)"
+    title = "Hawke's Bay Cyclone Gabrielle 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_elevation(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
     metadata_hb["category"] = "dsm"
+    metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     metadata_hb["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(metadata_hb)
-    title = "Hawke's Bay - Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
+    title = "Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_satellite_imagery(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
     metadata_hb["category"] = "satellite-imagery"
+    metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     metadata_hb["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(metadata_hb)
-    title = "Hawke's Bay 0.3m Cyclone Gabrielle Satellite Imagery (2023)"
+    title = "Hawke's Bay Cyclone Gabrielle 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
@@ -147,7 +150,8 @@ def test_generate_imagery_title_empty_optional_str(metadata: Tuple[CollectionMet
 
 def test_generate_imagery_title_with_event(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
-    metadata_auck["event_name"] = "Forest assessment"
+    metadata_auck["geographic_description"] = "Auckland Forest Assessment"
+    metadata_auck["event_name"] = "Forest Assessment"
     collection = ImageryCollection(metadata_auck)
-    title = "Auckland 0.3m Forest assessment Rural Aerial Photos (2023)"
+    title = "Auckland Forest Assessment 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title


### PR DESCRIPTION
#### Motivation

refactor title & description formatting to align with naming documentation

#### Modification

- docstring updated to point to `naming.md`
- `event` removed from all titles as should now also be included in `geographic_description`
- `geographic_description` removed from elevation description otherwise, if the dataset has an event it will be repeated

Examples:
`Hawke's Bay Cyclone Gabrielle 0.3m Rural Aerial Photos (2023)`
`Ponsonby 0.3m Rural Aerial Photos (2023)`

`Hawke's Bay Cyclone Gabrielle 0.3m Satellite Imagery (2023)`

`Auckland LiDAR 0.3m DSM (2023) - Preview`


#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated - just docstrings
- [x] Issue linked in Title
