### PR TITLE
fix: don't limit footprint points, increase capture area buffer TDE-1049

### DIFF
--- a/scripts/stac/imagery/capture_area.py
+++ b/scripts/stac/imagery/capture_area.py
@@ -49,22 +49,26 @@ def merge_polygons(polygons: List[Polygon], buffer_distance: float) -> Geometry:
 
 def generate_capture_area(polygons: List[Polygon], gsd: float) -> Dict[str, Any]:
     """Generate the capture area from a list of polygons.
-    Providing the `gsd` allows to round the geometry as we've seen some tiffs geometry being slightly off,
-    sometimes due to rounding issue in their creation process (before delivery).
+    Providing the `gsd` allows to round the geometry as we've seen some tiffs
+    geometry being slightly off, sometimes due to rounding issue in their
+    creation process (before delivery).
     If we don't apply this rounding, we could get a very small gaps between tiffs
     which would result in a capture area having gaps.
-    The `gsd` (in meter) is multiplied by the 1m degree of precision.
+    The `gsd` (in meters) is multiplied by 2 and then by the 1m degree of precision.
+    A `buffer factor` of 2 was decided on after experimenting with different outputs,
+    details of this can be found in TDE-1049.
     Note that all the polygons are buffered which means a gap bigger than the gsd,
-    but < gsd*2) will be closed.
+    but < buffer_factor*2 will be closed.
 
     Args:
         polygons: list of polygons of the area
-        gsd: Ground Sample Distance in meter
+        gsd: Ground Sample Distance in meters
 
     Returns:
         The capture-area geojson document.
     """
-    buffer_distance = DECIMAL_DEGREES_1M * gsd
+    buffer_factor = gsd * 2
+    buffer_distance = DECIMAL_DEGREES_1M * buffer_factor
     merged_polygons = merge_polygons(polygons, buffer_distance)
 
     return to_feature(merged_polygons)

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -103,8 +103,8 @@ def test_generate_capture_area_not_rounded() -> None:
     polygons_no_gap.append(Polygon([(1, 1.0), (2.0, 1.0), (2.0, 0.0), (1.0, 0.0)]))
     polygon_with_gap = []
     polygon_with_gap.append(Polygon([(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)]))
-    # The top left corner of the following polygon is off by 0.000004 (~0.44m) to the "right" from the previous one
-    polygon_with_gap.append(Polygon([(1.000004, 1.0), (2.0, 1.0), (2.0, 0.0), (1.0, 0.0)]))
+    # The top left corner of the following polygon is off by 0.000008 (~0.88m) to the "right" from the previous one
+    polygon_with_gap.append(Polygon([(1.000008, 1.0), (2.0, 1.0), (2.0, 0.0), (1.0, 0.0)]))
 
     # Using GSD of 0.2m
     # Generate the capture area of the polygons that don't have a gap between each other
@@ -119,5 +119,5 @@ def test_generate_capture_area_not_rounded() -> None:
     print(f"Capture area expected: {capture_area_expected}")
     print(f"Capture area result: {capture_area_result}")
     # This gap should not be covered in the capture-area
-    # as the GSD is 0.2m * 2 < 0.44m
+    # as the GSD is 0.2m * a buffer of 2 * 2 < 0.88m
     assert capture_area_expected != capture_area_result

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -236,10 +236,10 @@ def test_capture_area_added(metadata: CollectionMetadata) -> None:
     assert "file:checksum" in collection.stac["assets"]["capture_area"]
     assert (
         collection.stac["assets"]["capture_area"]["file:checksum"]
-        == "12209043a7059c39aa8a8bd22ad0e50476b1628a5b20df11c5a507900cab19f2741b"
+        == "1220b15694be7495af38e0f70af67cfdc4f19b8bc415a2eb77d780e7a32c6e5b42c2"
     )
     assert "file:size" in collection.stac["assets"]["capture_area"]
-    assert collection.stac["assets"]["capture_area"]["file:size"] == 341
+    assert collection.stac["assets"]["capture_area"]["file:size"] == 339
 
 
 def test_event_name_is_present(metadata: CollectionMetadata) -> None:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -209,7 +209,7 @@ def standardising(
             if any(tile_byte_count != 0 for tile_byte_count in file_handle.pages.first.tags["TileByteCounts"].value):
                 # Create footprint GeoJSON
                 run_gdal(
-                    ["gdal_footprint", "-t_srs", EpsgCode.EPSG_4326],
+                    ["gdal_footprint", "-t_srs", EpsgCode.EPSG_4326, "-max_points", "unlimited"],
                     standardized_working_path,
                     footprint_tmp_path,
                 )


### PR DESCRIPTION
#### Motivation

The default behaviour of `gdal_footprint` is to set a maximum limit of 100 points in each footprint. This is not enough for all tiles, resulting in some gaps between tiles and not enough detail on more complicated shapes. The solution is to allow unlimited points in tile footprints, and to increase the buffer distance used when simplifying the capture area.

A buffer size of 2 * gsd was chosen after some investigation, [recorded in TDE-1049](https://toitutewhenua.atlassian.net/browse/TDE-1049). The aim is to reduce the number of vertices and therefore the file size, while still describing the capture area in enough detail.

#### Modification

- `gdal_footprint` use the `-max_points unlimited` option
- Set the capture area to use 2 * gsd for the buffer distance.

#### Checklist

_If not applicable, provide explanation of why._

- [X] Tests updated
- [X] Docs updated
- [X] Issue linked in Title
