### PR TITLE
fix: footprint should exists if tiff already exists

### DIFF
--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -213,12 +213,13 @@ def standardising(
                     standardized_working_path,
                     footprint_tmp_path,
                 )
-                write(standardized_file_path, read(standardized_working_path), content_type=ContentType.GEOTIFF.value)
                 write(
                     footprint_file_path,
                     read(footprint_tmp_path),
                     content_type=ContentType.GEOJSON.value,
                 )
+                write(standardized_file_path, read(standardized_working_path), content_type=ContentType.GEOTIFF.value)
+
                 return tiff
 
         get_log().info("Skipping empty output image", path=input_file, sourceEPSG=source_epsg, targetEPSG=target_epsg)


### PR DESCRIPTION
#### Motivation

The standardising process for a single tile is skipped if the output TIFF already exists in the target. However, the footprint file could not exists in the target directory if the system has stopped before writing the footprint to the target.

#### Modification

Quick solution of writing the footprint file before the output TIFF to make sure the footprint exists if the TIFF exists. 

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [ ] Issue linked in Title N/A
