### PR TITLE
fix: update dem/dsm STAC collection description wording TDE-955

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -336,7 +336,7 @@ class ImageryCollection:
         Urban Aerial Photos / Rural Aerial Photos:
           Orthophotography within the [Region] region captured in the [Year(s)] flying season.
         DEM / DSM:
-          [Digital Surface Model / Digital Elevation Model] within the [Region] region in [year(s)].
+          [Digital Surface Model / Digital Elevation Model] within the [Region] region captured in [year(s)].
         Satellite Imagery / Scanned Aerial Photos:
           [Satellite imagery | Scanned Aerial Photos] within the [Region] region captured in [Year(s)].
 
@@ -358,9 +358,9 @@ class ImageryCollection:
         elif self.metadata["category"] in [URBAN_AERIAL_PHOTOS, RURAL_AERIAL_PHOTOS]:
             desc = f"Orthophotography within the {region} region captured in the {date} flying season"
         elif self.metadata["category"] == DEM:
-            desc = f"Digital Elevation Model within the {region} region in {date}"
+            desc = f"Digital Elevation Model within the {region} region captured in {date}"
         elif self.metadata["category"] == DSM:
-            desc = f"Digital Surface Model within the {region} region in {date}"
+            desc = f"Digital Surface Model within the {region} region captured in {date}"
         else:
             raise SubtypeParameterError(self.metadata["category"])
 

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -46,7 +46,7 @@ def test_generate_description_elevation(metadata: Tuple[CollectionMetadata, Coll
     metadata_auck, _ = metadata
     metadata_auck["category"] = "dem"
     collection = ImageryCollection(metadata_auck)
-    description = "Digital Elevation Model within the Auckland region in 2023."
+    description = "Digital Elevation Model within the Auckland region captured in 2023."
     assert collection.stac["description"] == description
 
 
@@ -57,7 +57,7 @@ def test_generate_description_elevation_geographic_description_input(
     metadata_auck["category"] = "dem"
     metadata_auck["geographic_description"] = "Central"
     collection = ImageryCollection(metadata_auck)
-    description = "Digital Elevation Model within the Auckland region in 2023."
+    description = "Digital Elevation Model within the Auckland region captured in 2023."
     assert collection.stac["description"] == description
 
 


### PR DESCRIPTION
#### Motivation

Slight change to the wording of the STAC collection description for DEMs and DSMs for readability and consistency.

#### Modification

Add in the word "captured" for dem/dsm data type stac collection description.

#### Checklist

_If not applicable, provide explanation of why._

- [X] Tests updated
- [X] Docs updated
- [X] Issue linked in Title
