### PR TITLE
feat: keep Collection properties.created date when resupplying

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -32,6 +32,12 @@ def parse_args(args: List[str] | None) -> Namespace:
     parser.add_argument("--uri", dest="uri", help="s3 path to items and collection.json write location", required=True)
     parser.add_argument("--collection-id", dest="collection_id", help="Collection ID", required=True)
     parser.add_argument(
+        "--odr-url",
+        dest="odr_url",
+        help="The path of the published dataset. Example: 's3://nz-imagery/wellington/porirua_2024_0.1m/rgb/2193/'",
+        required=False,
+    )
+    parser.add_argument(
         "--category",
         dest="category",
         help="Dataset category description",
@@ -103,6 +109,15 @@ def parse_args(args: List[str] | None) -> Namespace:
         action="store_true",
         help="Add a title suffix to the collection title based on the lifecycle. For example, '[TITLE] - Preview'",
         required=False,
+    )
+    parser.add_argument(
+        "--current-datetime",
+        dest="current_datetime",
+        help=(
+            "The datetime that is used as current datetime in the metadata. "
+            "Format: RFC 3339 UTC datetime, `YYYY-MM-DDThh:mm:ssZ`."
+        ),
+        required=True,
     )
 
     return parser.parse_args(args)
@@ -184,6 +199,7 @@ def main(args: List[str] | None = None) -> None:
         collection_id=collection_id,
         linz_slug=arguments.linz_slug,
         collection_metadata=collection_metadata,
+        current_datetime=arguments.current_datetime,
         producers=coalesce_multi_single(arguments.producer_list, arguments.producer),
         licensors=coalesce_multi_single(arguments.licensor_list, arguments.licensor),
         stac_items=items_to_add,
@@ -191,6 +207,7 @@ def main(args: List[str] | None = None) -> None:
         add_capture_dates=arguments.capture_dates,
         uri=uri,
         add_title_suffix=arguments.add_title_suffix,
+        odr_url=arguments.odr_url,
     )
 
     destination = os.path.join(uri, "collection.json")

--- a/scripts/datetimes.py
+++ b/scripts/datetimes.py
@@ -39,22 +39,6 @@ def format_rfc_3339_nz_midnight_datetime_string(datetime_object: datetime) -> st
     return format_rfc_3339_datetime_string(datetime_utc)
 
 
-def utc_now() -> datetime:
-    """
-    Get the current datetime with UTC time zone
-
-    Should return something close to the current time:
-        >>> current_timestamp = datetime.now().timestamp()
-        >>> current_timestamp - 5 < utc_now().timestamp() < current_timestamp + 5
-        True
-
-    Should have UTC time zone:
-        >>> utc_now().tzname()
-        'UTC'
-    """
-    return datetime.now(tz=timezone.utc)
-
-
 class NaiveDatetimeError(Exception):
     def __init__(self) -> None:
         super().__init__("Can't convert naive datetime to UTC")

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -1,8 +1,5 @@
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
-from datetime import datetime
-from pathlib import Path
-from typing import TYPE_CHECKING
 
 from boto3 import client
 from linz_logger import get_log
@@ -10,11 +7,6 @@ from linz_logger import get_log
 from scripts.aws.aws_helper import is_s3
 from scripts.files import fs_local, fs_s3
 from scripts.stac.util.checksum import multihash_as_hex
-
-if TYPE_CHECKING:
-    from mypy_boto3_s3 import S3Client
-else:
-    S3Client = dict
 
 
 def write(destination: str, source: bytes, content_type: str | None = None) -> str:
@@ -85,13 +77,6 @@ def exists(path: str) -> bool:
     if is_s3(path):
         return fs_s3.exists(path)
     return fs_local.exists(path)
-
-
-def modified(path: str, s3_client: S3Client | None = None) -> datetime:
-    """Get modified datetime for S3 URL or local path"""
-    if is_s3(path):
-        return fs_s3.modified(fs_s3.bucket_name_from_path(path), fs_s3.prefix_from_path(path), s3_client)
-    return fs_local.modified(Path(path))
 
 
 def write_all(inputs: list[str], target: str, concurrency: int | None = 4, generate_name: bool | None = True) -> list[str]:

