### PR TITLE
refactor: simplify getting file name

### DIFF
--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -1,4 +1,3 @@
-import os
 from enum import Enum
 from typing import Optional
 
@@ -11,24 +10,6 @@ class ContentType(str, Enum):
     # https://www.iana.org/assignments/media-types/application/geo+json
     GEOJSON = "application/geo+json"
     JPEG = "image/jpeg"
-
-
-def get_file_name_from_path(path: str) -> str:
-    """Get the file name from a path.
-
-    Args:
-        path: a path to a file
-
-    Returns:
-        the name of the file
-
-    Example:
-        ```
-        >>> get_file_name_from_path("/a/path/to/file.ext")
-        "file.ext"
-        ```
-    """
-    return os.path.splitext(os.path.basename(path))[0]
 
 
 def is_tiff(path: str) -> bool:

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -1,8 +1,8 @@
+from os.path import basename
 from typing import Optional
 
 from linz_logger import get_log
 
-from scripts.files.files_helper import get_file_name_from_path
 from scripts.files.geotiff import get_extents
 from scripts.gdal.gdalinfo import GdalInfo, gdal_info
 from scripts.stac.imagery.item import ImageryItem
@@ -27,7 +27,7 @@ def create_item(
     Returns:
         a STAC Item wrapped in ImageryItem
     """
-    id_ = get_file_name_from_path(file)
+    id_ = basename(file)
 
     if not gdalinfo_result:
         gdalinfo_result = gdal_info(file)

--- a/scripts/stac/tests/item_test.py
+++ b/scripts/stac/tests/item_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime
+from os.path import basename
 
-from scripts.files.files_helper import get_file_name_from_path
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
@@ -17,7 +17,7 @@ def test_imagery_stac_item(mocker) -> None:  # type: ignore
     mocker.patch("scripts.stac.util.checksum.multihash_as_hex", return_value=checksum)
 
     path = "./test/BR34_5000_0302.tiff"
-    id_ = get_file_name_from_path(path)
+    id_ = basename(path)
     start_datetime = "2021-01-27 00:00:00Z"
     end_datetime = "2021-01-27 00:00:00Z"
 
@@ -53,7 +53,7 @@ def test_imagery_add_collection(mocker) -> None:  # type: ignore
     collection = ImageryCollection(metadata=metadata, collection_id=ulid)
 
     path = "./test/BR34_5000_0302.tiff"
-    id_ = get_file_name_from_path(path)
+    id_ = basename(path)
     checksum = "1220cdef68d62fb912110b810e62edc53de07f7a44fb2b310db700e9d9dd58baa6b4"
     mocker.patch("scripts.stac.util.checksum.multihash_as_hex", return_value=checksum)
     item = ImageryItem(id_, path)

--- a/scripts/thumbnails.py
+++ b/scripts/thumbnails.py
@@ -1,13 +1,13 @@
 import argparse
 import json
-import os
 import tempfile
 from functools import partial
 from multiprocessing import Pool
+from os.path import basename, join
 
 from linz_logger import get_log
 
-from scripts.files.files_helper import ContentType, get_file_name_from_path, is_geotiff, is_tiff
+from scripts.files.files_helper import ContentType, is_geotiff, is_tiff
 from scripts.files.fs import exists, read, write
 from scripts.gdal import gdalinfo
 from scripts.gdal.gdal_helper import run_gdal
@@ -31,15 +31,15 @@ def thumbnails(path: str, target: str) -> str | None:
             get_log().debug("thumbnails_skip_not_tiff", file=path)
             return None
 
-        basename = get_file_name_from_path(path)
-        target_thumbnail = os.path.join(target, f"{basename}-thumbnail.jpg")
+        filename = basename(path)
+        target_thumbnail = join(target, f"{filename}-thumbnail.jpg")
         # Verify the thumbnail has not been already generated
         if exists(target_thumbnail):
             get_log().info("thumbnails_already_exists", path=target_thumbnail)
             return None
-        transitional_jpg = os.path.join(tmp_path, f"{basename}.jpg")
-        tmp_thumbnail = os.path.join(tmp_path, f"{basename}-thumbnail.jpg")
-        source_tiff = os.path.join(tmp_path, f"{basename}.tiff")
+        transitional_jpg = join(tmp_path, f"{filename}.jpg")
+        tmp_thumbnail = join(tmp_path, f"{filename}-thumbnail.jpg")
+        source_tiff = join(tmp_path, f"{filename}.tiff")
         # Download source file
         write(source_tiff, read(path))
 

--- a/scripts/translate_ascii.py
+++ b/scripts/translate_ascii.py
@@ -1,14 +1,13 @@
 import argparse
 import json
-import os
 import tempfile
 from functools import partial
 from multiprocessing import Pool
+from os.path import basename, join, splitext
 
 from linz_logger import get_log
 
 from scripts.cli.cli_helper import is_argo
-from scripts.files.files_helper import get_file_name_from_path
 from scripts.files.fs import read, write_all, write_sidecars
 from scripts.gdal.gdal_helper import run_gdal
 from scripts.gdal.gdal_preset import get_ascii_translate_command
@@ -58,7 +57,7 @@ def main() -> None:
         sidecars = []
         for extension in [".prj", ".tfw"]:
             for ls in asc_files:
-                sidecars.append(f"{os.path.splitext(ls)[0]}{extension}")
+                sidecars.append(f"{splitext(ls)[0]}{extension}")
         write_sidecars(sidecars, f"{tmp_path}/source/")
         get_log().info("sidecar files copied", duration=time_in_ms() - start_time, count=len(sidecars))
 
@@ -72,8 +71,8 @@ def translate_ascii(file: str, target_dir_path: str) -> str:
     Returns:
         full path to translated file
     """
-    filename = get_file_name_from_path(file)
-    tiff = os.path.join(target_dir_path, f"{filename}.tiff")
+    filename = basename(file)
+    tiff = join(target_dir_path, f"{filename}.tiff")
     run_gdal(get_ascii_translate_command(), input_file=file, output_file=tiff)
     return tiff
 


### PR DESCRIPTION
#### Motivation

The current implementation to get the file name can be simplified.

#### Modification

- delete `get_file_name_from_path` method and use the builtin `os.path.basename` instead

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated _(no test)_
- [ ] Docs updated _(no docs)_
- [ ] Issue linked in Title _(no ticket)_
