### PR TITLE
fix: handle 50k imagery filenames TDE-1014

### DIFF
--- a/scripts/tile/tests/tile_index_test.py
+++ b/scripts/tile/tests/tile_index_test.py
@@ -10,6 +10,12 @@ def test_get_bounds_from_name() -> None:
     assert expected_bounds == bounds
 
 
+def test_get_bounds_from_50k_name() -> None:
+    expected_bounds = Bounds(Point(x=1180000, y=4758000), Size(width=24_000, height=36_000))
+    bounds = get_bounds_from_name("CK08")
+    assert expected_bounds == bounds
+
+
 @pytest.mark.dependency()
 def test_get_tile_offset() -> None:
     expected_bounds = Bounds(Point(x=8640, y=28440), Size(width=240, height=360))

--- a/scripts/tile/tile_index.py
+++ b/scripts/tile/tile_index.py
@@ -1,3 +1,4 @@
+import re
 from typing import NamedTuple, Union
 
 from scripts.tile.util import charcodeat
@@ -42,6 +43,16 @@ def get_bounds_from_name(tile_name: str) -> Bounds:
     Returns:
         a `Bounds` object
     """
+    # check for 50k imagery
+    if re.match(r"^[A-Z]{2}\d{2}$", tile_name):
+        map_sheet = tile_name
+        grid_size = 50_000
+        origin = get_mapsheet_offset(map_sheet)
+        return Bounds(
+            Point(x=origin.x, y=origin.y),
+            Size(SHEET_WIDTH, SHEET_HEIGHT),
+        )
+
     name_parts = tile_name.split("_")
     map_sheet = name_parts[0]
     # should be in [10_000, 5_000, 2_000, 1_000, 500]
@@ -104,9 +115,9 @@ def get_tile_offset(grid_size: int, x: int, y: int) -> Bounds:
     """Get the tile offset from its coordinate and the grid size
 
     Args:
-        grid_size: a size from in [10_000, 5_000, 2_000, 1_000, 500]
-        x: upper left cooridinate x
-        y: upper left cooridinate y
+        grid_size: a size in [50_000, 10_000, 5_000, 2_000, 1_000, 500]
+        x: upper left coordinate x
+        y: upper left coordinate y
 
     Returns:
         a `Bounds` object


### PR DESCRIPTION
#### Motivation

argo-tasks can now handle 50k imagery, so topo-imagery needs to be updated to handle 50k imagery filenames.

#### Modification

Update `get_bounds_from_name` to handle 50k filenames (tiles that are the same size as map sheets).

#### Checklist

_If not applicable, provide explanation of why._

- [X] Tests updated
- [X] Docs updated
- [X] Issue linked in Title
