### PR TITLE
fix: capture area winding order TDE-1205

### DIFF
--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -1,5 +1,7 @@
+from typing import cast
+
 from shapely import get_exterior_ring, is_ccw
-from shapely.geometry import Polygon, shape
+from shapely.geometry import MultiPolygon, Polygon, shape
 
 from scripts.stac.imagery.capture_area import generate_capture_area, merge_polygons, to_feature
 
@@ -151,7 +153,7 @@ def test_capture_area_orientation_polygon() -> None:
 
 def test_capture_area_orientation_multipolygon() -> None:
     # Test the orientation of the capture area
-    # The multipolygon capture area should be the same as the polygon and not reversed
+    # The multipolygon capture area polygons should be the same as the polygon and not reversed
     polygons = []
     polygons.append(
         shape(
@@ -185,4 +187,5 @@ def test_capture_area_orientation_multipolygon() -> None:
         )
     )
     capture_area = generate_capture_area(polygons, 0.05)
-    assert is_ccw(get_exterior_ring(shape(capture_area["geometry"]).geoms[0]))
+    mp_geom = cast(MultiPolygon, shape(capture_area["geometry"]))
+    assert is_ccw(get_exterior_ring(mp_geom.geoms[0]))

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -1,4 +1,5 @@
-from shapely.geometry import Polygon
+from shapely import get_exterior_ring, is_ccw
+from shapely.geometry import Polygon, shape
 
 from scripts.stac.imagery.capture_area import generate_capture_area, merge_polygons, to_feature
 
@@ -121,3 +122,67 @@ def test_generate_capture_area_not_rounded() -> None:
     # This gap should not be covered in the capture-area
     # as the GSD is 0.2m * a buffer of 2 * 2 < 0.88m
     assert capture_area_expected != capture_area_result
+
+
+def test_capture_area_orientation_polygon() -> None:
+    # Test the orientation of the capture area
+    # The polygon capture area should be the same as the polygon and not reversed
+    polygons = []
+    polygons.append(
+        shape(
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [174.673418475601466, -37.051277768264598],
+                            [174.673425023818197, -37.051550327851878],
+                            [174.673479832051271, -37.051280958541774],
+                            [174.673418475601466, -37.051277768264598],
+                        ]
+                    ]
+                ],
+            }
+        )
+    )
+    capture_area = generate_capture_area(polygons, 0.05)
+    assert is_ccw(get_exterior_ring(shape(capture_area["geometry"])))
+
+
+def test_capture_area_orientation_multipolygon() -> None:
+    # Test the orientation of the capture area
+    # The multipolygon capture area should be the same as the polygon and not reversed
+    polygons = []
+    polygons.append(
+        shape(
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [175.01786467173446, -36.80914409510033],
+                            [175.0154395531313, -36.80918523526587],
+                            [175.01524959114974, -36.80950706997984],
+                            [175.01312143626905, -36.81369683085496],
+                            [175.01801611134528, -36.81491172712502],
+                            [175.01786467173446, -36.80914409510033],
+                        ]
+                    ],
+                    [
+                        [
+                            [174.99635270693256, -36.809507300287486],
+                            [174.99160937900407, -36.80958686195598],
+                            [174.9916815185804, -36.80966722253352],
+                            [174.9909875028488, -36.810093453911804],
+                            [174.99113976763834, -36.815970642382126],
+                            [174.99336131537976, -36.81582975812777],
+                            [174.99645096077896, -36.81328982536313],
+                            [174.99635270693256, -36.809507300287486],
+                        ]
+                    ],
+                ],
+            }
+        )
+    )
+    capture_area = generate_capture_area(polygons, 0.05)
+    assert is_ccw(get_exterior_ring(shape(capture_area["geometry"]).geoms[0]))

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -310,8 +310,7 @@ def test_capture_area_added(metadata: CollectionMetadata, subtests: SubTests) ->
 
     with subtests.test():
         assert collection.stac["assets"]["capture_area"]["file:checksum"] in (
-            "1220b15694be7495af38e0f70af67cfdc4f19b8bc415a2eb77d780e7a32c6e5b42c2",  # geos 3.11
-            "122040fc8700d5d2d04600f730e10677b19d33f3b1e43b02c7867f4cfc2101930863",  # geos 3.12
+            "1220369cd5d4179f5f68ca0fd9be70b9f66033fcc6bb2f3305c0ad977adc79d7ad53",  # geos 3.11 - geos 3.12 as yet untested
         )
 
     with subtests.test():


### PR DESCRIPTION
### Motivation

[An issue was raised on the Elevation repo](https://github.com/linz/elevation/issues/298) to let us know that the capture areas we are generating are not compliant with https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6
Exterior polygon rings should follow the right-hand rule with a counter-clockwise winding order.
While the footprints generated by the standardising process are compliant with the right-hand rule, when the polygons are buffered for merging, [Shapely reverses the orientation of the polygons](https://github.com/shapely/shapely/issues/622).

### Modifications

Use the Shapely `orient` function to ensure that the capture area polygons have a counter-clockwise winding order.

[Example capture areas attached](https://github.com/user-attachments/files/16367933/examples.zip).

### Verification

Unit tests to check winding order of simple polygon and multipolygon capture areas.
Manual testing of more complicated capture areas with nested polygons and footprints with multiple polygons.
