### PR TITLE
feat: add description field for assets in collection TDE-1294

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -110,6 +110,8 @@ class ImageryCollection:
         capture_area = {
             "href": f"./{CAPTURE_AREA_FILE_NAME}",
             "title": "Capture area",
+            "description": "Boundary of the total capture area for this collection. Excludes nodata areas in the source "
+            "data. Geometries are simplified.",
             "type": ContentType.GEOJSON,
             "roles": ["metadata"],
             "file:checksum": file_checksum,
@@ -145,6 +147,9 @@ class ImageryCollection:
         capture_dates = {
             "href": f"./{CAPTURE_DATES_FILE_NAME}",
             "title": "Capture dates",
+            "description": "Boundaries of individual surveys or flight runs that make up the overall collection with "
+            "the data collection dates, data source links and other associated metadata, such as producers and licensors, "
+            "where available. Excludes nodata areas in the source data. Geometries are simplified.",
             "type": ContentType.GEOJSON,
             "roles": ["metadata"],
             "file:checksum": file_checksum,

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -297,6 +297,12 @@ def test_capture_area_added(fake_collection_metadata: CollectionMetadata, subtes
         assert collection.stac["assets"]["capture_area"]["title"] == "Capture area"
 
     with subtests.test():
+        assert (
+            collection.stac["assets"]["capture_area"]["description"] == "Boundary of the total capture area for "
+            "this collection. Excludes nodata areas in the source data. Geometries are simplified."
+        )
+
+    with subtests.test():
         assert collection.stac["assets"]["capture_area"]["type"] == "application/geo+json"
 
     with subtests.test():
@@ -342,6 +348,9 @@ def test_capture_dates_added(fake_collection_metadata: CollectionMetadata) -> No
     assert collection.stac["assets"]["capture_dates"] == {
         "href": "./capture-dates.geojson",
         "title": "Capture dates",
+        "description": "Boundaries of individual surveys or flight runs that make up the overall collection with the "
+        "data collection dates, data source links and other associated metadata, such as producers and licensors, "
+        "where available. Excludes nodata areas in the source data. Geometries are simplified.",
         "type": ContentType.GEOJSON,
         "roles": ["metadata"],
         "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",


### PR DESCRIPTION
### Motivation

To show a data consumer more information about what kind of data the linked `capture-area.geojson` and `capture-dates.geojson` files hold without having to view those.

### Modifications

Added a `description` field to the `capture_area` and `capture_dates` Asset objects created in `collection.py` and associated tests.

### Verification

Unit tests updated to include the new data fields.
pre-commit checks to unify formatting.
