### PR TITLE
test: init automatic tests for collection_from_items.py script TDE-1227

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -93,7 +93,6 @@ def parse_args(args: List[str] | None) -> Namespace:
 def main(args: List[str] | None = None) -> None:
     arguments = parse_args(args)
     uri = arguments.uri
-    print(arguments.start_date)
 
     providers: list[Provider] = []
     for producer_name in coalesce_multi_single(arguments.producer_list, arguments.producer):

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -1,6 +1,9 @@
 import argparse
 import json
 import os
+import sys
+from argparse import Namespace
+from typing import List
 
 import shapely.geometry
 import shapely.ops
@@ -17,8 +20,7 @@ from scripts.stac.imagery.metadata_constants import DATA_CATEGORIES, HUMAN_READA
 from scripts.stac.imagery.provider import Provider, ProviderRole
 
 
-# pylint: disable=too-many-locals
-def main() -> None:
+def parse_args(args: List[str] | None) -> Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--uri", dest="uri", help="s3 path to items and collection.json write location", required=True)
     parser.add_argument("--collection-id", dest="collection_id", help="Collection ID", required=True)
@@ -85,8 +87,14 @@ def main() -> None:
         "--concurrency", dest="concurrency", help="The number of files to limit concurrent reads", required=True, type=int
     )
 
-    arguments = parser.parse_args()
+    return parser.parse_args(args)
+    
+
+# pylint: disable=too-many-locals
+def main(args: List[str] | None = None) -> None:
+    arguments = parse_args(args)
     uri = arguments.uri
+    print(arguments.start_date)
 
     providers: list[Provider] = []
     for producer_name in coalesce_multi_single(arguments.producer_list, arguments.producer):

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import os
-import sys
 from argparse import Namespace
 from typing import List
 
@@ -88,7 +87,7 @@ def parse_args(args: List[str] | None) -> Namespace:
     )
 
     return parser.parse_args(args)
-    
+
 
 # pylint: disable=too-many-locals
 def main(args: List[str] | None = None) -> None:

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -29,9 +29,32 @@ def test_should_create_collection_file() -> None:
     item.add_collection("abc")
     write("s3://stacfiles/item.json", dict_to_json_bytes(item.stac))
     # CLI arguments
-    args = ['--uri', 's3://stacfiles/', '--collection-id',  'abc', '--category', 'urban-aerial-photos', '--region', 'hawkes-bay', '--gsd', '1m', '--start-date', '2023-09-20', '--end-date', '2023-09-20', '--lifecycle', 'ongoing', '--producer', 'Placeholder', '--licensor', 'Placeholder', '--concurrency', '25']
+    args = [
+        "--uri",
+        "s3://stacfiles/",
+        "--collection-id",
+        "abc",
+        "--category",
+        "urban-aerial-photos",
+        "--region",
+        "hawkes-bay",
+        "--gsd",
+        "1m",
+        "--start-date",
+        "2023-09-20",
+        "--end-date",
+        "2023-09-20",
+        "--lifecycle",
+        "ongoing",
+        "--producer",
+        "Placeholder",
+        "--licensor",
+        "Placeholder",
+        "--concurrency",
+        "25",
+    ]
     # Call script's main function
     main(args)
     # Verify collection.json has been created
     resp = boto3_client.get_object(Bucket="stacfiles", Key="collection.json")
-    assert '"type": "Collection"' in resp["Body"].read().decode('utf-8')
+    assert '"type": "Collection"' in resp["Body"].read().decode("utf-8")

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -1,0 +1,37 @@
+from boto3 import client, resource
+from moto import mock_aws
+from moto.s3.responses import DEFAULT_REGION_NAME
+
+from scripts.collection_from_items import main
+from scripts.datetimes import utc_now
+from scripts.files.fs_s3 import write
+from scripts.json_codec import dict_to_json_bytes
+from scripts.stac.imagery.item import ImageryItem
+
+
+@mock_aws
+def test_should_create_collection_file() -> None:
+    # Mock AWS S3
+    s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
+    boto3_client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="stacfiles")
+    # Create mocked STAC Item
+    item = ImageryItem("123", "./scripts/tests/data/empty.tiff", utc_now)
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]],
+    }
+    bbox = (1799667.5, 5815977.0, 1800422.5, 5814986.0)
+    start_datetime = "2021-01-27T00:00:00Z"
+    end_datetime = "2021-01-27T00:00:00Z"
+    item.update_spatial(geometry, bbox)
+    item.update_datetime(start_datetime, end_datetime)
+    item.add_collection("abc")
+    write("s3://stacfiles/item.json", dict_to_json_bytes(item.stac))
+    # CLI arguments
+    args = ['--uri', 's3://stacfiles/', '--collection-id',  'abc', '--category', 'urban-aerial-photos', '--region', 'hawkes-bay', '--gsd', '1m', '--start-date', '2023-09-20', '--end-date', '2023-09-20', '--lifecycle', 'ongoing', '--producer', 'Placeholder', '--licensor', 'Placeholder', '--concurrency', '25']
+    # Call script's main function
+    main(args)
+    # Verify collection.json has been created
+    resp = boto3_client.get_object(Bucket="stacfiles", Key="collection.json")
+    assert '"type": "Collection"' in resp["Body"].read().decode('utf-8')


### PR DESCRIPTION
### Motivation

Having automatic tests for `collection_from_items.py` script.

### Modifications

- Refactor `collection_from_items.py` `main()` function so it can be easily called passing a list of arguments.
- Add a simple test that verifies the `collection.json` file is created on a usual use case.

### Verification

run `pytest`
