### PR TITLE
fix: Make build compatible with new GDAL container TDE-1179

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,33 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.4@sha256:60d3bc2f8b09ca1a7ef2db0239699b2c03713aa02be6e525e731c0020bbb10a4
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.4@sha256:60d3bc2f8b09ca1a7ef2db0239699b2c03713aa02be6e525e731c0020bbb10a4 as builder
+
+# Avoid blocking `apt-get install` commands
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV TZ=Etc/UTC
 
 RUN apt-get update
-# Install pip
-RUN apt-get install python3-pip -y
-# Install Poetry
-RUN pip install poetry
+# Install pipx and build dependencies
+RUN apt-get install --assume-yes gcc libgeos-dev pipx python3-dev
+# Install Poetry with the bundle plugin
+RUN pipx install poetry
+RUN pipx inject poetry poetry-plugin-bundle
 
 # Define the working directory for the following commands
-WORKDIR /app
+WORKDIR /src
 
 # Add Poetry config
-COPY poetry.lock pyproject.toml /app/
+COPY poetry.lock pyproject.toml /src/
 
-# Install Python dependencies
-RUN poetry config virtualenvs.create false \
-    && poetry install --only main --no-interaction --no-ansi
+# Bundle production dependencies into /venv
+RUN /root/.local/bin/poetry bundle venv --no-ansi --no-interaction --only=main -vvv /venv
+
+
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.4@sha256:60d3bc2f8b09ca1a7ef2db0239699b2c03713aa02be6e525e731c0020bbb10a4
+
+ENV TZ=Etc/UTC
+
+# Copy just the bundle from the first stage
+COPY --from=builder /venv /venv
 
 # Copy Python scripts
 COPY ./scripts/ /app/scripts/
@@ -23,3 +36,5 @@ ENV PYTHONPATH="/app"
 ENV GTIFF_SRS_SOURCE="EPSG"
 
 WORKDIR /app/scripts
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+
+. /venv/bin/activate
+
+exec "$@"


### PR DESCRIPTION
Depends on https://github.com/linz/topo-workflows/pull/604.

Make build compatible with [GDAL 3.9 container](https://github.com/linz/topo-imagery/pull/962).

- Use multi-stage build to avoid including build tools in the final image.
- Install Poetry using pipx, as [recommended](https://python-poetry.org/docs/#installation).
- Use a different working directory in the first stage, to avoid the possibility of confusing the two or unintended interactions between them.
- Use a virtualenv to avoid clobbering OS packages.

- [ ] Tests updated (N/A)
- [ ] Docs updated (N/A)
- [x] Issue linked in Title

This reverts commit 3990bf967e4da461b3e1de7d079aa3f14ed0046c.