### PR TITLE
ci: allow fork PR to run format-test gh action TDE-1032

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -1,5 +1,9 @@
 name: Format and Tests
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
#### Motivation

A PR made from a fork should be able to run the `format-tests` workflow.

#### Modification

Allow the `format-tests` workflow to be run from any PR aiming to be merged to the master branch.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
