### PR TITLE
refactor: Simplify type annotations

### DIFF
--- a/scripts/aws/aws_credential_source.py
+++ b/scripts/aws/aws_credential_source.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 
 # pylint: disable=too-many-instance-attributes
@@ -21,15 +20,15 @@ class CredentialSource:
     """
     Role arn to use
     """
-    externalId: Optional[str] = None
+    externalId: str | None = None
     """
     Role external ID if it exists
     """
-    roleSessionDuration: Optional[int] = 1 * 60 * 60
+    roleSessionDuration: int | None = 1 * 60 * 60
     """
     Max duration of the assumed session in seconds, default 1 hours
     """
-    flags: Optional[str] = None
+    flags: str | None = None
     """
     flags that the role can use either "r" for read-only or "rw" for read-write
     """

--- a/scripts/aws/aws_helper.py
+++ b/scripts/aws/aws_helper.py
@@ -1,7 +1,7 @@
 import json
 from os import environ
 from time import sleep
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 from urllib.parse import urlparse
 
 from boto3 import Session
@@ -15,7 +15,7 @@ S3Path = NamedTuple("S3Path", [("bucket", str), ("key", str)])
 
 aws_profile = environ.get("AWS_PROFILE")
 session = Session(profile_name=aws_profile)
-sessions: Dict[str, Session] = {}
+sessions: dict[str, Session] = {}
 
 bucket_roles: List[CredentialSource] = []
 
@@ -67,7 +67,7 @@ def get_session(prefix: str) -> Session:
     if current_session is not None:
         return current_session
 
-    extra_args: Dict[str, Any] = {"DurationSeconds": cfg.roleSessionDuration}
+    extra_args: dict[str, Any] = {"DurationSeconds": cfg.roleSessionDuration}
 
     if cfg.externalId:
         extra_args["ExternalId"] = cfg.externalId

--- a/scripts/aws/aws_helper.py
+++ b/scripts/aws/aws_helper.py
@@ -1,7 +1,7 @@
 import json
 from os import environ
 from time import sleep
-from typing import Any, List, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 from urllib.parse import urlparse
 
 from boto3 import Session
@@ -17,7 +17,7 @@ aws_profile = environ.get("AWS_PROFILE")
 session = Session(profile_name=aws_profile)
 sessions: dict[str, Session] = {}
 
-bucket_roles: List[CredentialSource] = []
+bucket_roles: list[CredentialSource] = []
 
 client_sts = session.client("sts")
 

--- a/scripts/aws/aws_helper.py
+++ b/scripts/aws/aws_helper.py
@@ -1,7 +1,7 @@
 import json
 from os import environ
 from time import sleep
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
 from boto3 import Session
@@ -119,7 +119,7 @@ def get_session_credentials(prefix: str, retry_count: int = 3) -> ReadOnlyCreden
     raise last_error
 
 
-def _get_credential_config(prefix: str) -> Optional[CredentialSource]:
+def _get_credential_config(prefix: str) -> CredentialSource | None:
     """Get the credential config (`bucket-config`) for the `prefix`.
 
     Args:

--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from datetime import datetime
 from os import environ
-from typing import List, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 from linz_logger import get_log
 
@@ -16,10 +16,10 @@ class InputParameterError(Exception):
 
 class TileFiles(NamedTuple):
     output: str
-    inputs: List[str]
+    inputs: list[str]
 
 
-def get_tile_files(source: str) -> List[TileFiles]:
+def get_tile_files(source: str) -> list[TileFiles]:
     """Transform a JSON string representing a list of input file paths and output tile name created
     by `argo-tasks` (see examples) to a list of `TileFiles`
 
@@ -37,7 +37,7 @@ def get_tile_files(source: str) -> List[TileFiles]:
         [TileFiles(output='CE16_5000_1001', inputs=['s3://bucket/SN9457_CE16_10k_0501.tif'])]
     """
     try:
-        source_json: List[TileFiles] = json.loads(
+        source_json: list[TileFiles] = json.loads(
             source, object_hook=lambda d: TileFiles(inputs=d["input"], output=d["output"])
         )
     except (json.decoder.JSONDecodeError, KeyError) as e:
@@ -47,7 +47,7 @@ def get_tile_files(source: str) -> List[TileFiles]:
     return source_json
 
 
-def load_input_files(path: str) -> List[TileFiles]:
+def load_input_files(path: str) -> list[TileFiles]:
     """Load the TileFiles from a JSON input file containing a list of output and input files.
     Args:
         path: path to a JSON file listing output name and input files
@@ -58,7 +58,7 @@ def load_input_files(path: str) -> List[TileFiles]:
     source = json.dumps(json.loads(read(path)))
 
     try:
-        tile_files: List[TileFiles] = get_tile_files(source)
+        tile_files: list[TileFiles] = get_tile_files(source)
         return tile_files
     except InputParameterError as e:
         get_log().error("An error occurred while getting tile_files", error=str(e))
@@ -77,7 +77,7 @@ def valid_date(s: str) -> datetime:
         raise argparse.ArgumentTypeError(msg) from e
 
 
-def parse_list(list_s: str, separator: Optional[str] = ";") -> List[str]:
+def parse_list(list_s: str, separator: Optional[str] = ";") -> list[str]:
     """Transform a string representing a list to a list of strings
     example: "foo; bar; foo bar" -> ["foo", "bar", "foo bar"]
 
@@ -93,7 +93,7 @@ def parse_list(list_s: str, separator: Optional[str] = ";") -> List[str]:
     return []
 
 
-def coalesce_multi_single(multi_items: Optional[str], single_item: Optional[str]) -> List[str]:
+def coalesce_multi_single(multi_items: Optional[str], single_item: Optional[str]) -> list[str]:
     """Coalesce strings containing either semicolon delimited values or a single
     value into a list. `single_item` is used only if `multi_items` is falsy.
     If both are falsy, an empty list is returned.

--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from datetime import datetime
 from os import environ
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from linz_logger import get_log
 
@@ -77,7 +77,7 @@ def valid_date(s: str) -> datetime:
         raise argparse.ArgumentTypeError(msg) from e
 
 
-def parse_list(list_s: str, separator: Optional[str] = ";") -> list[str]:
+def parse_list(list_s: str, separator: str | None = ";") -> list[str]:
     """Transform a string representing a list to a list of strings
     example: "foo; bar; foo bar" -> ["foo", "bar", "foo bar"]
 
@@ -93,7 +93,7 @@ def parse_list(list_s: str, separator: Optional[str] = ";") -> list[str]:
     return []
 
 
-def coalesce_multi_single(multi_items: Optional[str], single_item: Optional[str]) -> list[str]:
+def coalesce_multi_single(multi_items: str | None, single_item: str | None) -> list[str]:
     """Coalesce strings containing either semicolon delimited values or a single
     value into a list. `single_item` is used only if `multi_items` is falsy.
     If both are falsy, an empty list is returned.

--- a/scripts/cli/tests/cli_helper_test.py
+++ b/scripts/cli/tests/cli_helper_test.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pytest_subtests import SubTests
 
 from scripts.cli.cli_helper import TileFiles, coalesce_multi_single, get_tile_files, parse_list
