### PR TITLE
fix: always ignore existing overviews TDE-1046

### DIFF
--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -31,7 +31,7 @@ BASE_COG = [
     # An error will be raise by GDAL if it fails creating a tiff > 4GB in size
     "-co",
     "bigtiff=no",
-    # Always ignore existing overviews
+    # Always ignore existing overviews so they are not created from already compressed overviews
     "-co",
     "overviews=ignore_existing",
 ]
@@ -63,7 +63,7 @@ COMPRESS_LZW = [
 ]
 
 COMPRESS_WEBP_LOSSLESS = [
-    # Comppress into webp
+    # Compress into webp
     "-co",
     "compress=webp",
     # Compress losslessly

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -31,6 +31,9 @@ BASE_COG = [
     # An error will be raise by GDAL if it fails creating a tiff > 4GB in size
     "-co",
     "bigtiff=no",
+    # Always ignore existing overviews
+    "-co",
+    "overviews=ignore_existing",
 ]
 
 DEM_LERC = [
@@ -79,8 +82,6 @@ WEBP_OVERVIEWS = [
     # Reduce quality of overviews to 90%
     "-co",
     "overview_quality=90",
-    "-co",
-    "overviews=ignore_existing",
 ]
 
 

--- a/scripts/gdal/tests/gdal_preset_test.py
+++ b/scripts/gdal/tests/gdal_preset_test.py
@@ -31,6 +31,7 @@ def test_preset_lzw() -> None:
     assert "blocksize=512" in gdal_command
     assert "num_threads=all_cpus" in gdal_command
     assert "bigtiff=no" in gdal_command
+    assert "overviews=ignore_existing" in gdal_command
 
     # LZW compression
     assert "compress=lzw" in gdal_command
@@ -40,7 +41,6 @@ def test_preset_lzw() -> None:
     assert "overview_compress=webp" in gdal_command
     assert "overview_resampling=lanczos" in gdal_command
     assert "overview_quality=90" in gdal_command
-    assert "overviews=ignore_existing" in gdal_command
 
     assert "EPSG:2193" in gdal_command
 
@@ -52,6 +52,7 @@ def test_preset_dem_lerc() -> None:
     assert "blocksize=512" in gdal_command
     assert "num_threads=all_cpus" in gdal_command
     assert "bigtiff=no" in gdal_command
+    assert "overviews=ignore_existing" in gdal_command
 
     # LERC compression
     assert "compress=lerc" in gdal_command
@@ -62,7 +63,6 @@ def test_preset_dem_lerc() -> None:
     assert "overview_compress=webp" not in gdal_command
     assert "overview_resampling=lanczos" not in gdal_command
     assert "overview_quality=90" not in gdal_command
-    assert "overviews=ignore_existing" not in gdal_command
 
     assert "EPSG:2193" in gdal_command
 


### PR DESCRIPTION
#### Motivation

Existing overviews were only being ignored when webp overview compression was used. This was not used by the dem_lerc preset so overviews were not being ignored for LERC compressed DEMs/DSMs and therefore when restandardising already standardised datasets the quality of the overviews could be degraded.

#### Modification

Move the `overviews=ignore_existing` `gdal_translate` configuration option to the `BASE_COG` configuration so it is always set.

#### Checklist

_If not applicable, provide explanation of why._

- [X] Tests updated
- [X] Docs updated
- [X] Issue linked in Title
