### PR TITLE
ci: publish container to gh on pr label container TDE-1252

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -5,10 +5,12 @@ on:
     branches: ["master"]
     types:
       - completed
+  pull_request:
+    types: labeled
 jobs:
   build-containers:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.label.name == 'container' }}
     permissions:
       id-token: write
       contents: read
@@ -41,7 +43,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
 
       - name: Login to GitHub Container Registry
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:')) || github.event.label.name == 'container'}}
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
@@ -68,8 +70,12 @@ jobs:
           result-encoding: string
           script: |
             const tags = [];
-            tags.push('ghcr.io/${{ github.repository }}:latest');
-            tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
+            if ('${{github.event.label.name}}' == 'container') {
+              tags.push('ghcr.io/${{ github.repository }}:pr-${{github.event.number}}');
+            } else{
+              tags.push('ghcr.io/${{ github.repository }}:latest');
+              tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}'); 
+            }
             if ("${{ steps.login-ecr.outputs.registry }}") {
             tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
             tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
@@ -81,7 +87,7 @@ jobs:
         with:
           context: .
           tags: ${{ steps.tags.outputs.result }}
-          push: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+          push: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:')) || github.event.label.name == 'container'}}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_HASH=${{ github.sha }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -72,7 +72,7 @@ jobs:
             const tags = [];
             if ('${{github.event.label.name}}' == 'container') {
               tags.push('ghcr.io/${{ github.repository }}:pr-${{github.event.number}}');
-            } else{
+            } else {
               tags.push('ghcr.io/${{ github.repository }}:latest');
               tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}'); 
             }


### PR DESCRIPTION
### Motivation

It is useful to be able to publish a container from a PR code base so we can test the container using external environment such as Kubernetes.

### Modifications

- GH Actions workflow `containers.yml` will run when a `container` label is added to a PR. The container will only be published on the GH package repository and be tagged `pr-[PR-NUMBER]`

### Verification

You can test it in this PR.
Also tested on a fork with the full process of merging the PR for non regression.
