### PR TITLE
fix: wrong vsis3 path logged

### DIFF
--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -34,6 +34,9 @@ def get_vfs_path(path: str) -> str:
 
     Returns:
         str: the path modified to comply with the corresponding storage service.
+    Examples:
+        >>> get_vfs_path("s3://scratch-bucket/path/to/file.tiff")
+        '/vsis3/scratch-bucket/path/to/file.tiff'
     """
     return path.replace("s3://", "/vsis3/")
 

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -83,14 +83,7 @@ def main() -> None:
                 standardised_path = file.get_path_standardised()
                 env_argo_template = os.environ.get("ARGO_TEMPLATE")
                 if env_argo_template:
-                    argo_template = json.loads(env_argo_template)
-                    s3_information = argo_template["archiveLocation"]["s3"]
-                    standardised_path = os.path.join(
-                        "/vsis3",
-                        s3_information["bucket"],
-                        s3_information["key"],
-                        *file.get_path_standardised().split("/"),
-                    )
+                    standardised_path = get_vfs_path(file.get_path_standardised())
                     original_s3_path: List[str] = []
                     for path in original_path:
                         original_s3_path.append(get_vfs_path(path))


### PR DESCRIPTION
#### Motivation

The `vsis3` path is logged in order to facilitate the user to investigate an issue on the output tile by running gdal directly with the path copied from logs.
The path is currently logged wrongly: when the script is ran on Argo Workflows, the standardised path is already a S3 path (as target is S3 scratch bucket).
The result with the old implementation gave a path like `/vsis3/linz-workflows-scratch/2024-02/14-test-northland-2018-2020-dsm-1mtfvvz/test-northland-2018-2020-dsm-1mtfvvz-standardise-validate-1780775412/s3:/linz-workflows-scratch/2024-02/14-test-northland-2018-2020-dsm-1mtfvvz/flat/AX27_10000_0105.tiff`

#### Modification

Change the implementation to use `get_vfs_path` which replaces `s3://` by `/vsis3/`.

#### Checklist

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
