### PR TITLE
ci: publish PR container on ECR

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
-        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:')) || github.event.label.name == 'container'}}
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
           aws-region: ap-southeast-2
@@ -59,7 +59,7 @@ jobs:
           role-to-assume: ${{ env.AWS_CI_ROLE }}
 
       - name: Login to Amazon ECR
-        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:')) || github.event.label.name == 'container'}}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
 
@@ -70,16 +70,21 @@ jobs:
           result-encoding: string
           script: |
             const tags = [];
+
             if ('${{github.event.label.name}}' == 'container') {
               tags.push('ghcr.io/${{ github.repository }}:pr-${{github.event.number}}');
+              if ("${{ steps.login-ecr.outputs.registry }}") {
+                tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:pr-${{ github.event.number }}');
+              }
             } else {
               tags.push('ghcr.io/${{ github.repository }}:latest');
-              tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}'); 
+              tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
+              if ("${{ steps.login-ecr.outputs.registry }}") {
+                tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
+                tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
+              }
             }
-            if ("${{ steps.login-ecr.outputs.registry }}") {
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
-            }
+
             return tags.join(', ')
 
       - name: Build and push container


### PR DESCRIPTION
### Motivation

When testing a "Pull Request" container with an existing Argo Workflows WorkflowTemplate, it makes it easier to replace [the container version parameter](https://github.com/linz/topo-workflows/blob/d59d28c639974fb19c0279535fde28e4e85e4b67/workflows/raster/standardising.yaml#L44) rather than publishing a new workflow having to modify [the full container link](https://github.com/linz/topo-workflows/blob/d59d28c639974fb19c0279535fde28e4e85e4b67/workflows/raster/standardising.yaml#L513). However, note that you should still do your test using a `test-*` generated name for your workflow run.

### Modifications

If the `container` label is added to a PR, the container is also published on ECR.

### Verification

Should verify in this PR.
