### PR TITLE
feat: add checksum metadata to s3 write function TDE-1181

### DIFF
--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -38,9 +38,9 @@ def write(destination: str, source: bytes, content_type: Optional[str] = None) -
     try:
         s3_object = s3.Object(s3_path.bucket, key)
         if content_type:
-            s3_object.put(Body=source, ContentType=content_type, Metadata={"file:checksum": fileChecksum})
+            s3_object.put(Body=source, ContentType=content_type, Metadata={"filechecksum": fileChecksum})
         else:
-            s3_object.put(Body=source, Metadata={"file:checksum": fileChecksum})
+            s3_object.put(Body=source, Metadata={"filechecksum": fileChecksum})
         get_log().debug("write_s3_success", path=destination, duration=time_in_ms() - start_time)
     except ClientError as ce:
         get_log().error("write_s3_error", path=destination, error=f"Unable to write the file: {ce}")

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -33,14 +33,14 @@ def write(destination: str, source: bytes, content_type: Optional[str] = None) -
     s3_path = parse_path(destination)
     key = s3_path.key
     s3 = resource("s3")
-    fileChecksum = checksum.multihash_as_hex(source)
+    multihash = checksum.multihash_as_hex(source)
 
     try:
         s3_object = s3.Object(s3_path.bucket, key)
         if content_type:
-            s3_object.put(Body=source, ContentType=content_type, Metadata={"filechecksum": fileChecksum})
+            s3_object.put(Body=source, ContentType=content_type, Metadata={"multihash": multihash})
         else:
-            s3_object.put(Body=source, Metadata={"filechecksum": fileChecksum})
+            s3_object.put(Body=source, Metadata={"multihash": multihash})
         get_log().debug("write_s3_success", path=destination, duration=time_in_ms() - start_time)
     except ClientError as ce:
         get_log().error("write_s3_error", path=destination, error=f"Unable to write the file: {ce}")

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -38,11 +38,9 @@ def write(destination: str, source: bytes, content_type: Optional[str] = None) -
     try:
         s3_object = s3.Object(s3_path.bucket, key)
         if content_type:
-            s3_object.put(
-                Body=source, ContentType=content_type, ChecksumSHA256=fileChecksum, Metadata={"file:checksum": fileChecksum}
-            )
+            s3_object.put(Body=source, ContentType=content_type, Metadata={"file:checksum": fileChecksum})
         else:
-            s3_object.put(Body=source, ChecksumSHA256=fileChecksum, Metadata={"file:checksum": fileChecksum})
+            s3_object.put(Body=source, Metadata={"file:checksum": fileChecksum})
         get_log().debug("write_s3_success", path=destination, duration=time_in_ms() - start_time)
     except ClientError as ce:
         get_log().error("write_s3_error", path=destination, error=f"Unable to write the file: {ce}")

--- a/scripts/files/tests/fs_s3_test.py
+++ b/scripts/files/tests/fs_s3_test.py
@@ -48,7 +48,7 @@ def test_write_content_type(subtests: SubTests) -> None:
 
 
 @mock_aws
-def test_write_checksum_metadata(subtests: SubTests) -> None:
+def test_write_multihash_as_metadata(subtests: SubTests) -> None:
     s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
     boto3_client = client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="testbucket")
@@ -57,7 +57,7 @@ def test_write_checksum_metadata(subtests: SubTests) -> None:
     resp = boto3_client.get_object(Bucket="testbucket", Key="test.tiff")
 
     with subtests.test():
-        assert resp["Metadata"]["filechecksum"] == "12206ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
+        assert resp["Metadata"]["multihash"] == "12206ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
 
 
 @mock_aws

--- a/scripts/files/tests/fs_s3_test.py
+++ b/scripts/files/tests/fs_s3_test.py
@@ -48,6 +48,19 @@ def test_write_content_type(subtests: SubTests) -> None:
 
 
 @mock_aws
+def test_write_checksum_metadata(subtests: SubTests) -> None:
+    s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
+    boto3_client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="testbucket")
+
+    write("s3://testbucket/test.tiff", b"test content", ContentType.GEOTIFF.value)
+    resp = boto3_client.get_object(Bucket="testbucket", Key="test.tiff")
+
+    with subtests.test():
+        assert resp["Metadata"]["filechecksum"] == "12206ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
+
+
+@mock_aws
 def test_read() -> None:
     s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
     boto3_client = client("s3", region_name=DEFAULT_REGION_NAME)


### PR DESCRIPTION
#### Motivation

Store checksum as s3 metadata so that we can determine if files have changed

#### Modification

- add checksum to s3 object [metadata](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/object/put.html#:~:text=S3%20on%20Outposts.-,Metadata%20(dict)%20%E2%80%93,(string)%20%E2%80%93,-ServerSideEncryption%20(string)) as `filechecksum`

#### Output
![image](https://github.com/linz/topo-imagery/assets/33814653/23b0023a-8759-4622-80f1-c60f4154b2e0)
nb: in the code, it is defined as `filechecksum` and in the tests you use `resp["Metadata"]["filechecksum"]` but something else adds the prefix `x-amz-meta-` here that I can't remove.


#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated - has also been tested manually
- [ ] Docs updated - no docs
- [x] Issue linked in Title
