### PR TITLE
fix: Make capture area geometry valid TDE-1306

### DIFF
--- a/scripts/stac/imagery/capture_area.py
+++ b/scripts/stac/imagery/capture_area.py
@@ -4,6 +4,7 @@ from typing import Any, Sequence
 
 from linz_logger import get_log
 from shapely import BufferCapStyle, BufferJoinStyle, to_geojson, union_all, wkt
+from shapely.constructive import make_valid
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import orient
 
@@ -67,7 +68,7 @@ def merge_polygons(polygons: Sequence[BaseGeometry], buffer_distance: float) -> 
     # Ref: https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6
     oriented_union_simplified = orient(union_rounded, sign=1.0)
 
-    return oriented_union_simplified
+    return make_valid(oriented_union_simplified)
 
 
 def generate_capture_area(polygons: Sequence[BaseGeometry], gsd: Decimal) -> dict[str, Any]:


### PR DESCRIPTION
Caveat: Shapely's `BaseGeometry.buffer` produces different results on different machines, even with exactly the same Python package versions installed. To reproduce, change `test_should_make_valid_capture_area` to run with a buffer distance of `0.3`, and revert the change in `merge_polygons`. At this point the test passes on my machine, but fails on @schmidtnz's machine! We tracked this down to the line `union_buffered.buffer(-buffer_distance, cap_style=BufferCapStyle.flat, join_style=BufferJoinStyle.mitre)`. With the changes mentioned above, this returns a `MultiPolygon` on my machine (basically doing the same as `make_valid`, and therefore making the test pass), and a `Polygon` on @schmidtnz's machine (making the `make_valid` necessary to produce a valid polygon).

### Motivation

Ensure that published `capture-area.geojson` files are valid.

### Modifications

Use [Shapely's `make_valid`](https://shapely.readthedocs.io/en/2.0.4/reference/shapely.make_valid.html) before saving the geometry.

### Verification

- [x] Unit test
- [x] Verify in QGIS:
   1. `nix-shell --packages qgis --run qgis`
   3. Press <kbd>Ctrl-l</kbd>
   4. Open one of the `capture-area.geojson` files created by the unit test (for example by pausing the test at the assert)
   5. Go to Vector → Geometry Tools → Check Validity
   6. Press _Run_
   7. Verify that it prints `INVALID_COUNT: 0` and `ERROR_COUNT: 0`