### PR TITLE
fix: providers should not be duplicated when having different roles TDE-1286

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -24,7 +24,7 @@ from scripts.stac.imagery.metadata_constants import (
     MissingMetadataError,
     SubtypeParameterError,
 )
-from scripts.stac.imagery.provider import Provider, ProviderRole
+from scripts.stac.imagery.provider import Provider, ProviderRole, merge_provider_roles
 from scripts.stac.link import Link, Relation
 from scripts.stac.util import checksum
 from scripts.stac.util.STAC_VERSION import STAC_VERSION
@@ -89,7 +89,7 @@ class ImageryCollection:
                 {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.HOST, ProviderRole.PROCESSOR]}
             )
 
-        self.add_providers(providers)
+        self.add_providers(merge_provider_roles(providers))
 
     def add_capture_area(self, polygons: list[BaseGeometry], target: str, artifact_target: str = "/tmp") -> None:
         """Add the capture area of the Collection.
@@ -172,11 +172,13 @@ class ImageryCollection:
 
     def add_providers(self, providers: list[Provider]) -> None:
         """Add a list of Providers to the existing list of `providers` of the Collection.
+        The provider roles are sorted alphabetically.
 
         Args:
             providers: a list of `Provider` objects
         """
         for p in providers:
+            p["roles"] = sorted(p["roles"])
             self.stac["providers"].append(p)
 
     def update_spatial_extent(self, item_bbox: list[float]) -> None:

--- a/scripts/stac/imagery/provider.py
+++ b/scripts/stac/imagery/provider.py
@@ -17,8 +17,7 @@ class Provider(TypedDict):
 
 
 def merge_provider_roles(providers: list[Provider]) -> list[Provider]:
-    """Merge the roles of the providers with the same name.
-    Does not manage duplicates in the final roles list.
+    """Remove duplicate providers based on name and merge their roles. See example below.
 
     Args:
         providers: a list of `Provider` objects

--- a/scripts/stac/imagery/provider.py
+++ b/scripts/stac/imagery/provider.py
@@ -27,8 +27,8 @@ def merge_provider_roles(providers: list[Provider]) -> list[Provider]:
         a list of `Provider` objects with merged roles
 
     Example:
-        >>> merge_provider_roles([{"name": "Maxar", "roles": [ProviderRole.PRODUCER]}, {"name": "Maxar",
-        "roles": [ProviderRole.LICENSOR]}])
+        >>> merge_provider_roles([{"name": "Maxar", "roles": [ProviderRole.PRODUCER]}, {"name": "Maxar",\
+              "roles": [ProviderRole.LICENSOR]}])
         [{'name': 'Maxar', 'roles': [<ProviderRole.PRODUCER: 'producer'>, <ProviderRole.LICENSOR: 'licensor'>]}]
     """
     merged_providers: list[Provider] = []

--- a/scripts/stac/imagery/provider.py
+++ b/scripts/stac/imagery/provider.py
@@ -38,4 +38,5 @@ def merge_provider_roles(providers: list[Provider]) -> list[Provider]:
             for p in merged_providers:
                 if p["name"] == provider["name"]:
                     p["roles"].extend(provider["roles"])
+                    continue
     return merged_providers

--- a/scripts/stac/imagery/provider.py
+++ b/scripts/stac/imagery/provider.py
@@ -14,3 +14,29 @@ class Provider(TypedDict):
     """Organization name"""
     roles: list[ProviderRole]
     """Organization roles"""
+
+
+def merge_provider_roles(providers: list[Provider]) -> list[Provider]:
+    """Merge the roles of the providers with the same name.
+    Does not manage duplicates in the final roles list.
+
+    Args:
+        providers: a list of `Provider` objects
+
+    Returns:
+        a list of `Provider` objects with merged roles
+
+    Example:
+        >>> merge_provider_roles([{"name": "Maxar", "roles": [ProviderRole.PRODUCER]}, {"name": "Maxar",
+        "roles": [ProviderRole.LICENSOR]}])
+        [{'name': 'Maxar', 'roles': [<ProviderRole.PRODUCER: 'producer'>, <ProviderRole.LICENSOR: 'licensor'>]}]
+    """
+    merged_providers: list[Provider] = []
+    for provider in providers:
+        if provider["name"] not in [p["name"] for p in merged_providers]:
+            merged_providers.append(provider)
+        else:
+            for p in merged_providers:
+                if p["name"] == provider["name"]:
+                    p["roles"].extend(provider["roles"])
+    return merged_providers

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -200,7 +200,7 @@ def test_default_provider_roles_are_kept(fake_collection_metadata: CollectionMet
     with subtests.test(msg="it adds the non default role to the existing default role list"):
         assert {
             "name": "Toitū Te Whenua Land Information New Zealand",
-            "roles": ["licensor", "host", "processor"],
+            "roles": ["host", "licensor", "processor"],
         } in collection.stac["providers"]
 
     with subtests.test(msg="it does not duplicate the default provider"):
@@ -220,6 +220,17 @@ def test_default_provider_is_present(fake_collection_metadata: CollectionMetadat
         ]
     with subtests.test(msg="the new provider is added"):
         assert {"name": "Maxar", "roles": ["producer"]} in collection.stac["providers"]
+
+
+def test_providers_are_not_duplicated(fake_collection_metadata: CollectionMetadata) -> None:
+    producer: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.PRODUCER]}
+    licensor: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.LICENSOR]}
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, providers=[producer, licensor])
+    assert len(collection.stac["providers"]) == 1
+    assert {
+        "name": "Toitū Te Whenua Land Information New Zealand",
+        "roles": ["host", "licensor", "processor", "producer"],
+    } in collection.stac["providers"]
 
 
 def test_capture_area_added(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:


### PR DESCRIPTION
### Motivation

When a user add the same provider (same `name`) as a different role (for example, `--licensor='Maxar' --producer='Maxar'`) the provider should not be duplicated, but added with both role (for example: `{'name': 'Maxar', 'roles': ['producer', 'licensor']}`).

### Modifications

- merge provider list based on their name
- sort provider roles alphabetically (for readibility and conveniance) when added to the Collection

### Verification

automatic tests
