### PR TITLE
fix: Use GeoJSON media type for item links TDE-1254

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -163,7 +163,7 @@ class ImageryCollection:
                 Link(
                     path=item_self_link["href"],
                     rel=Relation.ITEM,
-                    media_type=StacMediaType.JSON,
+                    media_type=StacMediaType.GEOJSON,
                     file_content=dict_to_json_bytes(item),
                 ).stac
             )

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -54,7 +54,12 @@ def create_item(
                 start_datetime = min(start_datetime, derived_stac["properties"]["start_datetime"])
                 end_datetime = max(end_datetime, derived_stac["properties"]["end_datetime"])
             item.add_link(
-                Link(path=derived, rel=Relation.DERIVED_FROM, media_type=StacMediaType.JSON, file_content=derived_item_content)
+                Link(
+                    path=derived,
+                    rel=Relation.DERIVED_FROM,
+                    media_type=StacMediaType.GEOJSON,
+                    file_content=derived_item_content,
+                )
             )
 
     item.update_datetime(start_datetime, end_datetime)

--- a/scripts/stac/imagery/item.py
+++ b/scripts/stac/imagery/item.py
@@ -24,7 +24,7 @@ class ImageryItem:
             "type": "Feature",
             "stac_version": STAC_VERSION,
             "id": id_,
-            "links": [Link(path=f"./{id_}.json", rel=Relation.SELF, media_type=StacMediaType.JSON).stac],
+            "links": [Link(path=f"./{id_}.json", rel=Relation.SELF, media_type=StacMediaType.GEOJSON).stac],
             "assets": {
                 "visual": {
                     "href": os.path.join(".", os.path.basename(file)),

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -155,7 +155,7 @@ def test_add_item(metadata: CollectionMetadata, subtests: SubTests) -> None:
     with subtests.test(msg="Main links content"):
         assert [
             {"href": "./collection.json", "rel": "self", "type": "application/json"},
-            {"rel": "item", "href": "./BR34_5000_0304.json", "type": "application/json"},
+            {"rel": "item", "href": "./BR34_5000_0304.json", "type": "application/geo+json"},
         ] == links
 
     with subtests.test():

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -23,7 +23,7 @@ def test_create_item_with_derived_from(tmp_path: Path) -> None:
     assert {
         "href": derived_from_path.as_posix(),
         "rel": "derived_from",
-        "type": "application/json",
+        "type": "application/geo+json",
         "file:checksum": "12209c3d50f21fdd739de5c76b3c7ca60ee7f5cf69c2cf92b1d0136308cf63d9c5d5",
     } in item.stac["links"]
 

--- a/scripts/stac/imagery/tests/item_test.py
+++ b/scripts/stac/imagery/tests/item_test.py
@@ -56,7 +56,7 @@ def test_imagery_stac_item(mocker: MockerFixture, subtests: SubTests) -> None:
         )
 
     with subtests.test():
-        assert {"rel": "self", "href": f"./{id_}.json", "type": "application/json"} in item.stac["links"]
+        assert {"rel": "self", "href": f"./{id_}.json", "type": "application/geo+json"} in item.stac["links"]
 
 
 # pylint: disable=duplicate-code


### PR DESCRIPTION
### Motivation

https://github.com/radiantearth/stac-spec/blob/master/commons/links.md#stac-media-types

### Modifications

Change item links from media type `application/json` to `application/geo+json`.

### Verification

`pytest`
