### PR TITLE
feat: save a copy of capture-area.geojson as an artifact for Argo Workflows TDE-1045

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -83,7 +83,7 @@ class ImageryCollection:
 
         self.add_providers(providers)
 
-    def add_capture_area(self, polygons: List[shapely.geometry.shape], target: str) -> None:
+    def add_capture_area(self, polygons: List[shapely.geometry.shape], target: str, artifact_target: str = "tmp/") -> None:
         """Add the capture area of the Collection.
         The `href` or path of the capture-area.geojson is always set as the relative `./capture-area.geojson`
 
@@ -112,6 +112,9 @@ class ImageryCollection:
             capture_area_content,
             content_type=ContentType.GEOJSON.value,
         )
+
+        # Save `capture-area.geojson` as artifact for Argo UI
+        write(os.path.join(artifact_target, CAPTURE_AREA_FILE_NAME), capture_area_content)
 
         self.stac["stac_extensions"] = self.stac.get("stac_extensions", [])
 

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -83,7 +83,7 @@ class ImageryCollection:
 
         self.add_providers(providers)
 
-    def add_capture_area(self, polygons: List[shapely.geometry.shape], target: str, artifact_target: str = "tmp/") -> None:
+    def add_capture_area(self, polygons: List[shapely.geometry.shape], target: str, artifact_target: str = "/tmp") -> None:
         """Add the capture area of the Collection.
         The `href` or path of the capture-area.geojson is always set as the relative `./capture-area.geojson`
 

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -89,8 +89,8 @@ class ImageryCollection:
 
         Args:
             polygons: list of geometries
-            target: path where the capture-area.geojson file will be saved
-            artifact_target: path where the capture-area.geojson artifact file will be saved.
+            target: location where the capture-area.geojson file will be saved
+            artifact_target: location where the capture-area.geojson artifact file will be saved.
             This is useful for Argo Workflow in order to expose the file to the user for testing/validation purpose.
         """
 

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -89,7 +89,9 @@ class ImageryCollection:
 
         Args:
             polygons: list of geometries
-            target: path of the capture-area-geojson file
+            target: path where the capture-area.geojson file is saved
+            artifact_target: path where the capture-area.geojson artifact file is saved.
+            This is useful for Argo Workflow in order to expose the file to the user for testing/validation purpose.
         """
 
         # The GSD is measured in meters (e.g., `0.3m`)

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -89,8 +89,8 @@ class ImageryCollection:
 
         Args:
             polygons: list of geometries
-            target: path where the capture-area.geojson file is saved
-            artifact_target: path where the capture-area.geojson artifact file is saved.
+            target: path where the capture-area.geojson file will be saved
+            artifact_target: path where the capture-area.geojson artifact file will be saved.
             This is useful for Argo Workflow in order to expose the file to the user for testing/validation purpose.
         """
 

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -181,6 +181,7 @@ def test_default_provider_is_present(metadata: CollectionMetadata) -> None:
 
 def test_capture_area_added(metadata: CollectionMetadata) -> None:
     collection = ImageryCollection(metadata)
+    file_name = "capture-area.geojson"
 
     polygons = []
     polygons.append(
@@ -220,9 +221,14 @@ def test_capture_area_added(metadata: CollectionMetadata) -> None:
         )
     )
     with tempfile.TemporaryDirectory() as tmp_path:
-        collection.add_capture_area(polygons, tmp_path)
+        artifact_path = os.path.join(tmp_path, "tmp")
+        collection.add_capture_area(polygons, tmp_path, artifact_path)
+        file_target = os.path.join(tmp_path, file_name)
+        file_artifact = os.path.join(artifact_path, file_name)
+        assert os.path.isfile(file_target)
+        assert os.path.isfile(file_artifact)
 
-    assert collection.stac["assets"]["capture_area"]["href"] == "./capture-area.geojson"
+    assert collection.stac["assets"]["capture_area"]["href"] == f"./{file_name}"
     assert collection.stac["assets"]["capture_area"]["title"] == "Capture area"
     assert collection.stac["assets"]["capture_area"]["type"] == "application/geo+json"
     assert collection.stac["assets"]["capture_area"]["roles"] == ["metadata"]


### PR DESCRIPTION
#### Motivation

In order to allow Argo Workflows UI to expose a file to the user, the file has to be stored in the local machine. The workflows can then pulled the file as an artifact output. https://github.com/linz/topo-workflows/pull/443

#### Modification

Save a copy of  `capture-area.geojson` file in a different path than the one linked to the STAC Collection.

Another option would be to only save the file locally and let Argo Workflow to save it to the target directory. I haven't choose that option to monitor AWS issues from the application rather than from Argo.

#### Checklist

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
