### PR TITLE
test: refactor fake collection metadata

### DIFF
--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -1,12 +1,11 @@
 import json
 import os
 import tempfile
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from datetime import datetime, timezone
 from shutil import rmtree
 from tempfile import mkdtemp
 
-import pytest
 import shapely.geometry
 from boto3 import resource
 from moto import mock_aws
@@ -25,42 +24,27 @@ from scripts.stac.util.stac_extensions import StacExtensions
 from scripts.tests.datetimes_test import any_epoch_datetime
 
 
-# pylint: disable=duplicate-code
-@pytest.fixture(name="metadata", autouse=True)
-def setup() -> Generator[CollectionMetadata, None, None]:
-    metadata: CollectionMetadata = {
-        "category": "urban-aerial-photos",
-        "region": "auckland",
-        "gsd": "0.3m",
-        "start_datetime": datetime(2022, 2, 2),
-        "end_datetime": datetime(2022, 2, 2),
-        "lifecycle": "completed",
-        "event_name": "Forest Assessment",
-        "historic_survey_number": None,
-        "geographic_description": "Auckland North Forest Assessment",
-    }
-    yield metadata
-
-
-def test_title_description_id_created_on_init(metadata: CollectionMetadata, subtests: SubTests) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_title_description_id_created_on_init(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
+    fake_collection_metadata["event_name"] = "Forest Assessment"
+    fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     with subtests.test():
-        assert collection.stac["title"] == "Auckland North Forest Assessment 0.3m Urban Aerial Photos (2022)"
+        assert collection.stac["title"] == "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
 
     with subtests.test():
         assert (
             collection.stac["description"]
-            == "Orthophotography within the Auckland region captured in the 2022 flying season, published as a record of the Forest Assessment event."  # pylint: disable=line-too-long
+            == "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, published as a record of the Forest Assessment event."  # pylint: disable=line-too-long
         )
 
     with subtests.test():
         assert collection.stac["id"]
 
     with subtests.test():
-        assert collection.stac["linz:region"] == "auckland"
+        assert collection.stac["linz:region"] == "hawkes-bay"
 
     with subtests.test():
-        assert collection.stac["linz:geographic_description"] == "Auckland North Forest Assessment"
+        assert collection.stac["linz:geographic_description"] == "Hawke's Bay Forest Assessment"
 
     with subtests.test():
         assert collection.stac["linz:event_name"] == "Forest Assessment"
@@ -69,24 +53,24 @@ def test_title_description_id_created_on_init(metadata: CollectionMetadata, subt
         assert collection.stac["linz:lifecycle"] == "completed"
 
     with subtests.test():
-        assert collection.stac["linz:geospatial_category"] == "urban-aerial-photos"
+        assert collection.stac["linz:geospatial_category"] == "rural-aerial-photos"
 
 
-def test_id_parsed_on_init(metadata: CollectionMetadata) -> None:
+def test_id_parsed_on_init(fake_collection_metadata: CollectionMetadata) -> None:
     id_ = "Parsed-Ulid"
-    collection = ImageryCollection(metadata, any_epoch_datetime, id_)
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, id_)
     assert collection.stac["id"] == "Parsed-Ulid"
 
 
-def test_bbox_updated_from_none(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_bbox_updated_from_none(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     bbox = [1799667.5, 5815977.0, 1800422.5, 5814986.0]
     collection.update_spatial_extent(bbox)
     assert collection.stac["extent"]["spatial"]["bbox"] == [bbox]
 
 
-def test_bbox_updated_from_existing(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_bbox_updated_from_existing(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     # init bbox
     bbox = [174.889641, -41.217532, 174.902344, -41.203521]
     collection.update_spatial_extent(bbox)
@@ -97,16 +81,16 @@ def test_bbox_updated_from_existing(metadata: CollectionMetadata) -> None:
     assert collection.stac["extent"]["spatial"]["bbox"] == [[174.889641, -41.217532, 174.922965, -41.203521]]
 
 
-def test_interval_updated_from_none(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_interval_updated_from_none(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     start_datetime = "2021-01-27T00:00:00Z"
     end_datetime = "2021-01-27T00:00:00Z"
     collection.update_temporal_extent(start_datetime, end_datetime)
     assert collection.stac["extent"]["temporal"]["interval"] == [[start_datetime, end_datetime]]
 
 
-def test_interval_updated_from_existing(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_interval_updated_from_existing(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     # init interval
     start_datetime = "2021-01-27T00:00:00Z"
     end_datetime = "2021-01-27T00:00:00Z"
@@ -126,10 +110,10 @@ def fixed_now_function(now: datetime) -> Callable[[], datetime]:
     return func
 
 
-def test_add_item(metadata: CollectionMetadata, subtests: SubTests) -> None:
+def test_add_item(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     now = any_epoch_datetime()
     now_function = fixed_now_function(now)
-    collection = ImageryCollection(metadata, now_function)
+    collection = ImageryCollection(fake_collection_metadata, now_function)
     item_file_path = "./scripts/tests/data/empty.tiff"
     modified_datetime = datetime(2001, 2, 3, hour=4, minute=5, second=6, tzinfo=timezone.utc)
     os.utime(item_file_path, times=(any_epoch_datetime().timestamp(), modified_datetime.timestamp()))
@@ -175,9 +159,9 @@ def test_add_item(metadata: CollectionMetadata, subtests: SubTests) -> None:
             assert item.stac["assets"]["visual"][property_name] == "2001-02-03T04:05:06Z"
 
 
-def test_write_collection(metadata: CollectionMetadata) -> None:
+def test_write_collection(fake_collection_metadata: CollectionMetadata) -> None:
     target = mkdtemp()
-    collectionObj = ImageryCollection(metadata, any_epoch_datetime)
+    collectionObj = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     collection_target = os.path.join(target, "collection.json")
     collectionObj.write_to(collection_target)
     collection = json.loads(read(collection_target))
@@ -186,10 +170,10 @@ def test_write_collection(metadata: CollectionMetadata) -> None:
     assert collection["title"] == collectionObj.stac["title"]
 
 
-def test_write_collection_special_chars(metadata: CollectionMetadata) -> None:
+def test_write_collection_special_chars(fake_collection_metadata: CollectionMetadata) -> None:
     target = mkdtemp()
     title = "Manawatū-Whanganui"
-    collectionObj = ImageryCollection(metadata, any_epoch_datetime)
+    collectionObj = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     collectionObj.stac["title"] = title
     collection_target = os.path.join(target, "collection.json")
     collectionObj.write_to(collection_target)
@@ -199,19 +183,19 @@ def test_write_collection_special_chars(metadata: CollectionMetadata) -> None:
     assert collection["title"] == title
 
 
-def test_add_providers(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_add_providers(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
     collection.add_providers([producer])
 
     assert {"name": "Maxar", "roles": ["producer"]} in collection.stac["providers"]
 
 
-def test_default_provider_roles_are_kept(metadata: CollectionMetadata, subtests: SubTests) -> None:
+def test_default_provider_roles_are_kept(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     # given we are adding a non default role to the default provider
     licensor: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.LICENSOR]}
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
-    collection = ImageryCollection(metadata, any_epoch_datetime, providers=[producer, licensor])
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, providers=[producer, licensor])
 
     with subtests.test(msg="it adds the non default role to the existing default role list"):
         assert {
@@ -225,10 +209,10 @@ def test_default_provider_roles_are_kept(metadata: CollectionMetadata, subtests:
         ]
 
 
-def test_default_provider_is_present(metadata: CollectionMetadata, subtests: SubTests) -> None:
+def test_default_provider_is_present(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     # given adding a provider
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
-    collection = ImageryCollection(metadata, any_epoch_datetime, providers=[producer])
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, providers=[producer])
 
     with subtests.test(msg="the default provider is still present"):
         assert {"name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"]} in collection.stac[
@@ -238,13 +222,13 @@ def test_default_provider_is_present(metadata: CollectionMetadata, subtests: Sub
         assert {"name": "Maxar", "roles": ["producer"]} in collection.stac["providers"]
 
 
-def test_capture_area_added(metadata: CollectionMetadata, subtests: SubTests) -> None:
+def test_capture_area_added(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     """
     TODO: geos 3.12 changes the topology-preserving simplifier to produce stable results; see
     <https://github.com/libgeos/geos/pull/718>. Once we start using geos 3.12 in CI we can delete the values for 3.11
     below.
     """
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     file_name = "capture-area.geojson"
 
     polygons = []
@@ -328,19 +312,21 @@ def test_capture_area_added(metadata: CollectionMetadata, subtests: SubTests) ->
         )
 
 
-def test_event_name_is_present(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_event_name_is_present(fake_collection_metadata: CollectionMetadata) -> None:
+    fake_collection_metadata["event_name"] = "Forest Assessment"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     assert "Forest Assessment" == collection.stac["linz:event_name"]
 
 
-def test_geographic_description_is_present(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
-    assert "Auckland North Forest Assessment" == collection.stac["linz:geographic_description"]
+def test_geographic_description_is_present(fake_collection_metadata: CollectionMetadata) -> None:
+    fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
+    assert "Hawke's Bay Forest Assessment" == collection.stac["linz:geographic_description"]
 
 
 @mock_aws
-def test_capture_dates_added(metadata: CollectionMetadata) -> None:
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+def test_capture_dates_added(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="flat")
     write("s3://flat/capture-dates.geojson", b"")

--- a/scripts/stac/imagery/tests/conftest.py
+++ b/scripts/stac/imagery/tests/conftest.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Generator
+
+import pytest
+
+from scripts.stac.imagery.metadata_constants import CollectionMetadata
+
+
+@pytest.fixture(autouse=True)
+def fake_collection_metadata() -> Generator[CollectionMetadata, None, None]:
+    collection_metadata: CollectionMetadata = {
+        "category": "rural-aerial-photos",
+        "region": "hawkes-bay",
+        "gsd": "0.3m",
+        "start_datetime": datetime(2023, 1, 1),
+        "end_datetime": datetime(2023, 2, 2),
+        "lifecycle": "completed",
+        "event_name": None,
+        "historic_survey_number": None,
+        "geographic_description": None,
+    }
+    yield collection_metadata

--- a/scripts/stac/imagery/tests/conftest.py
+++ b/scripts/stac/imagery/tests/conftest.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 from typing import Generator
 
 import pytest
@@ -11,7 +12,7 @@ def fake_collection_metadata() -> Generator[CollectionMetadata, None, None]:
     collection_metadata: CollectionMetadata = {
         "category": "rural-aerial-photos",
         "region": "hawkes-bay",
-        "gsd": "0.3m",
+        "gsd": Decimal("0.3"),
         "start_datetime": datetime(2023, 1, 1),
         "end_datetime": datetime(2023, 2, 2),
         "lifecycle": "completed",

--- a/scripts/stac/imagery/tests/conftest.py
+++ b/scripts/stac/imagery/tests/conftest.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
-from typing import Generator
+from typing import Iterator
 
 import pytest
 
@@ -8,7 +8,7 @@ from scripts.stac.imagery.metadata_constants import CollectionMetadata
 
 
 @pytest.fixture(autouse=True)
-def fake_collection_metadata() -> Generator[CollectionMetadata, None, None]:
+def fake_collection_metadata() -> Iterator[CollectionMetadata]:
     collection_metadata: CollectionMetadata = {
         "category": "rural-aerial-photos",
         "region": "hawkes-bay",

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -1,88 +1,48 @@
-from collections.abc import Generator
-from datetime import datetime
-
-import pytest
-
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.tests.datetimes_test import any_epoch_datetime
 
 
-# pylint: disable=duplicate-code
-@pytest.fixture(name="metadata", autouse=True)
-def setup() -> Generator[tuple[CollectionMetadata, CollectionMetadata], None, None]:
-    metadata_auck: CollectionMetadata = {
-        "category": "rural-aerial-photos",
-        "region": "auckland",
-        "gsd": "0.3m",
-        "start_datetime": datetime(2023, 1, 1),
-        "end_datetime": datetime(2023, 2, 2),
-        "lifecycle": "completed",
-        "geographic_description": None,
-        "event_name": None,
-        "historic_survey_number": None,
-    }
-    metadata_hb: CollectionMetadata = {
-        "category": "rural-aerial-photos",
-        "region": "hawkes-bay",
-        "gsd": "0.3m",
-        "start_datetime": datetime(2023, 1, 1),
-        "end_datetime": datetime(2023, 2, 2),
-        "lifecycle": "completed",
-        "geographic_description": None,
-        "event_name": None,
-        "historic_survey_number": None,
-    }
-    yield (metadata_auck, metadata_hb)
-
-
-def test_generate_description_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    description = "Orthophotography within the Auckland region captured in the 2023 flying season."
+def test_generate_description_imagery(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
+    description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_elevation(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "dem"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    description = "Digital Elevation Model within the Auckland region captured in 2023."
+def test_generate_description_elevation(fake_collection_metadata: CollectionMetadata) -> None:
+    fake_collection_metadata["category"] = "dem"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
+    description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_elevation_geographic_description_input(
-    metadata: tuple[CollectionMetadata, CollectionMetadata]
-) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "dem"
-    metadata_auck["geographic_description"] = "Central"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    description = "Digital Elevation Model within the Auckland region captured in 2023."
+def test_generate_description_elevation_geographic_description_input(fake_collection_metadata: CollectionMetadata) -> None:
+    fake_collection_metadata["category"] = "dem"
+    fake_collection_metadata["category"] = "dem"
+    fake_collection_metadata["geographic_description"] = "Central"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
+    description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_satellite_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "satellite-imagery"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    description = "Satellite imagery within the Auckland region captured in 2023."
+def test_generate_description_satellite_imagery(fake_collection_metadata: CollectionMetadata) -> None:
+    fake_collection_metadata["category"] = "satellite-imagery"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
+    description = "Satellite imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_historic_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "scanned-aerial-photos"
-    metadata_auck["historic_survey_number"] = "SNC8844"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    description = "Scanned aerial imagery within the Auckland region captured in 2023."
+def test_generate_description_historic_imagery(fake_collection_metadata: CollectionMetadata) -> None:
+    fake_collection_metadata["category"] = "scanned-aerial-photos"
+    fake_collection_metadata["historic_survey_number"] = "SNC8844"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
+    description = "Scanned aerial imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_event(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    _, metadata_hb = metadata
-    metadata_hb["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(metadata_hb, any_epoch_datetime)
+def test_generate_description_event(fake_collection_metadata: CollectionMetadata) -> None:
+    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, \
 published as a record of the Cyclone Gabrielle event."
     assert collection.stac["description"] == description

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -18,7 +18,6 @@ def test_generate_description_elevation(fake_collection_metadata: CollectionMeta
 
 def test_generate_description_elevation_geographic_description_input(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata["category"] = "dem"
-    fake_collection_metadata["category"] = "dem"
     fake_collection_metadata["geographic_description"] = "Central"
     collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -1,4 +1,3 @@
-from collections.abc import Generator
 from datetime import datetime
 
 import pytest
@@ -8,159 +7,131 @@ from scripts.stac.imagery.metadata_constants import CollectionMetadata, MissingM
 from scripts.tests.datetimes_test import any_epoch_datetime
 
 
-# pylint: disable=duplicate-code
-@pytest.fixture(name="metadata", autouse=True)
-def setup() -> Generator[tuple[CollectionMetadata, CollectionMetadata], None, None]:
-    metadata_auck: CollectionMetadata = {
-        "category": "rural-aerial-photos",
-        "region": "auckland",
-        "gsd": "0.3m",
-        "start_datetime": datetime(2023, 1, 1),
-        "end_datetime": datetime(2023, 2, 2),
-        "lifecycle": "completed",
-        "event_name": None,
-        "historic_survey_number": None,
-        "geographic_description": None,
-    }
-    metadata_hb: CollectionMetadata = {
-        "category": "rural-aerial-photos",
-        "region": "hawkes-bay",
-        "gsd": "0.3m",
-        "start_datetime": datetime(2023, 1, 1),
-        "end_datetime": datetime(2023, 2, 2),
-        "lifecycle": "completed",
-        "event_name": None,
-        "historic_survey_number": None,
-        "geographic_description": None,
-    }
-    yield (metadata_auck, metadata_hb)
-
-
-def test_generate_imagery_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    title = "Auckland 0.3m Rural Aerial Photos (2023)"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
+def test_generate_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
     assert collection.stac["title"] == title
 
 
-def test_generate_dem_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "dem"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    title = "Auckland LiDAR 0.3m DEM (2023)"
+def test_generate_dem_title(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["category"] = "dem"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    title = "Hawke's Bay LiDAR 0.3m DEM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_dsm_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "dsm"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    title = "Auckland LiDAR 0.3m DSM (2023)"
+def test_generate_dsm_title(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["category"] = "dsm"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    title = "Hawke's Bay LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_satellite_imagery_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "satellite-imagery"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    title = "Auckland 0.3m Satellite Imagery (2023)"
+def test_generate_satellite_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["category"] = "satellite-imagery"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    title = "Hawke's Bay 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_historic_imagery_title(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    title = "Auckland 0.3m SNC8844 (2023)"
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "scanned-aerial-photos"
-    metadata_auck["historic_survey_number"] = "SNC8844"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
+def test_generate_historic_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
+    title = "Hawke's Bay 0.3m SNC8844 (2023)"
+    metadata = fake_collection_metadata
+    metadata["category"] = "scanned-aerial-photos"
+    metadata["historic_survey_number"] = "SNC8844"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
     assert collection.stac["title"] == title
 
 
-def test_generate_historic_imagery_title_missing_number(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "scanned-aerial-photos"
-    metadata_auck["historic_survey_number"] = None
+def test_generate_historic_imagery_title_missing_number(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["category"] = "scanned-aerial-photos"
+    metadata["historic_survey_number"] = None
     with pytest.raises(MissingMetadataError) as excinfo:
-        ImageryCollection(metadata_auck, any_epoch_datetime)
+        ImageryCollection(metadata, any_epoch_datetime)
 
     assert "historic_survey_number" in str(excinfo.value)
 
 
-def test_generate_title_long_date(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["end_datetime"] = datetime(2024, 1, 1)
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    title = "Auckland 0.3m Rural Aerial Photos (2023-2024)"
+def test_generate_title_long_date(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["end_datetime"] = datetime(2024, 1, 1)
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    title = "Hawke's Bay 0.3m Rural Aerial Photos (2023-2024)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_geographic_description(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["geographic_description"] = "Ponsonby"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
+def test_generate_title_geographic_description(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["geographic_description"] = "Ponsonby"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
     title = "Ponsonby 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    _, metadata_hb = metadata
-    metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    metadata_hb["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(metadata_hb, any_epoch_datetime)
+def test_generate_title_event_imagery(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
+    metadata["event_name"] = "Cyclone Gabrielle"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_elevation(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    _, metadata_hb = metadata
-    metadata_hb["category"] = "dsm"
-    metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    metadata_hb["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(metadata_hb, any_epoch_datetime)
+def test_generate_title_event_elevation(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["category"] = "dsm"
+    metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
+    metadata["event_name"] = "Cyclone Gabrielle"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
     title = "Hawke's Bay - Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_satellite_imagery(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    _, metadata_hb = metadata
-    metadata_hb["category"] = "satellite-imagery"
-    metadata_hb["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    metadata_hb["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(metadata_hb, any_epoch_datetime)
+def test_generate_title_event_satellite_imagery(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["category"] = "satellite-imagery"
+    metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
+    metadata["event_name"] = "Cyclone Gabrielle"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_dsm_title_preview(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["category"] = "dsm"
-    metadata_auck["lifecycle"] = "preview"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    title = "Auckland LiDAR 0.3m DSM (2023) - Preview"
+def test_generate_dsm_title_preview(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["category"] = "dsm"
+    metadata["lifecycle"] = "preview"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    title = "Hawke's Bay LiDAR 0.3m DSM (2023) - Preview"
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_draft(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    _, metadata_hb = metadata
-    metadata_hb["lifecycle"] = "ongoing"
-    collection = ImageryCollection(metadata_hb, any_epoch_datetime)
+def test_generate_imagery_title_draft(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["lifecycle"] = "ongoing"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023) - Draft"
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_empty_optional_str(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["geographic_description"] = ""
-    metadata_auck["event_name"] = ""
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    title = "Auckland 0.3m Rural Aerial Photos (2023)"
+def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["geographic_description"] = ""
+    metadata["event_name"] = ""
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_with_event(metadata: tuple[CollectionMetadata, CollectionMetadata]) -> None:
-    metadata_auck, _ = metadata
-    metadata_auck["geographic_description"] = "Auckland Forest Assessment"
-    metadata_auck["event_name"] = "Forest Assessment"
-    collection = ImageryCollection(metadata_auck, any_epoch_datetime)
-    title = "Auckland Forest Assessment 0.3m Rural Aerial Photos (2023)"
+def test_generate_imagery_title_with_event(fake_collection_metadata: CollectionMetadata) -> None:
+    metadata = fake_collection_metadata
+    metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
+    metadata["event_name"] = "Forest Assessment"
+    collection = ImageryCollection(metadata, any_epoch_datetime)
+    title = "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -8,130 +8,115 @@ from scripts.tests.datetimes_test import any_epoch_datetime
 
 
 def test_generate_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     assert collection.stac["title"] == title
 
 
 def test_generate_dem_title(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["category"] = "dem"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["category"] = "dem"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay LiDAR 0.3m DEM (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_dsm_title(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["category"] = "dsm"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["category"] = "dsm"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_satellite_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["category"] = "satellite-imagery"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["category"] = "satellite-imagery"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_historic_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
     title = "Hawke's Bay 0.3m SNC8844 (2023)"
-    metadata = fake_collection_metadata
-    metadata["category"] = "scanned-aerial-photos"
-    metadata["historic_survey_number"] = "SNC8844"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["category"] = "scanned-aerial-photos"
+    fake_collection_metadata["historic_survey_number"] = "SNC8844"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     assert collection.stac["title"] == title
 
 
 def test_generate_historic_imagery_title_missing_number(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["category"] = "scanned-aerial-photos"
-    metadata["historic_survey_number"] = None
+    fake_collection_metadata["category"] = "scanned-aerial-photos"
+    fake_collection_metadata["historic_survey_number"] = None
     with pytest.raises(MissingMetadataError) as excinfo:
-        ImageryCollection(metadata, any_epoch_datetime)
+        ImageryCollection(fake_collection_metadata, any_epoch_datetime)
 
     assert "historic_survey_number" in str(excinfo.value)
 
 
 def test_generate_title_long_date(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["end_datetime"] = datetime(2024, 1, 1)
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["end_datetime"] = datetime(2024, 1, 1)
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023-2024)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_geographic_description(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["geographic_description"] = "Ponsonby"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["geographic_description"] = "Ponsonby"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Ponsonby 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_imagery(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    metadata["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
+    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_elevation(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["category"] = "dsm"
-    metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    metadata["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["category"] = "dsm"
+    fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
+    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay - Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_satellite_imagery(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["category"] = "satellite-imagery"
-    metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    metadata["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["category"] = "satellite-imagery"
+    fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
+    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_dsm_title_preview(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["category"] = "dsm"
-    metadata["lifecycle"] = "preview"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["category"] = "dsm"
+    fake_collection_metadata["lifecycle"] = "preview"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay LiDAR 0.3m DSM (2023) - Preview"
     assert collection.stac["title"] == title
 
 
 def test_generate_imagery_title_draft(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["lifecycle"] = "ongoing"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["lifecycle"] = "ongoing"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023) - Draft"
     assert collection.stac["title"] == title
 
 
 def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["geographic_description"] = ""
-    metadata["event_name"] = ""
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["geographic_description"] = ""
+    fake_collection_metadata["event_name"] = ""
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_imagery_title_with_event(fake_collection_metadata: CollectionMetadata) -> None:
-    metadata = fake_collection_metadata
-    metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
-    metadata["event_name"] = "Forest Assessment"
-    collection = ImageryCollection(metadata, any_epoch_datetime)
+    fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
+    fake_collection_metadata["event_name"] = "Forest Assessment"
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime)
     title = "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title


### PR DESCRIPTION
### Motivation

The collection metadata used for testing is duplicated in the code base which makes it difficult to maintain.

### Modifications

Use the same collection metadata for all the related tests.

### Verification

ran pytest
