### PR TITLE
build: comply with Docker FromAsCasing build check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.9.0@sha256:d1a38af532e5d9e3991c4a6bddc2f2cb52644dc30a4eb8242101e8e23c3f83f6 as builder
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.9.0@sha256:d1a38af532e5d9e3991c4a6bddc2f2cb52644dc30a4eb8242101e8e23c3f83f6 AS builder
 
 # Avoid blocking `apt-get install` commands
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Motivation

After a workstation upgrade of Docker CLI to v27, the [FromAsCasing build check](https://docs.docker.com/reference/build-checks/from-as-casing/) warning is logged
`=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`

### Modifications

Use consistent case in the Dockerfile (from `as` to `AS`).

### Verification

Built locally.