@@ -12,7 +10,7 @@ def test_get_tile_files(subtests: SubTests) -> None:
     expected_output_filename_b = "tile_name2"
     expected_input_filenames = ["file_a.tiff", "file_b.tiff"]
 
-    source: List[TileFiles] = get_tile_files(file_source)
+    source: list[TileFiles] = get_tile_files(file_source)
     with subtests.test():
         assert expected_output_filename == source[0].output
 

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import os
-from typing import List
 
 import shapely.geometry
 import shapely.ops
@@ -89,7 +88,7 @@ def main() -> None:
     arguments = parser.parse_args()
     uri = arguments.uri
 
-    providers: List[Provider] = []
+    providers: list[Provider] = []
     for producer_name in coalesce_multi_single(arguments.producer_list, arguments.producer):
         providers.append({"name": producer_name, "roles": [ProviderRole.PRODUCER]})
     for licensor_name in coalesce_multi_single(arguments.licensor_list, arguments.licensor):

--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -1,7 +1,7 @@
 import json
 from decimal import Decimal
 from enum import Enum
-from typing import Annotated, Any, List, Optional
+from typing import Annotated, Any, Optional
 from urllib.parse import unquote
 
 from scripts.gdal.gdal_helper import GDALExecutionException, gdal_info, run_gdal
@@ -28,7 +28,7 @@ class FileTiff:
 
     def __init__(
         self,
-        paths: List[str],
+        paths: list[str],
         preset: Optional[str] = None,
     ) -> None:
         paths_original = []
@@ -40,7 +40,7 @@ class FileTiff:
 
         self._paths_original = paths_original
         self._path_standardised = ""
-        self._errors: List[dict[str, Any]] = []
+        self._errors: list[dict[str, Any]] = []
         self._gdalinfo: Optional[GdalInfo] = None
         self._srs: Optional[bytes] = None
         if preset == "dem_lerc":
@@ -141,7 +141,7 @@ class FileTiff:
                 self.add_error(error_type=FileTiffErrorType.GDAL_INFO, error_message=f"error(s): {str(e)}")
         return self._gdalinfo
 
-    def get_errors(self) -> List[dict[str, Any]]:
+    def get_errors(self) -> list[dict[str, Any]]:
         """Get the Non Visual QA errors.
 
         Returns:
@@ -149,7 +149,7 @@ class FileTiff:
         """
         return self._errors
 
-    def get_paths_original(self) -> List[str]:
+    def get_paths_original(self) -> list[str]:
         """Get the path(es) of the original (non standardised) file.
         It can be a list of path if the standardised file is a retiled image.
 

--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -1,7 +1,7 @@
 import json
 from decimal import Decimal
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated, Any, List, Optional
 from urllib.parse import unquote
 
 from scripts.gdal.gdal_helper import GDALExecutionException, gdal_info, run_gdal
@@ -40,7 +40,7 @@ class FileTiff:
 
         self._paths_original = paths_original
         self._path_standardised = ""
-        self._errors: List[Dict[str, Any]] = []
+        self._errors: List[dict[str, Any]] = []
         self._gdalinfo: Optional[GdalInfo] = None
         self._srs: Optional[bytes] = None
         if preset == "dem_lerc":
@@ -141,7 +141,7 @@ class FileTiff:
                 self.add_error(error_type=FileTiffErrorType.GDAL_INFO, error_message=f"error(s): {str(e)}")
         return self._gdalinfo
 
-    def get_errors(self) -> List[Dict[str, Any]]:
+    def get_errors(self) -> List[dict[str, Any]]:
         """Get the Non Visual QA errors.
 
         Returns:
@@ -175,7 +175,7 @@ class FileTiff:
         return self._tiff_type
 
     def add_error(
-        self, error_type: FileTiffErrorType, error_message: str, custom_fields: Optional[Dict[str, str]] = None
+        self, error_type: FileTiffErrorType, error_message: str, custom_fields: Optional[dict[str, str]] = None
     ) -> None:
         """Add an error in Non Visual QA errors list.
 

--- a/scripts/files/file_tiff.py
+++ b/scripts/files/file_tiff.py
@@ -1,7 +1,7 @@
 import json
 from decimal import Decimal
 from enum import Enum
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any
 from urllib.parse import unquote
 
 from scripts.gdal.gdal_helper import GDALExecutionException, gdal_info, run_gdal
@@ -29,7 +29,7 @@ class FileTiff:
     def __init__(
         self,
         paths: list[str],
-        preset: Optional[str] = None,
+        preset: str | None = None,
     ) -> None:
         paths_original = []
         for p in paths:
@@ -41,8 +41,8 @@ class FileTiff:
         self._paths_original = paths_original
         self._path_standardised = ""
         self._errors: list[dict[str, Any]] = []
-        self._gdalinfo: Optional[GdalInfo] = None
-        self._srs: Optional[bytes] = None
+        self._gdalinfo: GdalInfo | None = None
+        self._srs: bytes | None = None
         if preset == "dem_lerc":
             self._tiff_type = FileTiffType.DEM
         else:
@@ -112,7 +112,7 @@ class FileTiff:
         """
         self._path_standardised = path
 
-    def get_gdalinfo(self, path: Optional[str] = None) -> Optional[GdalInfo]:
+    def get_gdalinfo(self, path: str | None = None) -> GdalInfo | None:
         """Get the `gdalinfo` output for the file.
         Run gdalinfo if not already ran or if different path is specified.
         `path` is useful to specify a local file to avoid downloading from external source.
@@ -175,7 +175,7 @@ class FileTiff:
         return self._tiff_type
 
     def add_error(
-        self, error_type: FileTiffErrorType, error_message: str, custom_fields: Optional[dict[str, str]] = None
+        self, error_type: FileTiffErrorType, error_message: str, custom_fields: dict[str, str] | None = None
     ) -> None:
         """Add an error in Non Visual QA errors list.
 

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -2,7 +2,7 @@ import os
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from boto3 import resource
 from linz_logger import get_log
@@ -17,7 +17,7 @@ else:
     S3Client = dict
 
 
-def write(destination: str, source: bytes, content_type: Optional[str] = None) -> str:
+def write(destination: str, source: bytes, content_type: str | None = None) -> str:
     """Write a file from its source to a destination path.
 
     Args:
@@ -87,16 +87,14 @@ def exists(path: str) -> bool:
     return fs_local.exists(path)
 
 
-def modified(path: str, s3_client: Optional[S3Client] = None) -> datetime:
+def modified(path: str, s3_client: S3Client | None = None) -> datetime:
     """Get modified datetime for S3 URL or local path"""
     if is_s3(path):
         return fs_s3.modified(fs_s3.bucket_name_from_path(path), fs_s3.prefix_from_path(path), s3_client)
     return fs_local.modified(Path(path))
 
 
-def write_all(
-    inputs: list[str], target: str, concurrency: Optional[int] = 4, generate_name: Optional[bool] = True
-) -> list[str]:
+def write_all(inputs: list[str], target: str, concurrency: int | None = 4, generate_name: bool | None = True) -> list[str]:
     """Writes list of files to target destination using multithreading.
     Args:
         inputs: list of files to read