--- a/scripts/files/fs_local.py
+++ b/scripts/files/fs_local.py
@@ -1,6 +1,4 @@
 import os
-from datetime import datetime, timezone
-from pathlib import Path
 
 
 def write(destination: str, source: bytes) -> None:
@@ -38,9 +36,3 @@ def exists(path: str) -> bool:
         True if the path exists
     """
     return os.path.exists(path)
-
-
-def modified(path: Path) -> datetime:
-    """Get path modified datetime as UTC"""
-    modified_timestamp = os.path.getmtime(path)
-    return datetime.fromtimestamp(modified_timestamp, tz=timezone.utc)

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -1,7 +1,6 @@
 from collections.abc import Generator
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from boto3 import client
@@ -236,8 +235,3 @@ def get_object_parallel_multithreading(
                 yield key, future.result()
             else:
                 yield key, exception
-
-
-def modified(bucket_name: str, key: str, s3_client: S3Client | None) -> datetime:
-    s3_client = s3_client or client("s3")
-    return _get_object(bucket_name, key, s3_client)["LastModified"]

--- a/scripts/files/tests/fs_local_test.py
+++ b/scripts/files/tests/fs_local_test.py
@@ -1,10 +1,8 @@
 import os
-from pathlib import Path
 
 import pytest
 
-from scripts.files.fs_local import exists, modified, read, write
-from scripts.tests.datetimes_test import any_epoch_datetime
+from scripts.files.fs_local import exists, read, write
 
 
 @pytest.mark.dependency(name="write")
@@ -45,11 +43,3 @@ def test_exists(setup: str) -> None:
 def test_exists_file_not_found() -> None:
     found = exists("/tmp/test.file")
     assert found is False
-
-
-def test_should_get_modified_datetime(setup: str) -> None:
-    path = Path(os.path.join(setup, "modified.file"))
-    path.touch()
-    modified_datetime = any_epoch_datetime()
-    os.utime(path, times=(any_epoch_datetime().timestamp(), modified_datetime.timestamp()))
-    assert modified(path) == modified_datetime

--- a/scripts/files/tests/fs_s3_test.py
+++ b/scripts/files/tests/fs_s3_test.py
@@ -3,17 +3,13 @@ import json
 from boto3 import client
 from botocore.exceptions import ClientError
 from moto import mock_aws
-from moto.core.models import DEFAULT_ACCOUNT_ID
-from moto.s3.models import s3_backends
 from moto.s3.responses import DEFAULT_REGION_NAME
-from moto.wafv2.models import GLOBAL_REGION
 from mypy_boto3_s3 import S3Client
 from pytest import CaptureFixture, raises
 from pytest_subtests import SubTests
 
 from scripts.files.files_helper import ContentType
-from scripts.files.fs_s3 import exists, list_files_in_uri, modified, read, write
-from scripts.tests.datetimes_test import any_epoch_datetime
+from scripts.files.fs_s3 import exists, list_files_in_uri, read, write
 
 
 @mock_aws
@@ -165,17 +161,3 @@ def test_list_files_in_uri(subtests: SubTests) -> None:
 
     with subtests.test():
         assert "data/image.tiff" not in files
-
-
-@mock_aws
-def test_should_get_modified_datetime() -> None:
-    bucket_name = "any-bucket-name"
-    key = "any-key"
-    modified_datetime = any_epoch_datetime()
-
-    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket=bucket_name)
-    s3_client.put_object(Bucket=bucket_name, Key=key, Body=b"any body")
-    s3_backends[DEFAULT_ACCOUNT_ID][GLOBAL_REGION].buckets[bucket_name].keys[key].last_modified = modified_datetime
-
-    assert modified(bucket_name, key, s3_client) == modified_datetime

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -5,16 +5,12 @@ from tempfile import mkdtemp
 
 from boto3 import client
 from moto import mock_aws
-from moto.core.models import DEFAULT_ACCOUNT_ID
-from moto.s3.models import s3_backends
 from moto.s3.responses import DEFAULT_REGION_NAME
-from moto.wafv2.models import GLOBAL_REGION
 from mypy_boto3_s3 import S3Client
 from pytest import CaptureFixture, raises
 from pytest_subtests import SubTests
 
-from scripts.files.fs import NoSuchFileError, modified, read, write, write_all, write_sidecars
-from scripts.tests.datetimes_test import any_epoch_datetime
+from scripts.files.fs import NoSuchFileError, read, write, write_all, write_sidecars
 
 
 def test_read_key_not_found_local() -> None:
@@ -103,25 +99,3 @@ def test_write_all_in_order(setup: str) -> None:
         i += 1
     written_files = write_all(inputs=inputs, target=setup, generate_name=False)
     assert written_files == inputs
-
-
-@mock_aws
-def test_should_get_s3_object_modified_datetime() -> None:
-    bucket_name = "any-bucket-name"
-    key = "any-key"
-    modified_datetime = any_epoch_datetime()
-
-    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket=bucket_name)
-    s3_client.put_object(Bucket=bucket_name, Key=key, Body=b"any body")
-    s3_backends[DEFAULT_ACCOUNT_ID][GLOBAL_REGION].buckets[bucket_name].keys[key].last_modified = modified_datetime
-
-    assert modified(f"s3://{bucket_name}/{key}", s3_client) == modified_datetime
-
-
-def test_should_get_local_file_modified_datetime(setup: str) -> None:
-    path = os.path.join(setup, "modified.file")
-    Path(path).touch()
-    modified_datetime = any_epoch_datetime()
-    os.utime(path, times=(any_epoch_datetime().timestamp(), modified_datetime.timestamp()))
-    assert modified(path) == modified_datetime

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -1,6 +1,4 @@
 import os
-from collections.abc import Callable
-from datetime import datetime
 from typing import Any
 
 import ulid
@@ -41,7 +39,8 @@ class ImageryCollection:
     def __init__(
         self,
         metadata: CollectionMetadata,
-        now: Callable[[], datetime],
+        created_datetime: str,
+        updated_datetime: str,
         linz_slug: str,
         collection_id: str | None = None,
         providers: list[Provider] | None = None,
@@ -52,7 +51,6 @@ class ImageryCollection:
 
         self.metadata = metadata
 
-        now_string = format_rfc_3339_datetime_string(now())
         self.stac = {
             "type": "Collection",
             "stac_version": STAC_VERSION,
@@ -67,8 +65,8 @@ class ImageryCollection:
             "linz:region": metadata["region"],
             "linz:security_classification": "unclassified",
             "linz:slug": linz_slug,
-            "created": now_string,
-            "updated": now_string,
+            "created": created_datetime,
+            "updated": updated_datetime,
         }
 
         # Optional metadata

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -12,7 +12,6 @@ from mypy_boto3_s3 import S3Client
 from pytest_subtests import SubTests
 from shapely.predicates import is_valid
 
-from scripts.datetimes import format_rfc_3339_datetime_string
 from scripts.files.files_helper import ContentType
 from scripts.files.fs import read
 from scripts.files.fs_s3 import write
@@ -21,9 +20,9 @@ from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem, STACAsset
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole
-from scripts.stac.imagery.tests.generators import any_stac_processing, fixed_now_function
+from scripts.stac.imagery.tests.generators import any_stac_processing
 from scripts.stac.util.stac_extensions import StacExtensions
-from scripts.tests.datetimes_test import any_epoch_datetime, any_epoch_datetime_string
+from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
 def test_title_description_id_created_on_init(
@@ -31,7 +30,9 @@ def test_title_description_id_created_on_init(
 ) -> None:
     fake_collection_metadata["event_name"] = "Forest Assessment"
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     with subtests.test():
         assert collection.stac["title"] == "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
 
@@ -62,19 +63,25 @@ def test_title_description_id_created_on_init(
 
 def test_id_parsed_on_init(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     id_ = "Parsed-Ulid"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug, id_)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug, id_
+    )
     assert collection.stac["id"] == "Parsed-Ulid"
 
 
 def test_bbox_updated_from_none(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     bbox = [1799667.5, 5815977.0, 1800422.5, 5814986.0]
     collection.update_spatial_extent(bbox)
     assert collection.stac["extent"]["spatial"]["bbox"] == [bbox]
 
 
 def test_bbox_updated_from_existing(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     # init bbox
     bbox = [174.889641, -41.217532, 174.902344, -41.203521]
     collection.update_spatial_extent(bbox)
@@ -86,7 +93,9 @@ def test_bbox_updated_from_existing(fake_collection_metadata: CollectionMetadata
 
 
 def test_interval_updated_from_none(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     start_datetime = "2021-01-27T00:00:00Z"
     end_datetime = "2021-01-27T00:00:00Z"
     collection.update_temporal_extent(start_datetime, end_datetime)
@@ -94,7 +103,9 @@ def test_interval_updated_from_none(fake_collection_metadata: CollectionMetadata
 
 
 def test_interval_updated_from_existing(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     # init interval
     start_datetime = "2021-01-27T00:00:00Z"
     end_datetime = "2021-01-27T00:00:00Z"
@@ -108,9 +119,8 @@ def test_interval_updated_from_existing(fake_collection_metadata: CollectionMeta
 
 
 def test_add_item(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str, subtests: SubTests) -> None:
-    now = any_epoch_datetime()
-    now_string = format_rfc_3339_datetime_string(now)
-    collection = ImageryCollection(fake_collection_metadata, fixed_now_function(now), fake_linz_slug)
+    now_string = any_epoch_datetime_string()
+    collection = ImageryCollection(fake_collection_metadata, now_string, now_string, fake_linz_slug)
     asset_datetimes = {
         "created": any_epoch_datetime_string(),
         "updated": any_epoch_datetime_string(),
@@ -170,7 +180,9 @@ def test_add_item(fake_collection_metadata: CollectionMetadata, fake_linz_slug: 
 
 def test_write_collection(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     target = mkdtemp()
-    collectionObj = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collectionObj = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     collection_target = os.path.join(target, "collection.json")
     collectionObj.write_to(collection_target)
     collection = json.loads(read(collection_target))
@@ -182,7 +194,9 @@ def test_write_collection(fake_collection_metadata: CollectionMetadata, fake_lin
 def test_write_collection_special_chars(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     target = mkdtemp()
     title = "Manawatū-Whanganui"
-    collectionObj = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collectionObj = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     collectionObj.stac["title"] = title
     collection_target = os.path.join(target, "collection.json")
     collectionObj.write_to(collection_target)
@@ -193,7 +207,9 @@ def test_write_collection_special_chars(fake_collection_metadata: CollectionMeta
 
 
 def test_add_providers(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
     collection.add_providers([producer])
 
@@ -207,7 +223,11 @@ def test_default_provider_roles_are_kept(
     licensor: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.LICENSOR]}
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime, fake_linz_slug, providers=[producer, licensor]
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
+        fake_linz_slug,
+        providers=[producer, licensor],
     )
 
     with subtests.test(msg="it adds the non default role to the existing default role list"):
@@ -227,7 +247,13 @@ def test_default_provider_is_present(
 ) -> None:
     # given adding a provider
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug, providers=[producer])
+    collection = ImageryCollection(
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
+        fake_linz_slug,
+        providers=[producer],
+    )
 
     with subtests.test(msg="the default provider is still present"):
         assert {"name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"]} in collection.stac[
@@ -241,7 +267,11 @@ def test_providers_are_not_duplicated(fake_collection_metadata: CollectionMetada
     producer: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.PRODUCER]}
     licensor: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.LICENSOR]}
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime, fake_linz_slug, providers=[producer, licensor]
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
+        fake_linz_slug,
+        providers=[producer, licensor],
     )
     assert len(collection.stac["providers"]) == 1
     assert {
@@ -256,7 +286,9 @@ def test_capture_area_added(fake_collection_metadata: CollectionMetadata, fake_l
     <https://github.com/libgeos/geos/pull/718>. Once we start using geos 3.12 in CI we can delete the values for 3.11
     below.
     """
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     file_name = "capture-area.geojson"
 
     polygons = []
