### PR TITLE
feat: add capture dates asset link to collection TDE-1256

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -89,6 +89,13 @@ def parse_args(args: List[str] | None) -> Namespace:
     parser.add_argument(
         "--concurrency", dest="concurrency", help="The number of files to limit concurrent reads", required=True, type=int
     )
+    parser.add_argument(
+        "--capture-dates",
+        dest="capture_dates",
+        action="store_true",
+        help="Add a capture-dates.geojson.gz file to the collection assets",
+        required=False,
+    )
 
     return parser.parse_args(args)
 
@@ -186,6 +193,9 @@ def main(args: List[str] | None = None) -> None:
         item_match_count=item_match_count,
         duration=time_in_ms() - start_time,
     )
+
+    if arguments.capture_dates:
+        collection.add_capture_dates(uri)
 
     destination = os.path.join(uri, "collection.json")
     collection.write_to(destination)

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -134,6 +134,9 @@ def main(args: List[str] | None = None) -> None:
         msg = f"uri is not a s3 path: {uri}"
         raise argparse.ArgumentTypeError(msg)
 
+    if arguments.capture_dates:
+        collection.add_capture_dates(uri)
+
     s3_client = client("s3")
 
     collection_id = collection.stac["id"]
@@ -193,9 +196,6 @@ def main(args: List[str] | None = None) -> None:
         item_match_count=item_match_count,
         duration=time_in_ms() - start_time,
     )
-
-    if arguments.capture_dates:
-        collection.add_capture_dates(uri)
 
     destination = os.path.join(uri, "collection.json")
     collection.write_to(destination)

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -32,7 +32,7 @@ from scripts.stac.util.media_type import StacMediaType
 from scripts.stac.util.stac_extensions import StacExtensions
 
 CAPTURE_AREA_FILE_NAME = "capture-area.geojson"
-CAPTURE_DATES_FILE_NAME = "capture-dates.geojson.gz"
+CAPTURE_DATES_FILE_NAME = "capture-dates.geojson"
 
 
 class ImageryCollection:
@@ -132,11 +132,11 @@ class ImageryCollection:
             self.stac["stac_extensions"].append(StacExtensions.file.value)
 
     def add_capture_dates(self, source_directory: str) -> None:
-        """Add the gzipped capture dates metadata file for the National 1m DEM dataset.
-        The `href` or path of capture-dates.geojson.gz is always set as the relative `./capture-dates.geojson.gz`
+        """Add the capture dates metadata file for the National 1m DEM dataset.
+        The `href` or path of capture-dates.geojson.gz is always set as the relative `./capture-dates.geojson`
 
         Args:
-            source_directory: the location of the capture-dates.geojson.gz file to be linked
+            source_directory: the location of the capture-dates.geojson file to be linked
         """
 
         capture_dates_content = read(os.path.join(source_directory, CAPTURE_DATES_FILE_NAME))
@@ -144,7 +144,7 @@ class ImageryCollection:
         capture_dates = {
             "href": f"./{CAPTURE_DATES_FILE_NAME}",
             "title": "Capture dates",
-            "type": "application/gzip",
+            "type": ContentType.GEOJSON,
             "roles": ["metadata"],
             "file:checksum": file_checksum,
             "file:size": len(capture_dates_content),

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -8,7 +8,7 @@ from shapely.geometry.base import BaseGeometry
 
 from scripts.datetimes import format_rfc_3339_datetime_string, parse_rfc_3339_datetime
 from scripts.files.files_helper import ContentType
-from scripts.files.fs import write
+from scripts.files.fs import read, write
 from scripts.json_codec import dict_to_json_bytes
 from scripts.stac.imagery.capture_area import generate_capture_area, gsd_to_float
 from scripts.stac.imagery.metadata_constants import (
@@ -32,6 +32,7 @@ from scripts.stac.util.media_type import StacMediaType
 from scripts.stac.util.stac_extensions import StacExtensions
 
 CAPTURE_AREA_FILE_NAME = "capture-area.geojson"
+CAPTURE_DATES_FILE_NAME = "capture-dates.geojson.gz"
 
 
 class ImageryCollection:
@@ -129,6 +130,19 @@ class ImageryCollection:
 
         if StacExtensions.file.value not in self.stac["stac_extensions"]:
             self.stac["stac_extensions"].append(StacExtensions.file.value)
+
+    def add_capture_dates(self, source_directory: str) -> None:
+        capture_dates_content = read(os.path.join(source_directory, CAPTURE_DATES_FILE_NAME))
+        file_checksum = checksum.multihash_as_hex(capture_dates_content)
+        capture_dates = {
+            "href": f"./{CAPTURE_DATES_FILE_NAME}",
+            "title": "Capture dates",
+            "type": "application/gzip",
+            "roles": ["metadata"],
+            "file:checksum": file_checksum,
+            "file:size": len(capture_dates_content),
+        }
+        self.stac.setdefault("assets", {})["capture_dates"] = capture_dates
 
     def add_item(self, item: dict[Any, Any]) -> None:
         """Add an `Item` to the `links` of the `Collection`.

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -132,6 +132,13 @@ class ImageryCollection:
             self.stac["stac_extensions"].append(StacExtensions.file.value)
 
     def add_capture_dates(self, source_directory: str) -> None:
+        """Add the gzipped capture dates metadata file for the National 1m DEM dataset.
+        The `href` or path of capture-dates.geojson.gz is always set as the relative `./capture-dates.geojson.gz`
+
+        Args:
+            source_directory: the location of the capture-dates.geojson.gz file to be linked
+        """
+
         capture_dates_content = read(os.path.join(source_directory, CAPTURE_DATES_FILE_NAME))
         file_checksum = checksum.multihash_as_hex(capture_dates_content)
         capture_dates = {

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -133,7 +133,7 @@ class ImageryCollection:
 
     def add_capture_dates(self, source_directory: str) -> None:
         """Add the capture dates metadata file for the National 1m DEM dataset.
-        The `href` or path of capture-dates.geojson.gz is always set as the relative `./capture-dates.geojson`
+        The `href` or path of capture-dates.geojson is always set as the relative `./capture-dates.geojson`
 
         Args:
             source_directory: the location of the capture-dates.geojson file to be linked

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -14,6 +14,7 @@ from moto.s3.responses import DEFAULT_REGION_NAME
 from pytest_subtests import SubTests
 
 from scripts.datetimes import format_rfc_3339_datetime_string
+from scripts.files.files_helper import ContentType
 from scripts.files.fs import read
 from scripts.files.fs_s3 import write
 from scripts.stac.imagery.collection import ImageryCollection
@@ -342,12 +343,12 @@ def test_capture_dates_added(metadata: CollectionMetadata) -> None:
     collection = ImageryCollection(metadata, any_epoch_datetime)
     s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="flat")
-    write("s3://flat/capture-dates.geojson.gz", b"")
+    write("s3://flat/capture-dates.geojson", b"")
     collection.add_capture_dates("s3://flat")
     assert collection.stac["assets"]["capture_dates"] == {
-        "href": "./capture-dates.geojson.gz",
+        "href": "./capture-dates.geojson",
         "title": "Capture dates",
-        "type": "application/gzip",
+        "type": ContentType.GEOJSON,
         "roles": ["metadata"],
         "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         "file:size": 0,

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -8,10 +8,14 @@ from tempfile import mkdtemp
 
 import pytest
 import shapely.geometry
+from boto3 import resource
+from moto import mock_aws
+from moto.s3.responses import DEFAULT_REGION_NAME
 from pytest_subtests import SubTests
 
 from scripts.datetimes import format_rfc_3339_datetime_string
 from scripts.files.fs import read
+from scripts.files.fs_s3 import write
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
@@ -331,3 +335,20 @@ def test_event_name_is_present(metadata: CollectionMetadata) -> None:
 def test_geographic_description_is_present(metadata: CollectionMetadata) -> None:
     collection = ImageryCollection(metadata, any_epoch_datetime)
     assert "Auckland North Forest Assessment" == collection.stac["linz:geographic_description"]
+
+
+@mock_aws
+def test_capture_dates_added(metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="flat")
+    write("s3://flat/capture-dates.geojson.gz", b"")
+    collection.add_capture_dates("s3://flat")
+    assert collection.stac["assets"]["capture_dates"] == {
+        "href": "./capture-dates.geojson.gz",
+        "title": "Capture dates",
+        "type": "application/gzip",
+        "roles": ["metadata"],
+        "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "file:size": 0,
+    }


### PR DESCRIPTION
### Motivation

The [National 1m DEM dataset](https://toitutewhenua.atlassian.net/browse/TDE-1130) STAC collection will have an additional `capture-dates.geojson` asset that contains provenance information for the dataset.

### Modifications

Added an additional command line argument flag to `collection_from_items`: if `--capture-dates` is specified a `capture-dates.geojson` asset link (with checksum and file size) will be added to the STAC collection.

Example:
```    "assets": {
        "capture_area": {
            "href": "./capture-area.geojson",
            "title": "Capture area",
            "type": "application/geo+json",
            "roles": [
                "metadata"
            ],
            "file:checksum": "1220e7357b15342abf53764861d20bbc7eed8a58bb662836bde9069dc8c68d247812",
            "file:size": 576615
        },
        "capture_dates": {
            "href": "./capture-dates.geojson.gz",
            "title": "Capture dates",
            "type": "application/gzip",
            "roles": [
                "metadata"
            ],
            "file:checksum": "12202c1fd185849103232cb8c602997f657abc51506e6074b2cf0d524ffd093336f6",
            "file:size": 147770
        }
    },
```

### Verification

Unit test created.

Command run locally:
`python /app/scripts/collection_from_items.py --uri s3://linz-workflows-scratch/afage/05-test-national-dem-restricted-lvhht/flat --collection-id 01J724PHHG3Q769YCRA6X1YHM1 --category dem --region new-zealand --gsd 1m --geographic-description foo --start-date 2023-02-18 --end-date 2023-08-15 --lifecycle completed --producer unknown --licensor unknown --concurrency 25 --capture-dates`