@@ -123,7 +121,7 @@ def write_all(
     return written_tiffs
 
 
-def write_sidecars(inputs: list[str], target: str, concurrency: Optional[int] = 4) -> None:
+def write_sidecars(inputs: list[str], target: str, concurrency: int | None = 4) -> None:
     """Writes list of files (if found) to target destination using multithreading.
     The copy of the files have a generated file name (@see `write_file`)
 
@@ -142,7 +140,7 @@ def write_sidecars(inputs: list[str], target: str, concurrency: Optional[int] = 
                 get_log().info("wrote_sidecar_file", path=future.result())
 
 
-def write_file(executor: ThreadPoolExecutor, input_: str, target: str, generate_name: Optional[bool] = True) -> Future[str]:
+def write_file(executor: ThreadPoolExecutor, input_: str, target: str, generate_name: bool | None = True) -> Future[str]:
     """Read a file from a path and write it to a target path.
     Args:
         executor: A ThreadPoolExecutor instance.

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -2,7 +2,7 @@ import os
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from boto3 import resource
 from linz_logger import get_log
@@ -95,8 +95,8 @@ def modified(path: str, s3_client: Optional[S3Client] = None) -> datetime:
 
 
 def write_all(
-    inputs: List[str], target: str, concurrency: Optional[int] = 4, generate_name: Optional[bool] = True
-) -> List[str]:
+    inputs: list[str], target: str, concurrency: Optional[int] = 4, generate_name: Optional[bool] = True
+) -> list[str]:
     """Writes list of files to target destination using multithreading.
     Args:
         inputs: list of files to read
@@ -107,7 +107,7 @@ def write_all(
     Returns:
         list of written file paths
     """
-    written_tiffs: List[str] = []
+    written_tiffs: list[str] = []
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         futuress = {write_file(executor, input_, target, generate_name): input_ for input_ in inputs}
         for future in as_completed(futuress):
@@ -123,7 +123,7 @@ def write_all(
     return written_tiffs
 
 
-def write_sidecars(inputs: List[str], target: str, concurrency: Optional[int] = 4) -> None:
+def write_sidecars(inputs: list[str], target: str, concurrency: Optional[int] = 4) -> None:
     """Writes list of files (if found) to target destination using multithreading.
     The copy of the files have a generated file name (@see `write_file`)
 

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -1,7 +1,7 @@
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Generator, Optional, Union
 
 from boto3 import client, resource
 from botocore.exceptions import ClientError
@@ -172,7 +172,7 @@ def prefix_from_path(path: str) -> str:
     return path.replace(f"s3://{bucket_name}/", "")
 
 
-def list_files_in_uri(uri: str, suffixes: List[str], s3_client: Optional[S3Client]) -> List[str]:
+def list_files_in_uri(uri: str, suffixes: list[str], s3_client: Optional[S3Client]) -> list[str]:
     """Get a list of file paths from a s3 path based on their suffixes
 
     Args:
@@ -215,7 +215,7 @@ def _get_object(bucket: str, file_name: str, s3_client: S3Client) -> GetObjectOu
 
 
 def get_object_parallel_multithreading(
-    bucket: str, files_to_read: List[str], s3_client: Optional[S3Client], concurrency: int
+    bucket: str, files_to_read: list[str], s3_client: Optional[S3Client], concurrency: int
 ) -> Generator[Any, Union[Any, BaseException], None]:
     """Get s3 objects in parallel
 

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -1,7 +1,8 @@
+from collections.abc import Generator
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generator, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from boto3 import client, resource
 from botocore.exceptions import ClientError

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -1,7 +1,7 @@
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generator, Optional, Union
+from typing import TYPE_CHECKING, Any, Generator, Union
 
 from boto3 import client, resource
 from botocore.exceptions import ClientError
@@ -18,7 +18,7 @@ else:
     S3Client = GetObjectOutputTypeDef = dict
 
 
-def write(destination: str, source: bytes, content_type: Optional[str] = None) -> None:
+def write(destination: str, source: bytes, content_type: str | None = None) -> None:
     """Write a source (bytes) in a AWS s3 destination (path in a bucket).
 
     Args:
@@ -172,7 +172,7 @@ def prefix_from_path(path: str) -> str:
     return path.replace(f"s3://{bucket_name}/", "")
 
 
-def list_files_in_uri(uri: str, suffixes: list[str], s3_client: Optional[S3Client]) -> list[str]:
+def list_files_in_uri(uri: str, suffixes: list[str], s3_client: S3Client | None) -> list[str]:
     """Get a list of file paths from a s3 path based on their suffixes
 
     Args:
@@ -215,7 +215,7 @@ def _get_object(bucket: str, file_name: str, s3_client: S3Client) -> GetObjectOu
 
 
 def get_object_parallel_multithreading(
-    bucket: str, files_to_read: list[str], s3_client: Optional[S3Client], concurrency: int
+    bucket: str, files_to_read: list[str], s3_client: S3Client | None, concurrency: int
 ) -> Generator[Any, Union[Any, BaseException], None]:
     """Get s3 objects in parallel
 
@@ -242,6 +242,6 @@ def get_object_parallel_multithreading(
                 yield key, exception
 
 
-def modified(bucket_name: str, key: str, s3_client: Optional[S3Client]) -> datetime:
+def modified(bucket_name: str, key: str, s3_client: S3Client | None) -> datetime:
     s3_client = s3_client or client("s3")
     return _get_object(bucket_name, key, s3_client)["LastModified"]

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -2,7 +2,7 @@ from collections.abc import Generator
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from boto3 import client, resource
 from botocore.exceptions import ClientError
@@ -217,7 +217,7 @@ def _get_object(bucket: str, file_name: str, s3_client: S3Client) -> GetObjectOu
 
 def get_object_parallel_multithreading(
     bucket: str, files_to_read: list[str], s3_client: S3Client | None, concurrency: int
-) -> Generator[Any, Union[Any, BaseException], None]:
+) -> Generator[Any, Any | BaseException, None]:
     """Get s3 objects in parallel
 
     Args:

--- a/scripts/files/geotiff.py
+++ b/scripts/files/geotiff.py
@@ -1,11 +1,11 @@
-from typing import List, Tuple
+from typing import Tuple
 
 from shapely.geometry import Polygon
 
 from scripts.gdal.gdalinfo import GdalInfo
 
 
-def get_extents(gdalinfo_result: GdalInfo) -> Tuple[dict[str, List[List[List[float]]]], Tuple[float, float, float, float]]:
+def get_extents(gdalinfo_result: GdalInfo) -> Tuple[dict[str, list[list[list[float]]]], Tuple[float, float, float, float]]:
     """Get the geometry and bounding box from the `gdalinfo`.
 
     Args:

--- a/scripts/files/geotiff.py
+++ b/scripts/files/geotiff.py
@@ -1,11 +1,9 @@
-from typing import Tuple
-
 from shapely.geometry import Polygon
 
 from scripts.gdal.gdalinfo import GdalInfo
 
 
-def get_extents(gdalinfo_result: GdalInfo) -> Tuple[dict[str, list[list[list[float]]]], Tuple[float, float, float, float]]:
+def get_extents(gdalinfo_result: GdalInfo) -> tuple[dict[str, list[list[list[float]]]], tuple[float, float, float, float]]:
     """Get the geometry and bounding box from the `gdalinfo`.
 
     Args:

--- a/scripts/files/geotiff.py
+++ b/scripts/files/geotiff.py
@@ -1,9 +1,11 @@
+from typing import List, Tuple
+
 from shapely.geometry import Polygon
 
 from scripts.gdal.gdalinfo import GdalInfo
 
 
-def get_extents(gdalinfo_result: GdalInfo) -> tuple[dict[str, list[list[list[float]]]], tuple[float, float, float, float]]:
+def get_extents(gdalinfo_result: GdalInfo) -> Tuple[dict[str, List[List[List[float]]]], Tuple[float, float, float, float]]:
     """Get the geometry and bounding box from the `gdalinfo`.
 
     Args:

--- a/scripts/files/tests/conftest.py
+++ b/scripts/files/tests/conftest.py
@@ -1,6 +1,6 @@
+from collections.abc import Generator
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Generator
 
 import pytest
 

--- a/scripts/gdal/gdal_bands.py
+++ b/scripts/gdal/gdal_bands.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 from linz_logger import get_log
 
 from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
 
 
-def find_band(bands: list[GdalInfoBand], color: str) -> Optional[GdalInfoBand]:
+def find_band(bands: list[GdalInfoBand], color: str) -> GdalInfoBand | None:
     """Look for a specific colorInterperation inside of a `gdalinfo` band output.
 
     Args:
@@ -23,7 +21,7 @@ def find_band(bands: list[GdalInfoBand], color: str) -> Optional[GdalInfoBand]:
 
 
 # pylint: disable-msg=too-many-return-statements
-def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None, preset: Optional[str] = None) -> list[str]:
+def get_gdal_band_offset(file: str, info: GdalInfo | None = None, preset: str | None = None) -> list[str]:
     """Get the banding parameters for a `gdal_translate` command.
 
     Args:
@@ -87,7 +85,7 @@ def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None, preset: Opt
     return ["-b", str(band_red["band"]), "-b", str(band_green["band"]), "-b", str(band_blue["band"])] + band_alpha_arg
 
 
-def get_gdal_band_type(file: str, info: Optional[GdalInfo] = None) -> str:
+def get_gdal_band_type(file: str, info: GdalInfo | None = None) -> str:
     """Get the band type of the first band.
 
     Args:

--- a/scripts/gdal/gdal_bands.py
+++ b/scripts/gdal/gdal_bands.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from linz_logger import get_log
 
@@ -6,7 +6,7 @@ from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
 
 
-def find_band(bands: List[GdalInfoBand], color: str) -> Optional[GdalInfoBand]:
+def find_band(bands: list[GdalInfoBand], color: str) -> Optional[GdalInfoBand]:
     """Look for a specific colorInterperation inside of a `gdalinfo` band output.
 
     Args:
@@ -23,7 +23,7 @@ def find_band(bands: List[GdalInfoBand], color: str) -> Optional[GdalInfoBand]:
 
 
 # pylint: disable-msg=too-many-return-statements
-def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None, preset: Optional[str] = None) -> List[str]:
+def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None, preset: Optional[str] = None) -> list[str]:
     """Get the banding parameters for a `gdal_translate` command.
 
     Args:
@@ -39,7 +39,7 @@ def get_gdal_band_offset(file: str, info: Optional[GdalInfo] = None, preset: Opt
 
     bands = info["bands"]
 
-    band_alpha_arg: List[str] = []
+    band_alpha_arg: list[str] = []
     if band_alpha := find_band(bands, "Alpha"):
         band_alpha_arg.extend(["-b", str(band_alpha["band"])])
 

--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -4,7 +4,7 @@ import subprocess
 from enum import Enum
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Optional, cast
+from typing import cast
 
 from linz_logger import get_log
 
@@ -74,8 +74,8 @@ def get_gdal_version() -> str:
 
 def run_gdal(
     command: list[str],
-    input_file: Optional[str] = None,
-    output_file: Optional[str] = None,
+    input_file: str | None = None,
+    output_file: str | None = None,
 ) -> "subprocess.CompletedProcess[bytes]":
     """Run the GDAL command. The permissions to access to the input file are applied to the gdal environment.
 