@@ -367,24 +399,32 @@ def test_should_make_valid_capture_area() -> None:
 
 def test_event_name_is_present(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["event_name"] = "Forest Assessment"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     assert "Forest Assessment" == collection.stac["linz:event_name"]
 
 
 def test_geographic_description_is_present(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     assert "Hawke's Bay Forest Assessment" == collection.stac["linz:geographic_description"]
 
 
 def test_linz_slug_is_present(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     assert fake_linz_slug == collection.stac["linz:slug"]
 
 
 @mock_aws
 def test_capture_dates_added(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="flat")
     write("s3://flat/capture-dates.geojson", b"")

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -1,17 +1,21 @@
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
-from scripts.tests.datetimes_test import any_epoch_datetime
+from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
 def test_generate_description_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_elevation(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["category"] = "dem"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
@@ -21,14 +25,18 @@ def test_generate_description_elevation_geographic_description_input(
 ) -> None:
     fake_collection_metadata["category"] = "dem"
     fake_collection_metadata["geographic_description"] = "Central"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_satellite_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["category"] = "satellite-imagery"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     description = "Satellite imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
@@ -36,14 +44,18 @@ def test_generate_description_satellite_imagery(fake_collection_metadata: Collec
 def test_generate_description_historic_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["category"] = "scanned-aerial-photos"
     fake_collection_metadata["historic_survey_number"] = "SNC8844"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     description = "Scanned aerial imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_event(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, \
 published as a record of the Cyclone Gabrielle event."
     assert collection.stac["description"] == description

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -4,32 +4,40 @@ import pytest
 
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.metadata_constants import CollectionMetadata, MissingMetadataError
-from scripts.tests.datetimes_test import any_epoch_datetime
+from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
 def test_generate_imagery_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     assert collection.stac["title"] == title
 
 
 def test_generate_dem_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["category"] = "dem"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay LiDAR 0.3m DEM (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_dsm_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["category"] = "dsm"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_satellite_imagery_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["category"] = "satellite-imagery"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
@@ -38,7 +46,9 @@ def test_generate_historic_imagery_title(fake_collection_metadata: CollectionMet
     title = "Hawke's Bay 0.3m SNC8844 (2023)"
     fake_collection_metadata["category"] = "scanned-aerial-photos"
     fake_collection_metadata["historic_survey_number"] = "SNC8844"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     assert collection.stac["title"] == title
 
 
@@ -48,21 +58,25 @@ def test_generate_historic_imagery_title_missing_number(
     fake_collection_metadata["category"] = "scanned-aerial-photos"
     fake_collection_metadata["historic_survey_number"] = None
     with pytest.raises(MissingMetadataError) as excinfo:
-        ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+        ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug)
 
     assert "historic_survey_number" in str(excinfo.value)
 
 
 def test_generate_title_long_date(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["end_datetime"] = datetime(2024, 1, 1)
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023-2024)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_geographic_description(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["geographic_description"] = "Ponsonby"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Ponsonby 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
@@ -70,7 +84,9 @@ def test_generate_title_geographic_description(fake_collection_metadata: Collect
 def test_generate_title_event_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
@@ -79,7 +95,9 @@ def test_generate_title_event_elevation(fake_collection_metadata: CollectionMeta
     fake_collection_metadata["category"] = "dsm"
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay - Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
@@ -88,7 +106,9 @@ def test_generate_title_event_satellite_imagery(fake_collection_metadata: Collec
     fake_collection_metadata["category"] = "satellite-imagery"
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
@@ -96,14 +116,18 @@ def test_generate_title_event_satellite_imagery(fake_collection_metadata: Collec
 def test_generate_dsm_title_preview(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["category"] = "dsm"
     fake_collection_metadata["lifecycle"] = "preview"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay LiDAR 0.3m DSM (2023) - Preview"
     assert collection.stac["title"] == title
 
 
 def test_generate_imagery_title_draft(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["lifecycle"] = "ongoing"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023) - Draft"
     assert collection.stac["title"] == title
 
@@ -112,7 +136,11 @@ def test_generate_imagery_title_without_suffix(fake_collection_metadata: Collect
     # `ongoing` lifecycle nominal case adds a suffix
     fake_collection_metadata["lifecycle"] = "ongoing"
     collection = ImageryCollection(
-        metadata=fake_collection_metadata, now=any_epoch_datetime, linz_slug=fake_linz_slug, add_title_suffix=False
+        metadata=fake_collection_metadata,
+        created_datetime=any_epoch_datetime_string(),
+        updated_datetime=any_epoch_datetime_string(),
+        linz_slug=fake_linz_slug,
+        add_title_suffix=False,
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
@@ -121,7 +149,9 @@ def test_generate_imagery_title_without_suffix(fake_collection_metadata: Collect
 def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["geographic_description"] = ""
     fake_collection_metadata["event_name"] = ""
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
@@ -129,6 +159,8 @@ def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: Col
 def test_generate_imagery_title_with_event(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
     fake_collection_metadata["event_name"] = "Forest Assessment"
-    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
     title = "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title

--- a/scripts/stac/imagery/tests/item_test.py
+++ b/scripts/stac/imagery/tests/item_test.py
@@ -15,7 +15,7 @@ from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.tests.generators import any_stac_asset, any_stac_processing
 from scripts.stac.link import Relation
 from scripts.stac.util.media_type import StacMediaType
-from scripts.tests.datetimes_test import any_epoch_datetime
+from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
 def test_imagery_stac_item(subtests: SubTests) -> None:
@@ -123,7 +123,13 @@ def test_imagery_add_collection(fake_linz_slug: str, subtests: SubTests) -> None
         "geographic_description": None,
     }
     ulid = "fake_ulid"
-    collection = ImageryCollection(metadata=metadata, now=any_epoch_datetime, linz_slug=fake_linz_slug, collection_id=ulid)
+    collection = ImageryCollection(
+        metadata=metadata,
+        created_datetime=any_epoch_datetime_string(),
+        updated_datetime=any_epoch_datetime_string(),
+        linz_slug=fake_linz_slug,
+        collection_id=ulid,
+    )
 
     path = "./scripts/tests/data/empty.tiff"
     id_ = get_file_name_from_path(path)

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -12,13 +12,13 @@ from pytest import CaptureFixture, raises
 from pytest_subtests import SubTests
 
 from scripts.collection_from_items import NoItemsError, main
-from scripts.datetimes import utc_now
 from scripts.files.fs_s3 import write
 from scripts.json_codec import dict_to_json_bytes
 from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.tests.generators import any_stac_asset, any_stac_processing
+from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
@@ -70,6 +70,8 @@ def test_should_create_collection_file(item: ImageryItem, fake_linz_slug: str) -
         "Placeholder",
         "--concurrency",
         "25",
+        "--current-datetime",
+        any_epoch_datetime_string(),
         "--linz-slug",
         fake_linz_slug,
     ]
@@ -113,6 +115,8 @@ def test_should_fail_if_collection_has_no_matching_items(
         "Placeholder",
         "--concurrency",
         "25",
+        "--current-datetime",
+        any_epoch_datetime_string(),
         "--linz-slug",
         fake_linz_slug,
     ]
@@ -173,7 +177,9 @@ def test_should_not_add_if_not_item(fake_linz_slug: str, capsys: CaptureFixture[
         "geographic_description": None,
         "historic_survey_number": None,
     }
-    existing_collection = ImageryCollection(metadata, utc_now, fake_linz_slug, collection_id)
+    existing_collection = ImageryCollection(
+        metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug, collection_id
+    )
     write("s3://stacfiles/collection.json", dict_to_json_bytes(existing_collection.stac))
     # CLI arguments
     args = [
@@ -195,6 +201,8 @@ def test_should_not_add_if_not_item(fake_linz_slug: str, capsys: CaptureFixture[
         "Placeholder",
         "--concurrency",
         "25",
+        "--current-datetime",
+        any_epoch_datetime_string(),
         "--linz-slug",
         fake_linz_slug,
     ]
@@ -236,6 +244,8 @@ def test_should_determine_dates_from_items(item: ImageryItem, fake_linz_slug: st
         "Placeholder",
         "--concurrency",
         "25",
+        "--current-datetime",
+        any_epoch_datetime_string(),
         "--linz-slug",
         fake_linz_slug,
     ]


### PR DESCRIPTION
### Motivation

Ensure that the STAC Collection `properties.created` datetime is not changed when resupplying.

### Modifications

- Add `--published-path` parameter to `collection_from_items.py`, to get created datetime on resupply.
- Add `--current-datetime` parameter to `collection_from_items.py` to use that instead of the actual clock time for created/updated datetimes.

### Verification

<!-- TODO: Say how you tested your changes. -->
