### PR TITLE
feat: allow forcing Collection title to not have suffix TDE-1289

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -85,6 +85,13 @@ def parse_args(args: List[str] | None) -> Namespace:
         help="Add a capture-dates.geojson.gz file to the collection assets",
         required=False,
     )
+    parser.add_argument(
+        "--add-title-suffix",
+        dest="add_title_suffix",
+        action="store_true",
+        help="Add a title suffix to the collection title based on the lifecycle. For example, '[TITLE] - Preview'",
+        required=False,
+    )
 
     return parser.parse_args(args)
 

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -177,6 +177,7 @@ def main(args: List[str] | None = None) -> None:
         item_polygons=polygons,
         add_capture_dates=arguments.capture_dates,
         uri=uri,
+        add_title_suffix=arguments.add_title_suffix,
     )
 
     destination = os.path.join(uri, "collection.json")

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -18,6 +18,7 @@ from scripts.stac.link import Link, Relation
 from scripts.stac.util.media_type import StacMediaType
 
 
+# pylint: disable=too-many-arguments
 def create_collection(
     collection_id: str,
     collection_metadata: CollectionMetadata,
@@ -27,6 +28,7 @@ def create_collection(
     item_polygons: list[BaseGeometry],
     add_capture_dates: bool,
     uri: str,
+    add_title_suffix: bool = False,
 ) -> ImageryCollection:
     """Create an ImageryCollection object.
     If `item_polygons` is not empty, it will add a generated capture area to the collection.
@@ -40,6 +42,7 @@ def create_collection(
         item_polygons: polygons of the items linked to the collection
         add_capture_dates: whether to add a capture-dates.geojson.gz file to the collection assets
         uri: path of the dataset
+        add_title_suffix: whether to add a title suffix to the collection title based on the lifecycle
 
     Returns:
         an ImageryCollection object
@@ -55,6 +58,7 @@ def create_collection(
         now=utc_now,
         collection_id=collection_id,
         providers=providers,
+        add_title_suffix=add_title_suffix,
     )
 
     for item in stac_items:

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -106,6 +106,14 @@ def test_generate_imagery_title_draft(fake_collection_metadata: CollectionMetada
     assert collection.stac["title"] == title
 
 
+def test_generate_imagery_title_without_suffix(fake_collection_metadata: CollectionMetadata) -> None:
+    # `ongoing` lifecycle nominal case adds a suffix
+    fake_collection_metadata["lifecycle"] = "ongoing"
+    collection = ImageryCollection(metadata=fake_collection_metadata, now=any_epoch_datetime, add_title_suffix=False)
+    title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
+    assert collection.stac["title"] == title
+
+
 def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata["geographic_description"] = ""
     fake_collection_metadata["event_name"] = ""


### PR DESCRIPTION
### Motivation

Some datasets might not required a suffix in their title. For example, a dataset with an `ongoing` lifecycle could not be tagged as a ` - Draft`.

### Modifications

- add an optional parameter `--add-title-suffix` (defaulted `True`) to the `collection_from_items.py` script so the title suffix, for example ` - Draft` can be ommitted in any case

### Verification

automatic tests