@@ -167,7 +167,7 @@ def gdal_info(path: str) -> GdalInfo:
         raise e
 
 
-def is_geotiff(path: str, gdalinfo_data: Optional[GdalInfo] = None) -> bool:
+def is_geotiff(path: str, gdalinfo_data: GdalInfo | None = None) -> bool:
     """Verifies if a file is a GTiff based on the presence of the
     `coordinateSystem`.
 

--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -4,7 +4,7 @@ import subprocess
 from enum import Enum
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 from linz_logger import get_log
 
@@ -41,11 +41,11 @@ def get_vfs_path(path: str) -> str:
     return path.replace("s3://", "/vsis3/")
 
 
-def command_to_string(command: List[str]) -> str:
+def command_to_string(command: list[str]) -> str:
     """Format the command, each arguments separated by a white space.
 
     Args:
-        command (List[str]): each arguments of the command as a string in a list.
+        command (list[str]): each arguments of the command as a string in a list.
 
     Returns:
         str: the formatted command.
@@ -73,7 +73,7 @@ def get_gdal_version() -> str:
 
 
 def run_gdal(
-    command: List[str],
+    command: list[str],
     input_file: Optional[str] = None,
     output_file: Optional[str] = None,
 ) -> "subprocess.CompletedProcess[bytes]":

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from linz_logger import get_log
 
 from scripts.files.file_tiff import DEFAULT_NO_DATA_VALUE
@@ -118,7 +116,7 @@ def get_gdal_command(preset: str, epsg: str) -> list[str]:
     return gdal_command
 
 
-def get_cutline_command(cutline: Optional[str]) -> list[str]:
+def get_cutline_command(cutline: str | None) -> list[str]:
     """Get a `gdalwarp` command to create a virtual file (`.vrt`) which has a cutline applied and alpha added.
 
     Args:
@@ -215,8 +213,8 @@ def get_thumbnail_command(
     output: str,
     xsize: str,
     ysize: str,
-    extra_args: Optional[list[str]] = None,
-    gdalinfo_data: Optional[GdalInfo] = None,
+    extra_args: list[str] | None = None,
+    gdalinfo_data: GdalInfo | None = None,
 ) -> list[str]:
     """Get a `gdal_translate` command to create thumbnails.
 

--- a/scripts/gdal/gdal_preset.py
+++ b/scripts/gdal/gdal_preset.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from linz_logger import get_log
 
@@ -86,7 +86,7 @@ WEBP_OVERVIEWS = [
 ]
 
 
-def get_gdal_command(preset: str, epsg: str) -> List[str]:
+def get_gdal_command(preset: str, epsg: str) -> list[str]:
     """Build a `gdal_translate` command based on the `preset`, `epsg` code, with conversion to 8bits if required.
 
     Args:
@@ -97,7 +97,7 @@ def get_gdal_command(preset: str, epsg: str) -> List[str]:
         a list of arguments to run `gdal_translate`
     """
     get_log().info("gdal_preset", preset=preset)
-    gdal_command: List[str] = ["gdal_translate"]
+    gdal_command: list[str] = ["gdal_translate"]
 
     gdal_command.extend(BASE_COG)
     # Force the source projection to an input EPSG
