### PR TITLE
feat: defaults for current-datetime argument TDE-1298

### DIFF
--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sys
+from datetime import datetime, timezone
 
 from linz_logger import get_log
 
@@ -75,7 +76,8 @@ def parse_args() -> argparse.Namespace:
             "The datetime to be used as current datetime in the metadata. "
             "Format: RFC 3339 UTC datetime, `YYYY-MM-DDThh:mm:ssZ`."
         ),
-        required=True,
+        required=False,
+        default=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
     return parser.parse_args()
 

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from linz_logger import get_log
 
 from scripts.cli.cli_helper import InputParameterError, is_argo, load_input_files, str_to_gsd, valid_date
-from scripts.datetimes import format_rfc_3339_nz_midnight_datetime_string
+from scripts.datetimes import RFC_3339_DATETIME_FORMAT, format_rfc_3339_nz_midnight_datetime_string
 from scripts.files.file_tiff import FileTiff
 from scripts.files.files_helper import SUFFIX_JSON, ContentType
 from scripts.files.fs import exists, write
@@ -77,7 +77,7 @@ def parse_args() -> argparse.Namespace:
             "Format: RFC 3339 UTC datetime, `YYYY-MM-DDThh:mm:ssZ`."
         ),
         required=False,
-        default=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        default=datetime.now(timezone.utc).strftime(RFC_3339_DATETIME_FORMAT),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
### Motivation

As a basemaps developer, I do not want to set many mandatory CLI arguments.

### Modifications

Added the current date / time as a semi-sane default for the `--current-date` command line argument

### Verification

`pytest`
