### PR TITLE
fix: concurrency file order TDE-1213

### DIFF
--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -141,7 +141,7 @@ def write_sidecars(inputs: list[str], target: str, concurrency: int | None = 4) 
     for future in results:
         future_ex = future.exception()
         if isinstance(future_ex, NoSuchFileError):
-            get_log().info("No sidecar file found; skipping", error="future.exception()")
+            get_log().info("No sidecar file found; skipping", error=future.exception())
         else:
             get_log().info("wrote_sidecar_file", path=future.result())
 

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -112,7 +112,6 @@ def write_all(inputs: list[str], target: str, concurrency: int | None = 4, gener
             results.append(executor.submit(write_file, input_, target, generate_name))
 
     for future in results:
-        print(future.exception())
         if future.exception():
             get_log().warn("Failed Read-Write", error=future.exception())
         else:
@@ -140,7 +139,6 @@ def write_sidecars(inputs: list[str], target: str, concurrency: int | None = 4) 
             results.append(executor.submit(write_file, input_, target))
 
     for future in results:
-        print("hello")
         future_ex = future.exception()
         if isinstance(future_ex, NoSuchFileError):
             get_log().info("No sidecar file found; skipping", error="future.exception()")

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -89,6 +89,18 @@ def test_write_sidecars_one_found(capsys: CaptureFixture[str], subtests: SubTest
     rmtree(target)
 
 
+def test_write_all_in_order(setup: str) -> None:
+    inputs: list[str] = []
+    i = 0
+    while i < 20:
+        path = Path(os.path.join(setup, str(i)))
+        path.touch()
+        inputs.append(path.as_posix())
+        i += 1
+    written_files = write_all(inputs=inputs, target=setup, generate_name=False)
+    assert written_files == inputs
+
+
 @mock_aws
 def test_should_get_s3_object_modified_datetime() -> None:
     bucket_name = "any-bucket-name"

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -91,17 +91,18 @@ def test_write_sidecars_one_found(capsys: CaptureFixture[str], subtests: SubTest
 
 def test_write_all_in_order(setup: str) -> None:
     inputs: list[str] = []
+    file_contents = "a" * 1000 * 1000
     i = 0
     while i < 10:
         path = Path(os.path.join(setup, str(i)))
         if i % 2 == 0:
-            path.write_text("a" * 1000 * 1000, encoding="utf-8")  # 1MB
+            path.write_text(file_contents, encoding="utf-8")  # 1MB
         else:
             path.touch()
         inputs.append(path.as_posix())
         i += 1
     written_files = write_all(inputs=inputs, target=setup, generate_name=False)
-    assert written_files == inputs
+    assert written_files != inputs
 
 
 @mock_aws

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -102,7 +102,7 @@ def test_write_all_in_order(setup: str) -> None:
         inputs.append(path.as_posix())
         i += 1
     written_files = write_all(inputs=inputs, target=setup, generate_name=False)
-    assert written_files != inputs
+    assert written_files == inputs
 
 
 @mock_aws

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -92,9 +92,12 @@ def test_write_sidecars_one_found(capsys: CaptureFixture[str], subtests: SubTest
 def test_write_all_in_order(setup: str) -> None:
     inputs: list[str] = []
     i = 0
-    while i < 20:
+    while i < 10:
         path = Path(os.path.join(setup, str(i)))
-        path.touch()
+        if i % 2 == 0:
+            path.write_text("a" * 1000 * 1000)  # 1MB
+        else:
+            path.touch()
         inputs.append(path.as_posix())
         i += 1
     written_files = write_all(inputs=inputs, target=setup, generate_name=False)

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -95,7 +95,7 @@ def test_write_all_in_order(setup: str) -> None:
     while i < 10:
         path = Path(os.path.join(setup, str(i)))
         if i % 2 == 0:
-            path.write_text("a" * 1000 * 1000)  # 1MB
+            path.write_text("a" * 1000 * 1000, encoding="utf-8")  # 1MB
         else:
             path.touch()
         inputs.append(path.as_posix())


### PR DESCRIPTION
#### Motivation

When supplying multiple source locations to use for standardising, if there are overlapping source images, the VRT created does not honour the priority order for the supplied datasets. This Pull Request is to retain the priority of the images for merging.

#### Modification

Move away from using `as_completed` for parallel processing so that the output file list is in the same order as the input file list.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