@@ -118,7 +118,7 @@ def get_gdal_command(preset: str, epsg: str) -> List[str]:
     return gdal_command
 
 
-def get_cutline_command(cutline: Optional[str]) -> List[str]:
+def get_cutline_command(cutline: Optional[str]) -> list[str]:
     """Get a `gdalwarp` command to create a virtual file (`.vrt`) which has a cutline applied and alpha added.
 
     Args:
@@ -144,7 +144,7 @@ def get_cutline_command(cutline: Optional[str]) -> List[str]:
     return gdal_command
 
 
-def get_build_vrt_command(files: List[str], output: str = "output.vrt", add_alpha: bool = False) -> List[str]:
+def get_build_vrt_command(files: list[str], output: str = "output.vrt", add_alpha: bool = False) -> list[str]:
     """Build a VRT from a list of tiff files.
 
     Args:
@@ -166,7 +166,7 @@ def get_build_vrt_command(files: List[str], output: str = "output.vrt", add_alph
     return gdal_command
 
 
-def get_alpha_command() -> List[str]:
+def get_alpha_command() -> list[str]:
     """Get a `gdalwarp` command to create a virtual file (.vrt) which has an alpha added.
 
     Returns:
@@ -183,7 +183,7 @@ def get_alpha_command() -> List[str]:
     ]
 
 
-def get_transform_srs_command(source_epsg: str, target_epsg: str) -> List[str]:
+def get_transform_srs_command(source_epsg: str, target_epsg: str) -> list[str]:
     """Get a `gdalwarp` command to transform the srs.
 
     Args:
@@ -215,9 +215,9 @@ def get_thumbnail_command(
     output: str,
     xsize: str,
     ysize: str,
-    extra_args: Optional[List[str]] = None,
+    extra_args: Optional[list[str]] = None,
     gdalinfo_data: Optional[GdalInfo] = None,
-) -> List[str]:
+) -> list[str]:
     """Get a `gdal_translate` command to create thumbnails.
 
     Args:
@@ -250,7 +250,7 @@ def get_thumbnail_command(
     return command
 
 
-def get_ascii_translate_command() -> List[str]:
+def get_ascii_translate_command() -> list[str]:
     """Get a `translate` command to transform the ascii files to tiff.
 
     Args:

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, List, Optional, TypedDict
 
 from scripts.tile.tile_index import Point
 
@@ -65,13 +65,13 @@ class GdalInfo(TypedDict):
     """GeoTransformation information
 
     """
-    metadata: Dict[Any, Any]
-    cornerCoordinates: Dict[Any, Any]
-    extent: Dict[Any, Any]
-    wgs84Extent: Optional[Dict[str, List[List[List[float]]]]]
+    metadata: dict[Any, Any]
+    cornerCoordinates: dict[Any, Any]
+    extent: dict[Any, Any]
+    wgs84Extent: Optional[dict[str, List[List[List[float]]]]]
     bands: List[GdalInfoBand]
     """Coordinate system description"""
-    coordinateSystem: Dict[Any, Any]
+    coordinateSystem: dict[Any, Any]
 
 
 def get_origin(gdalinfo: GdalInfo) -> Point:

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 
 from scripts.tile.tile_index import Point
 
@@ -35,8 +35,8 @@ class GdalInfoBand(TypedDict):
     Examples:
         "Red", "Green", "Blue", "Alpha", "Gray", "Palette"
     """
-    noDataValue: Optional[int]
-    colorTable: Optional[GdalInfoBandColorTable]
+    noDataValue: int | None
+    colorTable: GdalInfoBandColorTable | None
 
 
 class GdalInfo(TypedDict):
@@ -68,7 +68,7 @@ class GdalInfo(TypedDict):
     metadata: dict[Any, Any]
     cornerCoordinates: dict[Any, Any]
     extent: dict[Any, Any]
-    wgs84Extent: Optional[dict[str, list[list[list[float]]]]]
+    wgs84Extent: dict[str, list[list[list[float]]]] | None
     bands: list[GdalInfoBand]
     """Coordinate system description"""
     coordinateSystem: dict[Any, Any]

--- a/scripts/gdal/gdalinfo.py
+++ b/scripts/gdal/gdalinfo.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, TypedDict
+from typing import Any, Optional, TypedDict
 
 from scripts.tile.tile_index import Point
 
@@ -10,7 +10,7 @@ class GdalInfoBandColorTable(TypedDict):
     count: int
     """Count of entries in the colour palette
     Example: 256"""
-    entries: List[List[int]]
+    entries: list[list[int]]
     """List of colour palette entries. Each is a list of colour channel values
     Example:
     [
@@ -28,7 +28,7 @@ class GdalInfoBand(TypedDict):
     band: int
     """band offset, starting at 1
     """
-    block: List[int]
+    block: list[int]
     type: str
     colorInterpretation: str
     """Color
@@ -56,20 +56,20 @@ class GdalInfo(TypedDict):
         "GeoTIFF"
     """
 
-    files: List[str]
+    files: list[str]
     """List of files processed by the command
     """
-    size: List[int]
+    size: list[int]
     """Width and height of input"""
-    geoTransform: List[float]
+    geoTransform: list[float]
     """GeoTransformation information
 
     """
     metadata: dict[Any, Any]
     cornerCoordinates: dict[Any, Any]
     extent: dict[Any, Any]
-    wgs84Extent: Optional[dict[str, List[List[List[float]]]]]
-    bands: List[GdalInfoBand]
+    wgs84Extent: Optional[dict[str, list[list[list[float]]]]]
+    bands: list[GdalInfoBand]
     """Coordinate system description"""
     coordinateSystem: dict[Any, Any]
 

--- a/scripts/gdal/tests/gdalinfo.py
+++ b/scripts/gdal/tests/gdalinfo.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 
 from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
 
@@ -9,9 +9,9 @@ def fake_gdal_info() -> GdalInfo:
 
 def add_band(
     gdalinfo: GdalInfo,
-    color_interpretation: Optional[str] = None,
-    no_data_value: Optional[int] = None,
-    band_type: Optional[str] = None,
+    color_interpretation: str | None = None,
+    no_data_value: int | None = None,
+    band_type: str | None = None,
 ) -> None:
     if gdalinfo.get("bands", None) is None:
         gdalinfo["bands"] = []
@@ -29,7 +29,7 @@ def add_band(
     )
 
 
-def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: list[list[int]], no_data_value: Optional[str] = None) -> None:
+def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: list[list[int]], no_data_value: str | None = None) -> None:
     if gdalinfo.get("bands", None) is None:
         gdalinfo["bands"] = []
 

--- a/scripts/gdal/tests/gdalinfo.py
+++ b/scripts/gdal/tests/gdalinfo.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 from scripts.gdal.gdalinfo import GdalInfo, GdalInfoBand
 
@@ -29,7 +29,7 @@ def add_band(
     )
 
 
-def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: List[List[int]], no_data_value: Optional[str] = None) -> None:
+def add_palette_band(gdalinfo: GdalInfo, colour_table_entries: list[list[int]], no_data_value: Optional[str] = None) -> None:
     if gdalinfo.get("bands", None) is None:
         gdalinfo["bands"] = []
 

