### PR TITLE
refactor: save local standardised file gdalinfo in FileTiff object TDE-929

### DIFF
--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -106,9 +106,13 @@ class FileTiff:
         """
         self._path_standardised = path
 
-    def get_gdalinfo(self) -> Optional[GdalInfo]:
+    def get_gdalinfo(self, path: Optional[str] = None) -> Optional[GdalInfo]:
         """Get the `gdalinfo` output for the file.
-        Run gdalinfo if not already ran.
+        Run gdalinfo if not already ran or if different path is specified.
+        `path` is useful to specify a local file to avoid downloading from external source.
+
+        Args:
+            path: path to the file. Force the `gdalinfo` to be executed.
 
         Returns:
             the `gdalinfo` output
@@ -116,9 +120,13 @@ class FileTiff:
         # FIXME: Should not return None but not try running `gdalinfo` if there has already been an error
         if self.is_error_type(FileTiffErrorType.GDAL_INFO):
             return None
-        if not self._gdalinfo:
+        if path:
+            file_path = path
+        else:
+            file_path = self._path_standardised
+        if path or not self._gdalinfo:
             try:
-                self._gdalinfo = gdal_info(self._path_standardised)
+                self._gdalinfo = gdal_info(file_path)
             except json.JSONDecodeError as jde:
                 self.add_error(error_type=FileTiffErrorType.GDAL_INFO, error_message=f"parsing result issue: {str(jde)}")
             except GDALExecutionException as gee:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -198,6 +198,10 @@ def standardising(
         # Need GDAL to write to temporary location so no broken files end up in the done folder.
         run_gdal(command, input_file=input_file, output_file=standardized_working_path)
 
+        # Update the `FileTiff.gdalinfo` as the system has local access to the TIFF
+        get_log().debug("Saving gdalinfo from local standardised TIFF in FileTiff object", path=standardized_working_path)
+        tiff.get_gdalinfo(standardized_working_path)
+
         with TiffFile(standardized_working_path) as file_handle:
             if any(tile_byte_count != 0 for tile_byte_count in file_handle.pages.first.tags["TileByteCounts"].value):
                 write(standardized_file_path, read(standardized_working_path), content_type=ContentType.GEOTIFF.value)


### PR DESCRIPTION
#### Motivation

After standardising a TIFF, a `gdalinfo` is run in order to [validate the file](https://github.com/linz/topo-imagery/blob/94051b83f76c9983996e52cf1ca4fb3118c82716/scripts/standardise_validate.py#L76).
When the `target` is on S3, this `gdalinfo` is run on the file stored in S3. This is not ideal (network performance) especially when the system has direct access to the local TIFF before being written to the cloud storage.

#### Modification

- Allow to run `gdalinfo` for the `FileTiff` object from a different path than the final path
- Force the `FileTiff` `gdalinfo` to be run from the local path and saved for future usage

#### Checklist

- [ ] Tests updated (no test)
- [ ] Docs updated (no doc)
- [x] Issue linked in Title
