### PR TITLE
feat: Update collection summaries TDE-1147

### DIFF
--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -235,6 +235,28 @@ def test_collection_summary_created_and_updated(metadata: CollectionMetadata, su
             assert collection.stac["summaries"][property_name][MAXIMUM_KEY] == format_rfc_3339_datetime_string(latest_datetime)
 
 
+def test_collection_asset_summary_created_and_updated_does_not_clobber_other_summaries(metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    custom_summary_property = "custom"
+    collection.stac["summaries"] = {custom_summary_property: [0, 1]}
+
+    with NamedTemporaryFile() as any_file:
+        collection.add_item(
+            ImageryItem(
+                "oldest_id",
+                any_file.name,
+                any_epoch_datetime,
+                any_epoch_datetime_string(),
+                any_epoch_datetime_string(),
+                {},
+                any_bounding_box(),
+                collection.stac["id"],
+            )
+        )
+
+    assert custom_summary_property in collection.stac["summaries"]
+
+
 def test_write_collection(metadata: CollectionMetadata) -> None:
     target = mkdtemp()
     collectionObj = ImageryCollection(metadata, any_epoch_datetime)


### PR DESCRIPTION
#### Motivation

Users can get a good idea of whether, how, and when a collection has changed based on this summary without going to individual item metadata.

#### Modification

Set STAC collection `summaries` property's `created` and `updated` properties' `minimum` and `maximum` to the values of the relevant items. Verifies that this process does not clobber other summaries.

#### Checklist

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