--- a/scripts/json_codec.py
+++ b/scripts/json_codec.py
@@ -1,8 +1,8 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 
-def dict_to_json_bytes(input_dict: Dict[str, Any]) -> bytes:
+def dict_to_json_bytes(input_dict: dict[str, Any]) -> bytes:
     """
     Try to convert a `dict` into UTF-8 encoded `bytes` representing a JSON dictionary
 

--- a/scripts/stac/imagery/capture_area.py
+++ b/scripts/stac/imagery/capture_area.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 from linz_logger import get_log
 from shapely import BufferCapStyle, BufferJoinStyle, to_geojson, union_all
@@ -43,7 +43,7 @@ def get_buffer_distance(gsd: float) -> float:
     return gsd * 2 * DECIMAL_DEGREES_1M
 
 
-def to_feature(geometry: BaseGeometry) -> Dict[str, Any]:
+def to_feature(geometry: BaseGeometry) -> dict[str, Any]:
     """Transform a BaseGeometry to a GeoJSON feature.
 
     Args:
@@ -80,7 +80,7 @@ def merge_polygons(polygons: Sequence[BaseGeometry], buffer_distance: float) -> 
     return union_simplified
 
 
-def generate_capture_area(polygons: Sequence[BaseGeometry], gsd: float) -> Dict[str, Any]:
+def generate_capture_area(polygons: Sequence[BaseGeometry], gsd: float) -> dict[str, Any]:
     """Generate the capture area from a list of BaseGeometries.
     Providing the `gsd` allows to round the geometry as we've seen some tiffs
     geometry being slightly off, sometimes due to rounding issue in their

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import ulid
 from shapely.geometry.base import BaseGeometry
@@ -38,8 +38,8 @@ class ImageryCollection:
         self,
         metadata: CollectionMetadata,
         now: Callable[[], datetime],
-        collection_id: Optional[str] = None,
-        providers: Optional[list[Provider]] = None,
+        collection_id: str | None = None,
+        providers: list[Provider] | None = None,
     ) -> None:
         if not collection_id:
             collection_id = str(ulid.ULID())
@@ -214,7 +214,7 @@ class ImageryCollection:
             ]
         )
 
-    def update_extent(self, bbox: Optional[list[float]] = None, interval: Optional[list[str]] = None) -> None:
+    def update_extent(self, bbox: list[float] | None = None, interval: list[str] | None = None) -> None:
         """Update an extent of the Collection whereas it's spatial or temporal.
 
         Args:

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -1,6 +1,7 @@
 import os
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 
 import ulid
 from shapely.geometry.base import BaseGeometry

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional
 
 import ulid
 from shapely.geometry.base import BaseGeometry
@@ -39,7 +39,7 @@ class ImageryCollection:
         metadata: CollectionMetadata,
         now: Callable[[], datetime],
         collection_id: Optional[str] = None,
-        providers: Optional[List[Provider]] = None,
+        providers: Optional[list[Provider]] = None,
     ) -> None:
         if not collection_id:
             collection_id = str(ulid.ULID())
@@ -87,7 +87,7 @@ class ImageryCollection:
 
         self.add_providers(providers)
 
-    def add_capture_area(self, polygons: List[BaseGeometry], target: str, artifact_target: str = "/tmp") -> None:
+    def add_capture_area(self, polygons: list[BaseGeometry], target: str, artifact_target: str = "/tmp") -> None:
         """Add the capture area of the Collection.
         The `href` or path of the capture-area.geojson is always set as the relative `./capture-area.geojson`
 
@@ -150,7 +150,7 @@ class ImageryCollection:
         link = {"rel": "item", "href": href, "type": "application/json", "file:checksum": file_checksum}
         self.stac["links"].append(link)
 
-    def add_providers(self, providers: List[Provider]) -> None:
+    def add_providers(self, providers: list[Provider]) -> None:
         """Add a list of Providers to the existing list of `providers` of the Collection.
 
         Args:
@@ -159,7 +159,7 @@ class ImageryCollection:
         for p in providers:
             self.stac["providers"].append(p)
 
-    def update_spatial_extent(self, item_bbox: List[float]) -> None:
+    def update_spatial_extent(self, item_bbox: list[float]) -> None:
         """Update (if needed) the Collection spatial extent from a bounding box.
 
         Args:
@@ -214,7 +214,7 @@ class ImageryCollection:
             ]
         )
 
-    def update_extent(self, bbox: Optional[List[float]] = None, interval: Optional[List[str]] = None) -> None:
+    def update_extent(self, bbox: Optional[list[float]] = None, interval: Optional[list[str]] = None) -> None:
         """Update an extent of the Collection whereas it's spatial or temporal.
 
         Args:

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List, Optional
 
 import ulid
 from shapely.geometry.base import BaseGeometry
@@ -32,7 +32,7 @@ CAPTURE_AREA_FILE_NAME = "capture-area.geojson"
 
 
 class ImageryCollection:
