### PR TITLE
fix: write_file was not handling exception correctly TDE-1007

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -1,5 +1,9 @@
 name: Format and Tests
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -138,8 +138,8 @@ def write_file(executor: ThreadPoolExecutor, input_: str, target: str) -> Future
     Returns:
         Future[str]: The result of the execution.
     """
+    get_log().info(f"Trying write from file: {input_}")
     try:
-        get_log().info(f"Trying write from file: {input_}")
         return executor.submit(copy, input_, os.path.join(target, f"{os.path.basename(input_)}"))
     except NoSuchFileError as nsfe:
         future: Future[str] = Future()

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -1,4 +1,3 @@
-import json
 import os
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -24,33 +23,32 @@ def test_read_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
     with raises(NoSuchFileError):
         read("s3://testbucket/test.file")
 
-    logs = json.loads(capsys.readouterr().out)
-    assert logs["msg"] == "s3_key_not_found"
+    assert "s3_key_not_found" in capsys.readouterr().out
 
 
-def test_write_all_file_not_found_local(capsys: CaptureFixture[str]) -> None:
+def test_write_all_file_not_found_local() -> None:
     # Raises an exception as all files are not writte·
-    with raises(Exception):
+    with raises(Exception) as e:
         write_all(["/test.prj"], "/tmp")
-    assert '"error": "NoSuchFileError()"' in capsys.readouterr().out
+
+    assert str(e.value) == "Not all mandatory source files were written"
 
 
 def test_write_sidecars_file_not_found_local(capsys: CaptureFixture[str]) -> None:
     write_sidecars(["/test.prj"], "/tmp")
-
-    logs = json.loads(capsys.readouterr().out.strip())
-    assert logs["msg"] == "No sidecar file found; skipping"
+    assert "No sidecar file found; skipping" in capsys.readouterr().out
 
 
 @mock_s3  # type: ignore
-def test_write_all_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
+def test_write_all_key_not_found_s3() -> None:
     s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="testbucket")
 
     # Raises an exception as all files are not written
-    with raises(Exception):
+    with raises(Exception) as e:
         write_all(["s3://testbucket/test.tif"], "/tmp")
-    assert '"error": "NoSuchFileError()"' in capsys.readouterr().out
+
+    assert str(e.value) == "Not all mandatory source files were written"
 
 
 @mock_s3  # type: ignore


### PR DESCRIPTION
#### Motivation
`write_file()` was not handling exception correctly due to calling another function in the `executor` arguments.

#### Modification

- Create a `copy()` method (calling `write()` and `read()`) that allow the `executor` to call a single function.
- Refactor/simplify some code for readibility

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
