### PR TITLE
refactor: Simplify `ImageryItem` constructor TDE-1298

### DIFF
--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -137,7 +137,7 @@ def create_item(
 def create_base_item(asset_path: str, gdal_version: str) -> ImageryItem:
     """
     Args:
-        asset_path: asset tiff file path
+        asset_path: path of the visual asset (TIFF)
         gdal_version: GDAL version string
 
     Returns:

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -91,7 +91,7 @@ def create_item(
     """Create an ImageryItem (STAC) to be linked to a Collection.
 
     Args:
-        asset_path: asset tiff file
+        asset_path: path of the visual asset (TIFF)
         start_datetime: start date of the survey
         end_datetime: end date of the survey
         collection_id: collection id to link to the Item

--- a/scripts/stac/imagery/tests/generators.py
+++ b/scripts/stac/imagery/tests/generators.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Callable
+
+from scripts.stac.imagery.item import STACAsset, STACProcessing, STACProcessingSoftware
+
+
+def fixed_now_function(now: datetime) -> Callable[[], datetime]:
+    def func() -> datetime:
+        return now
+
+    return func
+
+
+def any_stac_asset() -> STACAsset:
+    return STACAsset(
+        **{
+            "href": "any href",
+            "file:checksum": "any checksum",
+            "created": "any created datetime",
+            "updated": "any updated datetime",
+        }
+    )
+
+
+def any_stac_processing() -> STACProcessing:
+    return STACProcessing(
+        **{
+            "processing:datetime": "any processing datetime",
+            "processing:software": STACProcessingSoftware(
+                **{"gdal": "any GDAL version", "linz/topo-imagery": "any topo imagery version"}
+            ),
+            "processing:version": "any processing version",
+        }
+    )

--- a/scripts/stac/imagery/tests/item_test.py
+++ b/scripts/stac/imagery/tests/item_test.py
@@ -1,97 +1,76 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from decimal import Decimal
 from os import environ
 from unittest.mock import patch
 
-from pytest_mock import MockerFixture
 from pytest_subtests import SubTests
 
 from scripts.files.files_helper import get_file_name_from_path
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
-from scripts.stac.util.stac_extensions import StacExtensions
-from scripts.tests.datetimes_test import any_epoch_datetime
+from scripts.stac.imagery.tests.generators import any_stac_asset, any_stac_processing
+from scripts.tests.datetimes_test import any_epoch_datetime, any_epoch_datetime_string
 
 
-def test_imagery_stac_item(mocker: MockerFixture, subtests: SubTests) -> None:
+def test_imagery_stac_item(subtests: SubTests) -> None:
     # mock functions that interact with files
     geometry = {
         "type": "Polygon",
         "coordinates": [[[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]]],
     }
     bbox = (1799667.5, 5815977.0, 1800422.5, 5814986.0)
-    mocker.patch("scripts.files.fs.read", return_value=b"")
 
     path = "./scripts/tests/data/empty.tiff"
     id_ = get_file_name_from_path(path)
     start_datetime = "2021-01-27T00:00:00Z"
-    end_datetime = "2021-01-27T00:00:00Z"
-
-    def fake_now() -> datetime:
-        return datetime(1979, 1, 1, tzinfo=timezone.utc)
+    end_datetime = "2021-01-29T00:00:00Z"
 
     git_hash = "any Git hash"
     git_version = "any Git version string"
-    gdal_version_string = "any GDAL version string"
+    asset = any_stac_asset()
+    now_string = any_epoch_datetime_string()
+    stac_processing = any_stac_processing()
     with patch.dict(environ, {"GIT_HASH": git_hash, "GIT_VERSION": git_version}):
-        item = ImageryItem(id_, path, gdal_version_string, fake_now)
+        item = ImageryItem(id_, now_string, asset, stac_processing)
     item.update_spatial(geometry, bbox)
     item.update_datetime(start_datetime, end_datetime)
+
     # checks
     with subtests.test():
-        assert item.stac["id"] == id_
-
-    with subtests.test():
-        assert item.stac["properties"]["start_datetime"] == start_datetime
-
-    with subtests.test():
-        assert item.stac["properties"]["end_datetime"] == end_datetime
-
-    with subtests.test():
-        assert item.stac["properties"]["datetime"] is None
-
-    with subtests.test():
-        assert (
-            item.stac["properties"]["created"]
-            == item.stac["properties"]["updated"]
-            == item.stac["properties"]["processing:datetime"]
-            == "1979-01-01T00:00:00Z"
-        )
-
-    with subtests.test():
-        assert item.stac["properties"]["processing:version"] == git_version
-
-    with subtests.test():
-        assert item.stac["properties"]["processing:software"] == {
-            "gdal": gdal_version_string,
-            "linz/topo-imagery": f"https://github.com/linz/topo-imagery/commit/{git_hash}",
+        assert item.stac == {
+            "assets": {
+                "visual": {**asset, "type": "image/tiff; application=geotiff; profile=cloud-optimized"},
+            },
+            "bbox": bbox,
+            "geometry": geometry,
+            "id": id_,
+            "links": [
+                {
+                    "href": "./empty.json",
+                    "rel": "self",
+                    "type": "application/geo+json",
+                },
+            ],
+            "properties": {
+                "created": now_string,
+                "datetime": None,
+                "end_datetime": end_datetime,
+                "start_datetime": start_datetime,
+                "updated": now_string,
+                **stac_processing,
+            },
+            "stac_extensions": [
+                "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+                "https://stac-extensions.github.io/processing/v1.2.0/schema.json",
+            ],
+            "stac_version": "1.0.0",
+            "type": "Feature",
         }
-
-    with subtests.test():
-        assert item.stac["stac_extensions"] == [StacExtensions.file.value, StacExtensions.processing.value]
-
-    with subtests.test():
-        assert item.stac["geometry"]["coordinates"] == geometry["coordinates"]
-
-    with subtests.test():
-        assert item.stac["geometry"] == geometry
-
-    with subtests.test():
-        assert item.stac["bbox"] == bbox
-
-    with subtests.test():
-        assert (
-            item.stac["assets"]["visual"]["file:checksum"]
-            == "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-        )
-
-    with subtests.test():
-        assert {"rel": "self", "href": f"./{id_}.json", "type": "application/geo+json"} in item.stac["links"]
 
 
 # pylint: disable=duplicate-code
-def test_imagery_add_collection(mocker: MockerFixture, subtests: SubTests) -> None:
+def test_imagery_add_collection(subtests: SubTests) -> None:
     metadata: CollectionMetadata = {
         "category": "urban-aerial-photos",
         "region": "auckland",
@@ -108,8 +87,7 @@ def test_imagery_add_collection(mocker: MockerFixture, subtests: SubTests) -> No
 
     path = "./scripts/tests/data/empty.tiff"
     id_ = get_file_name_from_path(path)
-    mocker.patch("scripts.files.fs.read", return_value=b"")
-    item = ImageryItem(id_, path, "any GDAL version", any_epoch_datetime)
+    item = ImageryItem(id_, any_epoch_datetime_string(), any_stac_asset(), any_stac_processing())
 
     item.add_collection(collection.stac["id"])
 
@@ -121,13 +99,3 @@ def test_imagery_add_collection(mocker: MockerFixture, subtests: SubTests) -> No
 
     with subtests.test():
         assert {"rel": "parent", "href": "./collection.json", "type": "application/json"} in item.stac["links"]
-
-
-def test_should_set_fallback_version_strings(subtests: SubTests) -> None:
-    item = ImageryItem("any ID", "./scripts/tests/data/empty.tiff", "any GDAL version", any_epoch_datetime)
-
-    with subtests.test():
-        assert item.stac["properties"]["processing:software"]["linz/topo-imagery"] == "GIT_HASH not specified"
-
-    with subtests.test():
-        assert item.stac["properties"]["processing:version"] == "GIT_VERSION not specified"

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -18,13 +18,15 @@ from scripts.json_codec import dict_to_json_bytes
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
+from scripts.stac.imagery.tests.generators import any_stac_asset, any_stac_processing
+from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
 @pytest.fixture(name="item", autouse=True)
 def setup() -> Iterator[ImageryItem]:
     # Create mocked STAC Item
     with patch.dict(environ, {"GIT_HASH": "any Git hash", "GIT_VERSION": "any Git version"}):
-        item = ImageryItem("123", "./scripts/tests/data/empty.tiff", "any GDAL version", utc_now)
+        item = ImageryItem("123", any_epoch_datetime_string(), any_stac_asset(), any_stac_processing())
     geometry = {
         "type": "Polygon",
         "coordinates": [[1799667.5, 5815977.0], [1800422.5, 5815977.0], [1800422.5, 5814986.0], [1799667.5, 5814986.0]],

--- a/scripts/tests/datetimes_test.py
+++ b/scripts/tests/datetimes_test.py
@@ -64,3 +64,7 @@ def any_datetime_between(start: datetime, end: datetime) -> datetime:
     """
     range_in_seconds = (end - start).total_seconds()
     return start + timedelta(seconds=randint(0, int(range_in_seconds)))
+
+
+def any_epoch_datetime_string() -> str:
+    return format_rfc_3339_datetime_string(any_epoch_datetime())


### PR DESCRIPTION
### Modifications

Pull out STAC asset and processing data types.

### Verification

Modified unit tests accordingly.
