### PR TITLE
feat: add checksum to item links in collections TDE-1138

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -129,20 +129,28 @@ class ImageryCollection:
             item: STAC Item to add
         """
         item_self_link = next((feat for feat in item["links"] if feat["rel"] == "self"), None)
+        file_checksum = checksum.multihash_as_hex(json.dumps(item).encode("utf-8"))
         if item_self_link:
-            self.add_link(href=item_self_link["href"])
+            self.add_link(href=item_self_link["href"], checksum=file_checksum)
             self.update_temporal_extent(item["properties"]["start_datetime"], item["properties"]["end_datetime"])
             self.update_spatial_extent(item["bbox"])
 
-    def add_link(self, href: str, rel: str = "item", file_type: str = "application/json") -> None:
+    def add_link(
+        self, href: str, rel: str = "item", file_type: str = "application/json", checksum: Optional[str] = None
+    ) -> None:
         """Add a `link` to the existing `links` list of the Collection.
 
         Args:
             href: path
-            rel: type of link. Defaults to "item".
+            rel: type of link. Defaults to "item". Defaults to "item".
             file_type: type of file pointed by the link. Defaults to "application/json".
+            checksum: Optional checksum of file. Defaults to None.
         """
-        self.stac["links"].append({"rel": rel, "href": href, "type": file_type})
+
+        link = {"rel": rel, "href": href, "type": file_type}
+        if checksum:
+            link["file:checksum"] = checksum
+        self.stac["links"].append(link)
 
     def add_providers(self, providers: List[Provider]) -> None:
         """Add a list of Providers to the existing list of `providers` of the Collection.

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -144,7 +144,7 @@ class ImageryCollection:
             href: path
             rel: type of link. Defaults to "item".
             file_type: type of file pointed by the link. Defaults to "application/json".
-            checksum: Optional checksum of file. Defaults to None.
+            file_checksum: Optional checksum of file. Defaults to None.
         """
 
         link = {"rel": rel, "href": href, "type": file_type}

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -142,7 +142,7 @@ class ImageryCollection:
 
         Args:
             href: path
-            rel: type of link. Defaults to "item". Defaults to "item".
+            rel: type of link. Defaults to "item".
             file_type: type of file pointed by the link. Defaults to "application/json".
             checksum: Optional checksum of file. Defaults to None.
         """

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -135,21 +135,14 @@ class ImageryCollection:
             self.update_temporal_extent(item["properties"]["start_datetime"], item["properties"]["end_datetime"])
             self.update_spatial_extent(item["bbox"])
 
-    def add_link(
-        self, href: str, rel: str = "item", file_type: str = "application/json", file_checksum: Optional[str] = None
-    ) -> None:
+    def add_link(self, href: str, file_checksum: str) -> None:
         """Add a `link` to the existing `links` list of the Collection.
 
         Args:
             href: path
-            rel: type of link. Defaults to "item".
-            file_type: type of file pointed by the link. Defaults to "application/json".
-            file_checksum: Optional checksum of file. Defaults to None.
+            file_checksum: Optional checksum of file.
         """
-
-        link = {"rel": rel, "href": href, "type": file_type}
-        if file_checksum:
-            link["file:checksum"] = file_checksum
+        link = {"rel": "item", "href": href, "type": "application/json", "file:checksum": file_checksum}
         self.stac["links"].append(link)
 
     def add_providers(self, providers: List[Provider]) -> None:

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -131,12 +131,12 @@ class ImageryCollection:
         item_self_link = next((feat for feat in item["links"] if feat["rel"] == "self"), None)
         file_checksum = checksum.multihash_as_hex(json.dumps(item).encode("utf-8"))
         if item_self_link:
-            self.add_link(href=item_self_link["href"], checksum=file_checksum)
+            self.add_link(href=item_self_link["href"], file_checksum=file_checksum)
             self.update_temporal_extent(item["properties"]["start_datetime"], item["properties"]["end_datetime"])
             self.update_spatial_extent(item["bbox"])
 
     def add_link(
-        self, href: str, rel: str = "item", file_type: str = "application/json", checksum: Optional[str] = None
+        self, href: str, rel: str = "item", file_type: str = "application/json", file_checksum: Optional[str] = None
     ) -> None:
         """Add a `link` to the existing `links` list of the Collection.
 
@@ -148,8 +148,8 @@ class ImageryCollection:
         """
 
         link = {"rel": rel, "href": href, "type": file_type}
-        if checksum:
-            link["file:checksum"] = checksum
+        if file_checksum:
+            link["file:checksum"] = file_checksum
         self.stac["links"].append(link)
 
     def add_providers(self, providers: List[Provider]) -> None:

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -131,7 +131,7 @@ def test_add_item(mocker: MockerFixture, metadata: CollectionMetadata, subtests:
 
     with subtests.test():
         assert {
-            "file:checksum": "122052794e4bb0f892b1681cb0efb8c4fdb8f034751cac347b76cc468e8bcbe9a700",
+            "file:checksum": "1220a049888b3971d9ed3fd52b830cfeb379d7069d6b7a927456bcf1fabab0ec4f46",
             "rel": "item",
             "href": "./BR34_5000_0304.json",
             "type": "application/json",

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -130,7 +130,12 @@ def test_add_item(mocker: MockerFixture, metadata: CollectionMetadata, subtests:
     collection.add_item(item.stac)
 
     with subtests.test():
-        assert {"rel": "item", "href": "./BR34_5000_0304.json", "type": "application/json"} in collection.stac["links"]
+        assert {
+            "file:checksum": "122052794e4bb0f892b1681cb0efb8c4fdb8f034751cac347b76cc468e8bcbe9a700",
+            "rel": "item",
+            "href": "./BR34_5000_0304.json",
+            "type": "application/json",
+        } in collection.stac["links"]
 
     with subtests.test():
         assert collection.stac["extent"]["temporal"]["interval"] == [[start_datetime, end_datetime]]


### PR DESCRIPTION
#### Motivation

Add checksum to items links in collections to help with visibility at the collection level of when items are edited

#### Modification

Add checksum to items links in collections when the collection is being created 

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated - no full docs but docstrings updated
- [x] Issue linked in Title
