### PR TITLE
fix: Don't attempt to install project inside virtualenv

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install
         run: |
           pip install poetry
-          poetry install
+          poetry install --no-root
       - name: Format
         run: |
           poetry run pre-commit run --all-files


### PR DESCRIPTION
### Motivation

Avoids the following:

```
Installing the current project: […]
Warning: The current project could not be installed: No file/folder found for package […]
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!
```

### Verification

N/A
