### PR TITLE
fix: Treat "no data" value as a decimal number TDE-1077

### DIFF
--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -1,10 +1,13 @@
 import json
+from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional
 from urllib.parse import unquote
 
 from scripts.gdal.gdal_helper import GDALExecutionException, gdal_info, run_gdal
 from scripts.gdal.gdalinfo import GdalInfo
+
+DEFAULT_NO_DATA_VALUE = Decimal(-9999)
 
 
 class FileTiffErrorType(str, Enum):
@@ -221,11 +224,11 @@ class FileTiff:
             return
         if "noDataValue" in bands[0]:
             current_nodata_val = bands[0]["noDataValue"]
-            # GDALINFO shows the `noDataValue` as `-9999.0`
-            if self._tiff_type == "DEM" and current_nodata_val and int(current_nodata_val) != -9999:
+            # Convert `gdalinfo -json` no data value string to decimal for numeric comparison
+            if self._tiff_type == "DEM" and current_nodata_val and Decimal(current_nodata_val) != DEFAULT_NO_DATA_VALUE:
                 self.add_error(
                     error_type=FileTiffErrorType.NO_DATA,
-                    error_message="noDataValue is not -9999",
+                    error_message=f"noDataValue is not {DEFAULT_NO_DATA_VALUE}",
                     custom_fields={"current": f"{current_nodata_val}"},
                 )
             elif self._tiff_type == "Imagery" and current_nodata_val != 255:

--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -150,7 +150,7 @@ def gdal_info(path: str) -> GdalInfo:
     Returns:
         GdalInfo output
     """
-    # Set GDAL_PAM_ENABLED to NO to temporarily diable PAM support and prevent creation of auxiliary XML file.
+    # Set GDAL_PAM_ENABLED to NO to temporarily disable PAM support and prevent creation of auxiliary XML file.
     gdalinfo_command = ["gdalinfo", "-json", "--config", "GDAL_PAM_ENABLED", "NO"]
 
     try:

--- a/scripts/gdal/tests/gdalinfo.py
+++ b/scripts/gdal/tests/gdalinfo.py
@@ -29,7 +29,7 @@ def add_band(
     )
 
 
-def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: List[List[int]], no_data_value: Optional[int] = None) -> None:
+def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: List[List[int]], no_data_value: Optional[str] = None) -> None:
     if gdalinfo.get("bands", None) is None:
         gdalinfo["bands"] = []
 


### PR DESCRIPTION
#### Modification

It's represented as a decimal number string in the `gdalinfo -json`
output, so we should treat it as such in the code. This should detect
any values not numerically equal to -9999.

#### Checklist

- [x] Tests updated
- [ ] Docs updated (N/A)
- [x] Issue linked in Title
