### PR TITLE
fix: Treat item as `dict` TDE-1209

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -1,6 +1,5 @@
 import os
 from collections.abc import Callable
-from dataclasses import asdict
 from datetime import datetime
 from typing import Any
 
@@ -12,7 +11,7 @@ from scripts.files.files_helper import ContentType
 from scripts.files.fs import write
 from scripts.json_codec import dict_to_json_bytes
 from scripts.stac.imagery.capture_area import generate_capture_area, gsd_to_float
-from scripts.stac.imagery.item import BoundingBox, ImageryItem
+from scripts.stac.imagery.item import BoundingBox
 from scripts.stac.imagery.metadata_constants import (
     DATA_CATEGORIES,
     DEM,
@@ -130,18 +129,18 @@ class ImageryCollection:
         if StacExtensions.file.value not in self.stac["stac_extensions"]:
             self.stac["stac_extensions"].append(StacExtensions.file.value)
 
-    def add_item(self, item: ImageryItem) -> None:
+    def add_item(self, item: dict[Any, Any]) -> None:
         """Add an `Item` to the `links` of the `Collection`.
 
         Args:
             item: STAC Item to add
         """
-        item_self_link = next((feat for feat in item.links if feat["rel"] == "self"), None)
-        file_checksum = checksum.multihash_as_hex(dict_to_json_bytes(asdict(item)))
+        item_self_link = next((feat for feat in item["links"] if feat["rel"] == "self"), None)
+        file_checksum = checksum.multihash_as_hex(dict_to_json_bytes(item))
         if item_self_link:
             self.add_link(href=item_self_link["href"], file_checksum=file_checksum)
-            self.update_temporal_extent(item.properties.start_datetime, item.properties.end_datetime)
-            self.update_spatial_extent(item.bbox)
+            self.update_temporal_extent(item["properties"]["start_datetime"], item["properties"]["end_datetime"])
+            self.update_spatial_extent(item["bbox"])
 
     def add_link(self, href: str, file_checksum: str) -> None:
         """Add a `link` to the existing `links` list of the Collection.

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -1,5 +1,6 @@
 import json
 import os
+from dataclasses import asdict
 from datetime import datetime, timezone
 from shutil import rmtree
 from tempfile import TemporaryDirectory, mkdtemp
@@ -138,7 +139,7 @@ def test_add_item(metadata: CollectionMetadata, subtests: SubTests) -> None:
         "BR34_5000_0304", item_file_path, now_function, start_datetime, end_datetime, geometry, bbox, collection.stac["id"]
     )
 
-    collection.add_item(item)
+    collection.add_item(asdict(item))
 
     links = collection.stac["links"].copy()
 


### PR DESCRIPTION
#### Motivation

Fix runtime error in commands like `docker build -t topo-imagery . && docker run -v ${HOME}/tmp/:/tmp/:rw -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro -e AWS_PROFILE=li-topo-prod topo-imagery python /app/scripts/collection_from_items.py --uri s3://linz-workflows-scratch/afage/small_example_dem_dataset/ --collection-id 01HYCJ3EXF37J4A9130AH7Q2RF --category dem --region hawkes-bay --gsd 1m --start-date 2023-09-20 --end-date 2023-12-21 --lifecycle ongoing --producer "Woolpert" --licensor "National Institute of Water and Atmospheric Research" --concurrency 25` on topo-prod account.

#### Modification

We load the item from a JSON file into a `dict` in the production code,
but none of our automated tests verify this code path, so it broke.

This partially reverts commit ed177c622dbb93587f00524635051c5f0f4a8b9f.

#### Checklist

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