-    stac: Dict[str, Any]
+    stac: dict[str, Any]
 
     def __init__(
         self,
@@ -127,7 +127,7 @@ class ImageryCollection:
         if StacExtensions.file.value not in self.stac["stac_extensions"]:
             self.stac["stac_extensions"].append(StacExtensions.file.value)
 
-    def add_item(self, item: Dict[Any, Any]) -> None:
+    def add_item(self, item: dict[Any, Any]) -> None:
         """Add an `Item` to the `links` of the `Collection`.
 
         Args:

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from linz_logger import get_log
 
 from scripts.datetimes import utc_now
@@ -15,7 +13,7 @@ def create_item(
     start_datetime: str,
     end_datetime: str,
     collection_id: str,
-    gdalinfo_result: Optional[GdalInfo] = None,
+    gdalinfo_result: GdalInfo | None = None,
 ) -> ImageryItem:
     """Create an ImageryItem (STAC) to be linked to a Collection.
 

--- a/scripts/stac/imagery/item.py
+++ b/scripts/stac/imagery/item.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 from scripts.datetimes import format_rfc_3339_datetime_string
 from scripts.files import fs
@@ -50,7 +50,7 @@ class ImageryItem:
         self.stac["properties"]["datetime"] = None
 
     # FIXME: redefine the 'Any'
-    def update_spatial(self, geometry: dict[str, Any], bbox: Tuple[float, ...]) -> None:
+    def update_spatial(self, geometry: dict[str, Any], bbox: tuple[float, ...]) -> None:
         """Update the `geometry` and `bbox` (bounding box) of the Item.
 
         Args:

--- a/scripts/stac/imagery/item.py
+++ b/scripts/stac/imagery/item.py
@@ -1,6 +1,7 @@
 import os
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 
 from scripts.datetimes import format_rfc_3339_datetime_string
 from scripts.files import fs

--- a/scripts/stac/imagery/item.py
+++ b/scripts/stac/imagery/item.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Tuple
 
 from scripts.datetimes import format_rfc_3339_datetime_string
 from scripts.files import fs
@@ -11,7 +11,7 @@ from scripts.stac.util.stac_extensions import StacExtensions
 
 
 class ImageryItem:
-    stac: Dict[str, Any]
+    stac: dict[str, Any]
 
     def __init__(self, id_: str, file: str, now: Callable[[], datetime]) -> None:
         file_content = fs.read(file)
@@ -50,7 +50,7 @@ class ImageryItem:
         self.stac["properties"]["datetime"] = None
 
     # FIXME: redefine the 'Any'
-    def update_spatial(self, geometry: Dict[str, Any], bbox: Tuple[float, ...]) -> None:
+    def update_spatial(self, geometry: dict[str, Any], bbox: Tuple[float, ...]) -> None:
         """Update the `geometry` and `bbox` (bounding box) of the Item.
 
         Args:

--- a/scripts/stac/imagery/metadata_constants.py
+++ b/scripts/stac/imagery/metadata_constants.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 
 class CollectionMetadata(TypedDict):
@@ -23,9 +23,9 @@ class CollectionMetadata(TypedDict):
     start_datetime: datetime
     end_datetime: datetime
     lifecycle: str
-    geographic_description: Optional[str]
-    event_name: Optional[str]
-    historic_survey_number: Optional[str]
+    geographic_description: str | None
+    event_name: str | None
+    historic_survey_number: str | None
 
 
 class SubtypeParameterError(Exception):

--- a/scripts/stac/imagery/provider.py
+++ b/scripts/stac/imagery/provider.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, TypedDict
+from typing import TypedDict
 
 
 class ProviderRole(str, Enum):
@@ -12,5 +12,5 @@ class ProviderRole(str, Enum):
 class Provider(TypedDict):
     name: str
     """Organization name"""
-    roles: List[ProviderRole]
+    roles: list[ProviderRole]
     """Organization roles"""

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -1,10 +1,11 @@
 import json
 import os
 import tempfile
+from collections.abc import Callable
 from datetime import datetime, timezone
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Callable, Generator
+from typing import Generator
 
 import pytest
 import shapely.geometry

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -1,11 +1,10 @@
 import json
 import os
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from datetime import datetime, timezone
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Generator
 
 import pytest
 import shapely.geometry

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from datetime import datetime
-from typing import Generator
 
 import pytest
 

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Generator, Tuple
+from typing import Generator
 
 import pytest
 
@@ -10,7 +10,7 @@ from scripts.tests.datetimes_test import any_epoch_datetime
 
 # pylint: disable=duplicate-code
 @pytest.fixture(name="metadata", autouse=True)
-def setup() -> Generator[Tuple[CollectionMetadata, CollectionMetadata], None, None]:
+def setup() -> Generator[tuple[CollectionMetadata, CollectionMetadata], None, None]:
     metadata_auck: CollectionMetadata = {
         "category": "rural-aerial-photos",
         "region": "auckland",
@@ -36,14 +36,14 @@ def setup() -> Generator[Tuple[CollectionMetadata, CollectionMetadata], None, No
     yield (metadata_auck, metadata_hb)
 
 
-def test_generate_description_imagery(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_description_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
     description = "Orthophotography within the Auckland region captured in the 2023 flying season."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_elevation(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_description_elevation(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "dem"
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
@@ -52,7 +52,7 @@ def test_generate_description_elevation(metadata: Tuple[CollectionMetadata, Coll
 
 
 def test_generate_description_elevation_geographic_description_input(
-    metadata: Tuple[CollectionMetadata, CollectionMetadata]
+    metadata: tuple[CollectionMetadata, CollectionMetadata]
 ) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "dem"
@@ -62,7 +62,7 @@ def test_generate_description_elevation_geographic_description_input(
     assert collection.stac["description"] == description
 
 
-def test_generate_description_satellite_imagery(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_description_satellite_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "satellite-imagery"
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
@@ -70,7 +70,7 @@ def test_generate_description_satellite_imagery(metadata: Tuple[CollectionMetada
     assert collection.stac["description"] == description
 
 
-def test_generate_description_historic_imagery(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_description_historic_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "scanned-aerial-photos"
     metadata_auck["historic_survey_number"] = "SNC8844"
@@ -79,7 +79,7 @@ def test_generate_description_historic_imagery(metadata: Tuple[CollectionMetadat
     assert collection.stac["description"] == description
 
 
-def test_generate_description_event(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_description_event(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
     metadata_hb["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(metadata_hb, any_epoch_datetime)

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from datetime import datetime
-from typing import Generator
 
 import pytest
 

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Generator, Tuple
+from typing import Generator
 
 import pytest
 
@@ -10,7 +10,7 @@ from scripts.tests.datetimes_test import any_epoch_datetime
 
 # pylint: disable=duplicate-code
 @pytest.fixture(name="metadata", autouse=True)
-def setup() -> Generator[Tuple[CollectionMetadata, CollectionMetadata], None, None]:
+def setup() -> Generator[tuple[CollectionMetadata, CollectionMetadata], None, None]:
     metadata_auck: CollectionMetadata = {
         "category": "rural-aerial-photos",
         "region": "auckland",
@@ -36,14 +36,14 @@ def setup() -> Generator[Tuple[CollectionMetadata, CollectionMetadata], None, No
     yield (metadata_auck, metadata_hb)
 
 
-def test_generate_imagery_title(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_imagery_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     title = "Auckland 0.3m Rural Aerial Photos (2023)"
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
     assert collection.stac["title"] == title
 
 
-def test_generate_dem_title(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_dem_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "dem"
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
@@ -51,7 +51,7 @@ def test_generate_dem_title(metadata: Tuple[CollectionMetadata, CollectionMetada
     assert collection.stac["title"] == title
 
 
-def test_generate_dsm_title(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_dsm_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "dsm"
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
@@ -59,7 +59,7 @@ def test_generate_dsm_title(metadata: Tuple[CollectionMetadata, CollectionMetada
     assert collection.stac["title"] == title
 
 
-def test_generate_satellite_imagery_title(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_satellite_imagery_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "satellite-imagery"
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
@@ -67,7 +67,7 @@ def test_generate_satellite_imagery_title(metadata: Tuple[CollectionMetadata, Co
     assert collection.stac["title"] == title
 
 
-def test_generate_historic_imagery_title(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_historic_imagery_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     title = "Auckland 0.3m SNC8844 (2023)"
     metadata_auck, _ = metadata
     metadata_auck["category"] = "scanned-aerial-photos"
@@ -76,7 +76,7 @@ def test_generate_historic_imagery_title(metadata: Tuple[CollectionMetadata, Col
     assert collection.stac["title"] == title
 
 
-def test_generate_historic_imagery_title_missing_number(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_historic_imagery_title_missing_number(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "scanned-aerial-photos"
     metadata_auck["historic_survey_number"] = None
@@ -86,7 +86,7 @@ def test_generate_historic_imagery_title_missing_number(metadata: Tuple[Collecti
     assert "historic_survey_number" in str(excinfo.value)
 
 
-def test_generate_title_long_date(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_title_long_date(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["end_datetime"] = datetime(2024, 1, 1)
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
@@ -94,7 +94,7 @@ def test_generate_title_long_date(metadata: Tuple[CollectionMetadata, Collection
     assert collection.stac["title"] == title
 
 
-def test_generate_title_geographic_description(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_title_geographic_description(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["geographic_description"] = "Ponsonby"
     collection = ImageryCollection(metadata_auck, any_epoch_datetime)
@@ -102,7 +102,7 @@ def test_generate_title_geographic_description(metadata: Tuple[CollectionMetadat
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_imagery(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_title_event_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
     metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     metadata_hb["event_name"] = "Cyclone Gabrielle"
@@ -111,7 +111,7 @@ def test_generate_title_event_imagery(metadata: Tuple[CollectionMetadata, Collec
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_elevation(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_title_event_elevation(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
     metadata_hb["category"] = "dsm"
     metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
@@ -121,7 +121,7 @@ def test_generate_title_event_elevation(metadata: Tuple[CollectionMetadata, Coll
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_satellite_imagery(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_title_event_satellite_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
     metadata_hb["category"] = "satellite-imagery"
     metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
@@ -131,7 +131,7 @@ def test_generate_title_event_satellite_imagery(metadata: Tuple[CollectionMetada
     assert collection.stac["title"] == title
 
 
-def test_generate_dsm_title_preview(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_dsm_title_preview(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["category"] = "dsm"
     metadata_auck["lifecycle"] = "preview"
@@ -140,7 +140,7 @@ def test_generate_dsm_title_preview(metadata: Tuple[CollectionMetadata, Collecti
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_draft(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_imagery_title_draft(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     _, metadata_hb = metadata
     metadata_hb["lifecycle"] = "ongoing"
     collection = ImageryCollection(metadata_hb, any_epoch_datetime)
@@ -148,7 +148,7 @@ def test_generate_imagery_title_draft(metadata: Tuple[CollectionMetadata, Collec
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_empty_optional_str(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_imagery_title_empty_optional_str(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["geographic_description"] = ""
     metadata_auck["event_name"] = ""
@@ -157,7 +157,7 @@ def test_generate_imagery_title_empty_optional_str(metadata: Tuple[CollectionMet
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_with_event(metadata: Tuple[CollectionMetadata, CollectionMetadata]) -> None:
+def test_generate_imagery_title_with_event(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
     metadata_auck, _ = metadata
     metadata_auck["geographic_description"] = "Auckland Forest Assessment"
     metadata_auck["event_name"] = "Forest Assessment"

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import sys
-from typing import List
 
 from linz_logger import get_log
 
@@ -96,12 +95,12 @@ def main() -> None:
                 # If the file is not valid (Non Visual QA errors)
                 # Logs the `vsis3` path to use `gdal` on the file directly from `s3`
                 # This is to help data analysts to verify the file.
-                original_path: List[str] = file.get_paths_original()
+                original_path: list[str] = file.get_paths_original()
                 standardised_path = file.get_path_standardised()
                 env_argo_template = os.environ.get("ARGO_TEMPLATE")
                 if env_argo_template:
                     standardised_path = get_vfs_path(file.get_path_standardised())
-                    original_s3_path: List[str] = []
+                    original_s3_path: list[str] = []
                     for path in original_path:
                         original_s3_path.append(get_vfs_path(path))
                     original_path = original_s3_path

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from functools import partial
 from multiprocessing import Pool
-from typing import List, Optional
+from typing import Optional
 
 from linz_logger import get_log
 from tifffile import TiffFile
@@ -27,7 +27,7 @@ from scripts.tile.tile_index import Bounds, get_bounds_from_name
 
 
 def run_standardising(
-    todo: List[TileFiles],
+    todo: list[TileFiles],
     preset: str,
     cutline: Optional[str],
     concurrency: int,
@@ -36,7 +36,7 @@ def run_standardising(
     gsd: str,
     create_footprints: bool,
     target_output: str = "/tmp/",
-) -> List[FileTiff]:
+) -> list[FileTiff]:
     """Run `standardising()` in parallel (`concurrency`).
 
     Args:
@@ -84,7 +84,7 @@ def run_standardising(
     return standardized_tiffs
 
 
-def create_vrt(source_tiffs: List[str], target_path: str, add_alpha: bool = False) -> str:
+def create_vrt(source_tiffs: list[str], target_path: str, add_alpha: bool = False) -> str:
     """Create a VRT from a list of tiffs files
 
     Args:
@@ -146,7 +146,7 @@ def standardising(
     with tempfile.TemporaryDirectory() as tmp_path:
         standardized_working_path = os.path.join(tmp_path, standardized_file_name)
         footprint_tmp_path = os.path.join(tmp_path, footprint_file_name)
-        sidecars: List[str] = []
+        sidecars: list[str] = []
         for extension in [".prj", ".tfw"]:
             for file_input in tiff.get_paths_original():
                 sidecars.append(f"{os.path.splitext(file_input)[0]}{extension}")

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 from functools import partial
 from multiprocessing import Pool
-from typing import Optional
 
 from linz_logger import get_log
 from tifffile import TiffFile
@@ -29,7 +28,7 @@ from scripts.tile.tile_index import Bounds, get_bounds_from_name
 def run_standardising(
     todo: list[TileFiles],
     preset: str,
-    cutline: Optional[str],
+    cutline: str | None,
     concurrency: int,
     source_epsg: str,
     target_epsg: str,
@@ -110,9 +109,9 @@ def standardising(
     target_epsg: str,
     gsd: str,
     create_footprints: bool,
-    cutline: Optional[str],
+    cutline: str | None,
     target_output: str = "/tmp/",
-) -> Optional[FileTiff]:
+) -> FileTiff | None:
     """Apply transformations using GDAL to the source file and create a footprint sidecar file.
 
     Args:

--- a/scripts/tile/tests/tile_index_data.py
+++ b/scripts/tile/tests/tile_index_data.py
@@ -1,6 +1,6 @@
-from typing import Any, List
+from typing import Any
 
-MAP_SHEET_DATA: List[dict[Any, Any]] = [
+MAP_SHEET_DATA: list[dict[Any, Any]] = [
     {"origin": {"x": 1492000, "y": 6234000}, "code": "AS21"},
     {"origin": {"x": 1516000, "y": 6234000}, "code": "AS22"},
     {"origin": {"x": 1564000, "y": 6198000}, "code": "AT24"},

--- a/scripts/tile/tests/tile_index_data.py
+++ b/scripts/tile/tests/tile_index_data.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, List
+from typing import Any, List
 
-MAP_SHEET_DATA: List[Dict[Any, Any]] = [
+MAP_SHEET_DATA: List[dict[Any, Any]] = [
     {"origin": {"x": 1492000, "y": 6234000}, "code": "AS21"},
     {"origin": {"x": 1516000, "y": 6234000}, "code": "AS22"},
     {"origin": {"x": 1564000, "y": 6198000}, "code": "AT24"},

--- a/scripts/tile/tile_index.py
+++ b/scripts/tile/tile_index.py
@@ -1,5 +1,5 @@
 import re
-from typing import NamedTuple, Union
+from typing import NamedTuple
 
 from scripts.tile.util import charcodeat
 
@@ -20,13 +20,13 @@ CHAR_S = charcodeat("S", 0)
 class Point(NamedTuple):
     """Class that represents a point(x,y)"""
 
-    x: Union[int, float]
-    y: Union[int, float]
+    x: int | float
+    y: int | float
 
 
 class Size(NamedTuple):
-    width: Union[int, float]
-    height: Union[int, float]
+    width: int | float
+    height: int | float
 
 
 class Bounds(NamedTuple):


### PR DESCRIPTION
#### Modification

Use post-Python 3.9 syntax for type annotations.

#### Checklist

All N/A, just a type annotation change.

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
