### PR TITLE
refactor: reorganise gdal helper

### DIFF
--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -2,8 +2,8 @@ import json
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
-from scripts.gdal.gdalinfo import GdalInfo, gdal_info
+from scripts.gdal.gdal_helper import GDALExecutionException, gdal_info, run_gdal
+from scripts.gdal.gdalinfo import GdalInfo
 
 
 class FileTiffErrorType(str, Enum):

--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -1,8 +1,5 @@
 import os
 from enum import Enum
-from typing import Optional
-
-from scripts.gdal.gdalinfo import GdalInfo, gdal_info
 
 
 class ContentType(str, Enum):
@@ -49,26 +46,6 @@ def is_tiff(path: str) -> bool:
         ```
     """
     return path.lower().endswith((".tiff", ".tif"))
-
-
-def is_geotiff(path: str, gdalinfo_data: Optional[GdalInfo] = None) -> bool:
-    """Verifies if a file is a GTiff based on the presence of the
-    `coordinateSystem`.
-
-    Args:
-        path: a path to a file
-        gdalinfo_data: gdalinfo of the file. Defaults to None.
-
-    Returns:
-        True if the file is a GTiff
-    """
-    if not gdalinfo_data:
-        gdalinfo_data = gdal_info(path)
-    if "coordinateSystem" not in gdalinfo_data:
-        return False
-    if gdalinfo_data["driverShortName"] == "GTiff":
-        return True
-    return False
 
 
 def is_json(path: str) -> bool:

--- a/scripts/files/tests/file_helper_test.py
+++ b/scripts/files/tests/file_helper_test.py
@@ -1,4 +1,5 @@
-from scripts.files.files_helper import is_geotiff, is_tiff
+from scripts.files.files_helper import is_tiff
+from scripts.gdal.gdal_helper import is_geotiff
 from scripts.gdal.tests.gdalinfo import fake_gdal_info
 
 

--- a/scripts/gdal/gdal_bands.py
+++ b/scripts/gdal/gdal_bands.py
@@ -2,7 +2,8 @@ from typing import List, Optional
 
 from linz_logger import get_log
 
-from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand, gdal_info
+from scripts.gdal.gdal_helper import gdal_info
+from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
 
 
 def find_band(bands: List[GdalInfoBand], color: str) -> Optional[GdalInfoBand]:

--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -1,10 +1,12 @@
+import json
 import os
 import subprocess
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from linz_logger import get_log
 
 from scripts.aws.aws_helper import get_session_credentials, is_s3
+from scripts.gdal.gdalinfo import GdalInfo
 from scripts.logging.time_helper import time_in_ms
 
 
@@ -123,3 +125,46 @@ def get_srs() -> bytes:
             f"Error trying to retrieve srs from epsg code, no files have been checked\n{gdalsrsinfo_result.stderr!r}"
         )
     return gdalsrsinfo_result.stdout
+
+
+def gdal_info(path: str) -> GdalInfo:
+    """run gdalinfo on the provided file
+
+    Args:
+        path: path to file to gdalinfo
+
+    Returns:
+        GdalInfo output
+    """
+    # Set GDAL_PAM_ENABLED to NO to temporarily diable PAM support and prevent creation of auxiliary XML file.
+    gdalinfo_command = ["gdalinfo", "-json", "--config", "GDAL_PAM_ENABLED", "NO"]
+
+    try:
+        gdalinfo_process = run_gdal(gdalinfo_command, path)
+        return cast(GdalInfo, json.loads(gdalinfo_process.stdout))
+    except json.JSONDecodeError as e:
+        get_log().error("load_gdalinfo_result_error", file=path, error=e)
+        raise e
+    except GDALExecutionException as e:
+        get_log().error("gdalinfo_failed", file=path, error=str(e))
+        raise e
+
+
+def is_geotiff(path: str, gdalinfo_data: Optional[GdalInfo] = None) -> bool:
+    """Verifies if a file is a GTiff based on the presence of the
+    `coordinateSystem`.
+
+    Args:
+        path: a path to a file
+        gdalinfo_data: gdalinfo of the file. Defaults to None.
+
+    Returns:
+        True if the file is a GTiff
+    """
+    if not gdalinfo_data:
+        gdalinfo_data = gdal_info(path)
+    if "coordinateSystem" not in gdalinfo_data:
+        return False
+    if gdalinfo_data["driverShortName"] == "GTiff":
+        return True
+    return False

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -1,10 +1,6 @@
-import json
 import re
-from typing import Any, Dict, List, Optional, TypedDict, cast
+from typing import Any, Dict, List, Optional, TypedDict
 
-from linz_logger import get_log
-
-from scripts.gdal.gdal_helper import GDALExecutionException, run_gdal
 from scripts.tile.tile_index import Point
 
 
@@ -77,29 +73,6 @@ class GdalInfo(TypedDict):
     bands: List[GdalInfoBand]
     """Coordinate system description"""
     coordinateSystem: Dict[Any, Any]
-
-
-def gdal_info(path: str) -> GdalInfo:
-    """run gdalinfo on the provided file
-
-    Args:
-        path: path to file to gdalinfo
-
-    Returns:
-        GdalInfo output
-    """
-    # Set GDAL_PAM_ENABLED to NO to temporarily diable PAM support and prevent creation of auxiliary XML file.
-    gdalinfo_command = ["gdalinfo", "-json", "--config", "GDAL_PAM_ENABLED", "NO"]
-
-    try:
-        gdalinfo_process = run_gdal(gdalinfo_command, path)
-        return cast(GdalInfo, json.loads(gdalinfo_process.stdout))
-    except json.JSONDecodeError as e:
-        get_log().error("load_gdalinfo_result_error", file=path, error=e)
-        raise e
-    except GDALExecutionException as e:
-        get_log().error("gdalinfo_failed", file=path, error=str(e))
-        raise e
 
 
 def format_wkt(wkt: str) -> str:

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -4,7 +4,8 @@ from linz_logger import get_log
 
 from scripts.files.files_helper import get_file_name_from_path
 from scripts.files.geotiff import get_extents
-from scripts.gdal.gdalinfo import GdalInfo, gdal_info
+from scripts.gdal.gdal_helper import gdal_info
+from scripts.gdal.gdalinfo import GdalInfo
 from scripts.stac.imagery.item import ImageryItem
 
 

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -13,7 +13,7 @@ from scripts.files.file_tiff import FileTiff, FileTiffType
 from scripts.files.files_helper import ContentType, is_tiff
 from scripts.files.fs import exists, read, write, write_all, write_sidecars
 from scripts.gdal.gdal_bands import get_gdal_band_offset
-from scripts.gdal.gdal_helper import get_gdal_version, run_gdal
+from scripts.gdal.gdal_helper import gdal_info, get_gdal_version, run_gdal
 from scripts.gdal.gdal_preset import (
     get_alpha_command,
     get_build_vrt_command,
@@ -21,7 +21,6 @@ from scripts.gdal.gdal_preset import (
     get_gdal_command,
     get_transform_srs_command,
 )
-from scripts.gdal.gdalinfo import gdal_info
 from scripts.logging.time_helper import time_in_ms
 from scripts.tile.tile_index import Bounds, get_bounds_from_name
 

--- a/scripts/thumbnails.py
+++ b/scripts/thumbnails.py
@@ -7,10 +7,10 @@ from multiprocessing import Pool
 
 from linz_logger import get_log
 
-from scripts.files.files_helper import ContentType, get_file_name_from_path, is_geotiff, is_tiff
+from scripts.files.files_helper import ContentType, get_file_name_from_path, is_tiff
 from scripts.files.fs import exists, read, write
-from scripts.gdal import gdalinfo
-from scripts.gdal.gdal_helper import run_gdal
+from scripts.gdal import gdal_helper
+from scripts.gdal.gdal_helper import is_geotiff, run_gdal
 from scripts.gdal.gdal_preset import get_thumbnail_command
 from scripts.logging.time_helper import time_in_ms
 
@@ -46,7 +46,7 @@ def thumbnails(path: str, target: str) -> str | None:
         # Generate thumbnail
         # For both GeoTIFF and TIFF (not georeferenced) this is done in 2 steps.
         # Why? because it hasn't been found another way to get the same visual aspect.
-        gdalinfo_data = gdalinfo.gdal_info(source_tiff)
+        gdalinfo_data = gdal_helper.gdal_info(source_tiff)
         if is_geotiff(source_tiff, gdalinfo_data):
             get_log().info("thumbnail_generate_geotiff", path=target_thumbnail)
             run_gdal(get_thumbnail_command("jpeg", source_tiff, transitional_jpg, "50%", "50%", None, gdalinfo_data))


### PR DESCRIPTION
#### Motivation

Helping running `gdal`commands should be done by `gdal_helper.py`. 

#### Modification

Move helper methods that run `gdal` to `gdal_helper.py`.
