### PR TITLE
feat: determine start and end datetimes when item include derived TDE-1258

### DIFF
--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -51,12 +51,11 @@ def create_item(
             derived_stac = json.loads(derived_item_content.decode("UTF-8"))
             start_date_list.append(derived_stac["properties"]["start_datetime"])
             end_date_list.append(derived_stac["properties"]["end_datetime"])
-
             item.add_link(
                 Link(path=derived, rel=Relation.DERIVED_FROM, media_type=StacMediaType.JSON, file_content=derived_item_content)
             )
-        start_datetime = min(start_date_list, key=lambda d: parse_rfc_3339_datetime(d))
-        end_datetime = max(end_date_list, key=lambda d: parse_rfc_3339_datetime(d))
+        start_datetime = min(start_date_list, key=parse_rfc_3339_datetime)
+        end_datetime = max(end_date_list, key=parse_rfc_3339_datetime)
 
     item.update_datetime(start_datetime, end_datetime)
     item.update_spatial(geometry, bbox)

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -1,6 +1,8 @@
+import json
+
 from linz_logger import get_log
 
-from scripts.datetimes import utc_now
+from scripts.datetimes import parse_rfc_3339_datetime, utc_now
 from scripts.files.files_helper import get_file_name_from_path
 from scripts.files.fs import read
 from scripts.files.geotiff import get_extents
@@ -40,15 +42,25 @@ def create_item(
     geometry, bbox = get_extents(gdalinfo_result)
 
     item = ImageryItem(id_, file, utc_now)
+
+    if derived_from is not None:
+        start_date_list = []
+        end_date_list = []
+        for derived in derived_from:
+            derived_item_content = read(derived)
+            derived_stac = json.loads(derived_item_content.decode("UTF-8"))
+            start_date_list.append(derived_stac["properties"]["start_datetime"])
+            end_date_list.append(derived_stac["properties"]["end_datetime"])
+
+            item.add_link(
+                Link(path=derived, rel=Relation.DERIVED_FROM, media_type=StacMediaType.JSON, file_content=derived_item_content)
+            )
+        start_datetime = min(start_date_list, key=lambda d: parse_rfc_3339_datetime(d))
+        end_datetime = max(end_date_list, key=lambda d: parse_rfc_3339_datetime(d))
+
     item.update_datetime(start_datetime, end_datetime)
     item.update_spatial(geometry, bbox)
     item.add_collection(collection_id)
-
-    if derived_from is not None:
-        for derived in derived_from:
-            item.add_link(
-                Link(path=derived, rel=Relation.DERIVED_FROM, media_type=StacMediaType.JSON, file_content=read(derived))
-            )
 
     get_log().info("ImageryItem created", path=file)
     return item

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -28,3 +28,35 @@ def test_create_item_with_derived_from(tmp_path: Path) -> None:
         "type": "application/json",
         "file:checksum": "12209c3d50f21fdd739de5c76b3c7ca60ee7f5cf69c2cf92b1d0136308cf63d9c5d5",
     } in item.stac["links"]
+
+
+def test_create_item_with_derived_from_datetimes(tmp_path: Path) -> None:
+    derived_from_path_a = tmp_path / "derived_from_item_a.json"
+    derived_from_path_b = tmp_path / "derived_from_item_b.json"
+    fake_item_a = {
+        "type": "Feature",
+        "id": "fake_item",
+        "properties": {"start_datetime": "2024-09-02T12:00:00Z", "end_datetime": "2024-09-02T12:00:00Z"},
+    }
+    fake_item_b = {
+        "type": "Feature",
+        "id": "fake_item",
+        "properties": {"start_datetime": "1998-02-12T11:00:00Z", "end_datetime": "1999-09-02T12:00:00Z"},
+    }
+    derived_from_path_a.write_text(json.dumps(fake_item_a))
+    derived_from_path_b.write_text(json.dumps(fake_item_b))
+    fake_gdal_info: GdalInfo = cast(
+        GdalInfo, {"wgs84Extent": {"type": "Polygon", "coordinates": [[[0, 1], [1, 1], [1, 0], [0, 0]]]}}
+    )
+
+    item = create_item(
+        "./scripts/tests/data/empty.tiff",
+        "2024-01-01",
+        "2024-01-02",
+        "abc123",
+        fake_gdal_info,
+        [derived_from_path_a.as_posix(), derived_from_path_b.as_posix()],
+    )
+
+    assert item.stac["properties"]["start_datetime"] == "1998-02-12T11:00:00Z"
+    assert item.stac["properties"]["end_datetime"] == "2024-09-02T12:00:00Z"

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import cast
 
@@ -7,7 +8,12 @@ from scripts.stac.imagery.create_stac import create_item
 
 def test_create_item_with_derived_from(tmp_path: Path) -> None:
     derived_from_path = tmp_path / "derived_from_item.json"
-    derived_from_path.write_text('{"type": "Feature", "id": "fake_item"}')
+    fake_item = {
+        "type": "Feature",
+        "id": "fake_item",
+        "properties": {"start_datetime": "2024-09-02T12:00:00Z", "end_datetime": "2024-09-02T12:00:00Z"},
+    }
+    derived_from_path.write_text(json.dumps(fake_item))
     fake_gdal_info: GdalInfo = cast(
         GdalInfo, {"wgs84Extent": {"type": "Polygon", "coordinates": [[[0, 1], [1, 1], [1, 0], [0, 0]]]}}
     )
@@ -20,5 +26,5 @@ def test_create_item_with_derived_from(tmp_path: Path) -> None:
         "href": derived_from_path.as_posix(),
         "rel": "derived_from",
         "type": "application/json",
-        "file:checksum": "12208010297a79dc2605d99cde3d1ca63f72647637529ef6eb3d57eef1c951dcf939",
+        "file:checksum": "12209c3d50f21fdd739de5c76b3c7ca60ee7f5cf69c2cf92b1d0136308cf63d9c5d5",
     } in item.stac["links"]


### PR DESCRIPTION
### Motivation

When a STAC Item is derived from other STAC Items, its `properties.start_datetime` and `properties.end_datetime` should be determined from the derived  items.

### Modifications

- list all the `start_datetime` and `end_datetime` of derived Items to determine the new Item start and end datetime.

### Verification

tests
