### PR TITLE
ci: add doctest check

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -24,7 +24,7 @@ jobs:
           poetry run pre-commit run --all-files
       - name: Unit Tests
         run: |
-          poetry run pytest .
+          poetry run pytest --doctest-modules .
 
       - name: Build containers
         run: |

--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -26,14 +26,15 @@ def get_tile_files(source: str) -> List[TileFiles]:
     Args:
         source: JSON string containing representing a list of input file paths and output tile name
 
+    Raises:
+        InputParameterError: for any parsing error
+
     Returns:
         a list of `TileFiles` namedtuple
 
     Example:
-    ```
-    >>> get_tile_files("[{'output': 'CE16_5000_1001', 'input': ['s3://bucket/SN9457_CE16_10k_0501.tif']}]")
-    [TileFiles(output='CE16_5000_1001', input=['s3://bucket/SN9457_CE16_10k_0501.tif'])])]
-    ```
+        >>> get_tile_files('[{"output": "CE16_5000_1001", "input": ["s3://bucket/SN9457_CE16_10k_0501.tif"]}]')
+        [TileFiles(output='CE16_5000_1001', inputs=['s3://bucket/SN9457_CE16_10k_0501.tif'])]
     """
     try:
         source_json: List[TileFiles] = json.loads(

--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -98,11 +98,6 @@ class FileTiff:
 
         Args:
             path: the path to the standardised file
-
-        Example:
-            ```
-            >>> file_tiff.set_path_standardised("/output/BY12_5000_0805.tiff")
-            ```
         """
         self._path_standardised = path
 

--- a/scripts/files/files_helper.py
+++ b/scripts/files/files_helper.py
@@ -20,10 +20,8 @@ def get_file_name_from_path(path: str) -> str:
         the name of the file
 
     Example:
-        ```
         >>> get_file_name_from_path("/a/path/to/file.ext")
-        "file.ext"
-        ```
+        'file'
     """
     return os.path.splitext(os.path.basename(path))[0]
 
@@ -35,15 +33,13 @@ def is_tiff(path: str) -> bool:
         path: a path to a file
 
     Returns:
-        True if the file is a TIFF
+        True if the file has a `.tiff` or `.tif` extension
 
     Examples:
-        ```
         >>> is_tiff("/a/path/to/file.tif")
         True
         >>> is_tiff("/a/path/to/file.jpg")
         False
-        ```
     """
     return path.lower().endswith((".tiff", ".tif"))
 
@@ -55,14 +51,12 @@ def is_json(path: str) -> bool:
         path: a path to a file
 
     Returns:
-        True if the file is a JSON
+        True if the file has a `.json` extension
 
     Examples:
-        ```
-        >>> is_tiff("/a/path/to/file.json")
+        >>> is_json("/a/path/to/file.json")
         True
-        >>> is_tiff("/a/path/to/file.csv")
+        >>> is_json("/a/path/to/file.csv")
         False
-        ```
     """
     return path.lower().endswith(".json")

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -140,10 +140,8 @@ def bucket_name_from_path(path: str) -> str:
         the bucket name
 
     Example:
-        ```
         >>> bucket_name_from_path("s3://linz-imagery/wellingon/")
-        "linz-imagery"
-        ```
+        'linz-imagery'
     """
     path_parts = path.replace("s3://", "").split("/")
     return path_parts.pop(0)
@@ -159,10 +157,8 @@ def prefix_from_path(path: str) -> str:
         the prefix
 
     Example:
-        ```
         >>> prefix_from_path("s3://linz-imagery/wellington/wellington_2021_0.075m/rgb/2193/BP31_500_097091.tiff")
-        "wellington/wellington_2021_0.075m/rgb/2193/BP31_500_097091.tiff"
-        ```
+        'wellington/wellington_2021_0.075m/rgb/2193/BP31_500_097091.tiff'
     """
     bucket_name = bucket_name_from_path(path)
     return path.replace(f"s3://{bucket_name}/", "")


### PR DESCRIPTION
#### Motivation

Some of the `docstring` comments contain `doctest`. Some were wrong. `doctest` are useful to have a quick understanding of what is doing a method based on an example, rather than navigate to test files (if there is any). Having them right is even better.

#### Modification

Allow `pytest` to run the `doctest` by adding the `--doctest-modules` flag.

#### Checklist

- [x] Tests updated
- [x] Docs updated
- [ ] Issue linked in Title (no ticket)
