### PR TITLE
refactor: Use boto3 clients rather than resources TDE-1034

### DIFF
--- a/scripts/aws/aws_helper.py
+++ b/scripts/aws/aws_helper.py
@@ -1,7 +1,7 @@
 import json
 from os import environ
 from time import sleep
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import urlparse
 
 from boto3 import Session
@@ -10,6 +10,11 @@ from botocore.session import Session as BotocoreSession
 from linz_logger import get_log
 
 from scripts.aws.aws_credential_source import CredentialSource
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+else:
+    S3Client = dict
 
 S3Path = NamedTuple("S3Path", [("bucket", str), ("key", str)])
 
@@ -26,9 +31,9 @@ bucket_config_path = environ.get("AWS_ROLE_CONFIG_PATH", "s3://linz-bucket-confi
 
 def _init_roles() -> None:
     """Load bucket to roleArn mapping for LINZ internal buckets from SSM"""
-    s3 = session.resource("s3")
+    s3_client: S3Client = session.client("s3")
     bucket, key = parse_path(bucket_config_path)
-    content_object = s3.Object(bucket, key)
+    content_object = s3_client.Object(bucket, key)
     file_content = content_object.get()["Body"].read().decode("utf-8")
     json_content = json.loads(file_content)
 

--- a/scripts/aws/aws_helper.py
+++ b/scripts/aws/aws_helper.py
@@ -27,8 +27,8 @@ bucket_config_path = environ.get("AWS_ROLE_CONFIG_PATH", "s3://linz-bucket-confi
 def _init_roles() -> None:
     """Load bucket to roleArn mapping for LINZ internal buckets from SSM"""
     s3 = session.resource("s3")
-    config_path = parse_path(bucket_config_path)
-    content_object = s3.Object(config_path.bucket, config_path.key)
+    bucket, key = parse_path(bucket_config_path)
+    content_object = s3.Object(bucket, key)
     file_content = content_object.get()["Body"].read().decode("utf-8")
     json_content = json.loads(file_content)
 

--- a/scripts/aws/tests/aws_helper_test.py
+++ b/scripts/aws/tests/aws_helper_test.py
@@ -6,13 +6,13 @@ from scripts.cli.cli_helper import is_argo
 
 def test_parse_path_s3(subtests: SubTests) -> None:
     s3_path = "s3://bucket-name/path/to/the/file.test"
-    path = parse_path(s3_path)
+    bucket, key = parse_path(s3_path)
 
     with subtests.test():
-        assert path.bucket == "bucket-name"
+        assert bucket == "bucket-name"
 
     with subtests.test():
-        assert path.key == "path/to/the/file.test"
+        assert key == "path/to/the/file.test"
 
 
 def test_parse_path_local() -> None:

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import os
 from argparse import Namespace
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import shapely.geometry
 import shapely.ops
@@ -16,6 +16,11 @@ from scripts.files.fs_s3 import bucket_name_from_path, get_object_parallel_multi
 from scripts.logging.time_helper import time_in_ms
 from scripts.stac.imagery.create_stac import create_collection
 from scripts.stac.imagery.metadata_constants import DATA_CATEGORIES, HUMAN_READABLE_REGIONS, CollectionMetadata
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+else:
+    S3Client = GetObjectOutputTypeDef = dict
 
 
 class NoItemsError(Exception):
@@ -114,7 +119,7 @@ def main(args: List[str] | None = None) -> None:
         msg = f"uri is not a s3 path: {uri}"
         raise argparse.ArgumentTypeError(msg)
 
-    s3_client = client("s3")
+    s3_client: S3Client = client("s3")
 
     files_to_read = list_files_in_uri(uri, [SUFFIX_JSON, SUFFIX_FOOTPRINT], s3_client)
 

--- a/scripts/files/fs.py
+++ b/scripts/files/fs.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from boto3 import resource
+from boto3 import client
 from linz_logger import get_log
 
 from scripts.aws.aws_helper import is_s3
@@ -47,7 +47,7 @@ def read(path: str) -> bytes:
         try:
             return fs_s3.read(path)
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services
-        except resource("s3").meta.client.exceptions.ClientError as ce:
+        except client("s3").exceptions.ClientError as ce:
             # Error Code can be found here:
             # https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
             if ce.response["Error"]["Code"] == "NoSuchKey":

--- a/scripts/files/fs_s3.py
+++ b/scripts/files/fs_s3.py
@@ -95,8 +95,8 @@ def exists(path: str, needs_credentials: bool = False) -> bool:
         needs_credentials: if acces to object needs credentials. Defaults to False.
 
     Raises:
-        ce: s3_client.exceptions.ClientError
-        nsb: NoSuchBucket
+        s3_client.exceptions.ClientError
+        NoSuchBucket
 
     Returns:
         True if the S3 Object exists

--- a/scripts/files/tests/fs_test.py
+++ b/scripts/files/tests/fs_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 
-from boto3 import client, resource
+from boto3 import client
 from moto import mock_aws
 from moto.core.models import DEFAULT_ACCOUNT_ID
 from moto.s3.models import s3_backends
@@ -24,8 +24,8 @@ def test_read_key_not_found_local() -> None:
 
 @mock_aws
 def test_read_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
-    s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
-    s3.create_bucket(Bucket="testbucket")
+    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="testbucket")
 
     with raises(NoSuchFileError):
         read("s3://testbucket/test.file")
@@ -48,8 +48,8 @@ def test_write_sidecars_file_not_found_local(capsys: CaptureFixture[str]) -> Non
 
 @mock_aws
 def test_write_all_key_not_found_s3() -> None:
-    s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
-    s3.create_bucket(Bucket="testbucket")
+    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="testbucket")
 
     # Raises an exception as all files are not written
     with raises(Exception) as e:
