### PR TITLE
refactor: use environment variable to get GDAL version

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,6 +2,9 @@
 
 set -o errexit
 
+GDAL_VERSION="$(gdalinfo --version)"
+export GDAL_VERSION
+
 . /venv/bin/activate
 
 exec "$@"

--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -53,25 +53,6 @@ def command_to_string(command: list[str]) -> str:
     return " ".join(command)
 
 
-def get_gdal_version() -> str:
-    """Return the GDAL version assuming all GDAL commands are in the same version of gdalinfo.
-
-    Raises:
-        GDALExecutionException: If the GDAL command fails.
-
-    Returns:
-        str: The GDAL version returned by GDAL.
-    """
-    gdal_env = os.environ.copy()
-    gdalinfo_version = ["gdalinfo", "--version"]
-    try:
-        proc = subprocess.run(gdalinfo_version, env=gdal_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
-        return proc.stdout.decode().strip()
-    except subprocess.CalledProcessError as cpe:
-        get_log().error("get_gdal_version_failed", command=command_to_string(gdalinfo_version), error=str(cpe.stderr, "utf-8"))
-        raise GDALExecutionException(f"GDAL {str(cpe.stderr, 'utf-8')}") from cpe
-
-
 def run_gdal(
     command: list[str],
     input_file: str | None = None,

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -9,7 +9,7 @@ from scripts.datetimes import format_rfc_3339_nz_midnight_datetime_string
 from scripts.files.file_tiff import FileTiff
 from scripts.files.files_helper import SUFFIX_JSON, ContentType
 from scripts.files.fs import exists, write
-from scripts.gdal.gdal_helper import get_gdal_version, get_srs, get_vfs_path
+from scripts.gdal.gdal_helper import get_srs, get_vfs_path
 from scripts.json_codec import dict_to_json_bytes
 from scripts.stac.imagery.create_stac import create_item
 from scripts.standardising import run_standardising
@@ -107,7 +107,7 @@ def main() -> None:
     if is_argo():
         concurrency = 4
 
-    gdal_version = get_gdal_version()
+    gdal_version = os.environ["GDAL_VERSION"]
 
     tiff_files = run_standardising(
         tile_files,


### PR DESCRIPTION
### Motivation

Simplify getting the gdal version.

### Modifications

Use system environment variable to store the gdal version value rather than calling the shell from Python.

### Verification

Ran E2E test
