### PR TITLE
fix: add draft lifecycle tag TDE-1161

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -265,18 +265,20 @@ class ImageryCollection:
             imagery_name = region
             elevation_description = None
 
-        # determine if dataset is preview
+        # determine if the dataset title requires a lifecycle tag
         if self.metadata.get("lifecycle") == "preview":
-            preview = "- Preview"
+            lifecycle_tag = "- Preview"
+        elif self.metadata.get("lifecycle") == "ongoing":
+            lifecycle_tag = "- Draft"
         else:
-            preview = None
+            lifecycle_tag = None
 
         if self.metadata["category"] == SCANNED_AERIAL_PHOTOS:
             if not historic_survey_number:
                 raise MissingMetadataError("historic_survey_number")
             return " ".join(
                 value
-                for value in [imagery_name, self.metadata["gsd"], historic_survey_number, f"({date})", preview or None]
+                for value in [imagery_name, self.metadata["gsd"], historic_survey_number, f"({date})", lifecycle_tag or None]
                 if value is not None
             )
 
@@ -292,7 +294,7 @@ class ImageryCollection:
                     self.metadata["gsd"],
                     DATA_CATEGORIES[self.metadata["category"]],
                     f"({date})",
-                    preview or None,
+                    lifecycle_tag or None,
                 ]
                 if value is not None
             )
@@ -306,7 +308,7 @@ class ImageryCollection:
                     self.metadata["gsd"],
                     DATA_CATEGORIES[self.metadata["category"]],
                     f"({date})",
-                    preview or None,
+                    lifecycle_tag or None,
                 ]
                 if value is not None
             )

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -278,7 +278,7 @@ class ImageryCollection:
                 raise MissingMetadataError("historic_survey_number")
             return " ".join(
                 value
-                for value in [imagery_name, self.metadata["gsd"], historic_survey_number, f"({date})", lifecycle_tag or None]
+                for value in [imagery_name, self.metadata["gsd"], historic_survey_number, f"({date})", lifecycle_tag]
                 if value is not None
             )
 
@@ -294,7 +294,7 @@ class ImageryCollection:
                     self.metadata["gsd"],
                     DATA_CATEGORIES[self.metadata["category"]],
                     f"({date})",
-                    lifecycle_tag or None,
+                    lifecycle_tag,
                 ]
                 if value is not None
             )
@@ -303,12 +303,12 @@ class ImageryCollection:
                 value
                 for value in [
                     region,
-                    elevation_description or None,
+                    elevation_description,
                     "LiDAR",
                     self.metadata["gsd"],
                     DATA_CATEGORIES[self.metadata["category"]],
                     f"({date})",
-                    lifecycle_tag or None,
+                    lifecycle_tag,
                 ]
                 if value is not None
             )

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -139,6 +139,14 @@ def test_generate_dsm_title_preview(metadata: Tuple[CollectionMetadata, Collecti
     assert collection.stac["title"] == title
 
 
+def test_generate_imagery_title_draft(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+    _, metadata_hb = metadata
+    metadata_hb["lifecycle"] = "ongoing"
+    collection = ImageryCollection(metadata_hb)
+    title = "Hawke's Bay 0.3m Rural Aerial Photos (2023) - Draft"
+    assert collection.stac["title"] == title
+
+
 def test_generate_imagery_title_empty_optional_str(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["geographic_description"] = ""


### PR DESCRIPTION
#### Motivation

Align code with title naming convention documentation for [imagery](https://github.com/linz/imagery/blob/master/docs/naming.md#lifecycle) and [elevation](https://github.com/linz/elevation/blob/master/docs/naming.md#lifecycle)

#### Modification

Add `- Draft` to the end of a dataset title if the lifecycle status is `ongoing`

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated - Docs are correct updating code to match
- [x] Issue linked in Title
