### PR TITLE
fix: handle percent-encoded urls TDE-1054

### DIFF
--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -28,14 +28,14 @@ class FileTiff:
         paths: List[str],
         preset: Optional[str] = None,
     ) -> None:
-        paths_orginal = []
+        paths_original = []
         for p in paths:
             # paths can be URL containing percent-encoded (like `%20` for space) sequences
             # which would make the process fail later TDE-1054
             # FIXME: we should use URLs in the code base
-            paths_orginal.append(unquote(p))
+            paths_original.append(unquote(p))
 
-        self._paths_original = paths_orginal
+        self._paths_original = paths_original
         self._path_standardised = ""
         self._errors: List[Dict[str, Any]] = []
         self._gdalinfo: Optional[GdalInfo] = None

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -77,7 +77,7 @@ def main() -> None:
                 # If the file is not valid (Non Visual QA errors)
                 # Logs the `vsis3` path to use `gdal` on the file directly from `s3`
                 # This is to help data analysts to verify the file.
-                original_path: List[str] = file.get_path_original()
+                original_path: List[str] = file.get_paths_original()
                 standardised_path = file.get_path_standardised()
                 env_argo_template = os.environ.get("ARGO_TEMPLATE")
                 if env_argo_template:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -139,9 +139,9 @@ def standardising(
         footprint_tmp_path = os.path.join(tmp_path, footprint_file_name)
         sidecars: List[str] = []
         for extension in [".prj", ".tfw"]:
-            for file_input in files.inputs:
+            for file_input in tiff.get_paths_original():
                 sidecars.append(f"{os.path.splitext(file_input)[0]}{extension}")
-        source_files = write_all(files.inputs, f"{tmp_path}/source/")
+        source_files = write_all(tiff.get_paths_original(), f"{tmp_path}/source/")
         write_sidecars(sidecars, f"{tmp_path}/source/")
 
         source_tiffs = [file for file in source_files if is_tiff(file)]


### PR DESCRIPTION
#### Motivation

Path are converted to URL in argo-tasks which can percent-encode (example, space to `%20`).

#### Modification

Quick fix that unquotes percent-encoded sequences in input paths.
Long term fix could be using URL in this repo?

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [x] Issue linked in Title