@@ -60,8 +60,8 @@ def test_write_all_key_not_found_s3() -> None:
 
 @mock_aws
 def test_write_sidecars_key_not_found_s3(capsys: CaptureFixture[str]) -> None:
-    s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
-    s3.create_bucket(Bucket="testbucket")
+    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="testbucket")
 
     write_sidecars(["s3://testbucket/test.prj"], "/tmp")
 

--- a/scripts/gdal/gdal_helper.py
+++ b/scripts/gdal/gdal_helper.py
@@ -66,7 +66,7 @@ def run_gdal(
         output_file: the output file path
 
     Raises:
-        cpe: CalledProcessError is raised if something goes wrong during the execution of the command
+        CalledProcessError is raised if something goes wrong during the execution of the command
 
     Returns:
         subprocess.CompletedProcess: the output process.

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -5,9 +5,10 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 import shapely.geometry
-from boto3 import resource
+from boto3 import client
 from moto import mock_aws
 from moto.s3.responses import DEFAULT_REGION_NAME
+from mypy_boto3_s3 import S3Client
 from pytest_subtests import SubTests
 from shapely.predicates import is_valid
 
@@ -334,7 +335,8 @@ def test_capture_area_added(fake_collection_metadata: CollectionMetadata, fake_l
 
     with subtests.test():
         assert collection.stac["assets"]["capture_area"]["file:checksum"] in (
-            "1220ba57cd77defc7fa72e140f4faa0846e8905ae443de04aef99bf381d4650c17a0",  # geos 3.11 - geos 3.12 as yet untested
+            "1220ba57cd77defc7fa72e140f4faa0846e8905ae443de04aef99bf381d4650c17a0",
+            # geos 3.11 - geos 3.12 as yet untested
         )
 
     with subtests.test():
@@ -385,8 +387,8 @@ def test_linz_slug_is_present(fake_collection_metadata: CollectionMetadata, fake
 @mock_aws
 def test_capture_dates_added(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime, fake_linz_slug)
-    s3 = resource("s3", region_name=DEFAULT_REGION_NAME)
-    s3.create_bucket(Bucket="flat")
+    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="flat")
     write("s3://flat/capture-dates.geojson", b"")
     collection.add_capture_dates("s3://flat")
     assert collection.stac["assets"]["capture_dates"] == {

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -35,9 +35,9 @@ def test_title_description_id_created_on_init(
         assert collection.stac["title"] == "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
 
     with subtests.test():
-        assert (
-            collection.stac["description"]
-            == "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, published as a record of the Forest Assessment event."  # pylint: disable=line-too-long
+        assert collection.stac["description"] == (
+            "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, "
+            "published as a record of the Forest Assessment event."
         )
 
     with subtests.test():


### PR DESCRIPTION
### Motivation

The latter is deprecated
<https://boto3.amazonaws.com/v1/documentation/api/1.35.60/guide/resources.html>.

### Modifications

- Use the lower-level clients API instead of resources.
- Type annotate S3 clients to make IDE use easier.

### Verification

Standard tests.