### PR TITLE
revert: "fix: Make build compatible with new GDAL container TDE-1179 (#971)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,20 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.4@sha256:60d3bc2f8b09ca1a7ef2db0239699b2c03713aa02be6e525e731c0020bbb10a4 as builder
-
-# Avoid blocking `apt-get install` commands
-ARG DEBIAN_FRONTEND=noninteractive
-
-ENV TZ=Etc/UTC
-
-RUN apt-get update
-# Install pipx and build dependencies
-RUN apt-get install --assume-yes gcc libgeos-dev pipx python3-dev
-# Install Poetry with the bundle plugin
-RUN pipx install poetry
-RUN pipx inject poetry poetry-plugin-bundle
-
-# Define the working directory for the following commands
-WORKDIR /src
-
-# Add Poetry config
-COPY poetry.lock pyproject.toml /src/
-
-# Bundle production dependencies into /venv
-RUN /root/.local/bin/poetry bundle venv --no-ansi --no-interaction --only=main -vvv /venv
-
-
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.4@sha256:60d3bc2f8b09ca1a7ef2db0239699b2c03713aa02be6e525e731c0020bbb10a4
 
-ENV TZ=Etc/UTC
+RUN apt-get update
+# Install pip
+RUN apt-get install python3-pip -y
+# Install Poetry
+RUN pip install poetry
 
-# Copy just the bundle from the first stage
-COPY --from=builder /venv /venv
+# Define the working directory for the following commands
+WORKDIR /app
+
+# Add Poetry config
+COPY poetry.lock pyproject.toml /app/
+
+# Install Python dependencies
+RUN poetry config virtualenvs.create false \
+    && poetry install --only main --no-interaction --no-ansi
 
 # Copy Python scripts
 COPY ./scripts/ /app/scripts/
@@ -36,5 +23,3 @@ ENV PYTHONPATH="/app"
 ENV GTIFF_SRS_SOURCE="EPSG"
 
 WORKDIR /app/scripts
-
-ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -o errexit
-
-. /venv/bin/activate
-
-exec "$@"


### PR DESCRIPTION
#### Motivation

This reverts commit 719d96e1ff1133c351bbee7a1d93fa359cc702e4.
We are not using GDAL 3.9 and we had issues running the container within Argo Workflows since this change that modified how the Python environment is managed.
There are some jobs that need to be run on Argo workflows this week so we need to allow user to do it while we are finding a fix for the Argo issue.

#### Modification

_Why is this change being made? What implications or other considerations are there?_

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
