### PR TITLE
fix: handle existing derived_from links when Item is updated TDE-1356

### DIFF
--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -130,6 +130,9 @@ def create_item(
         gdalinfo_result = gdal_info(asset_path)
 
     if derived_from is not None:
+        # Remove existing derived_from links in case of resupply
+        item.stac["links"] = [link for link in item.stac["links"] if link["rel"] != "derived_from"]
+
         for derived in derived_from:
             derived_item_content = read(derived)
             derived_stac = json.loads(derived_item_content.decode("UTF-8"))

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -129,10 +129,11 @@ def create_item(
     if not gdalinfo_result:
         gdalinfo_result = gdal_info(asset_path)
 
-    if derived_from is not None:
+    if item.stac.get("links") is not None:
         # Remove existing derived_from links in case of resupply
         item.stac["links"] = [link for link in item.stac["links"] if link["rel"] != "derived_from"]
 
+    if derived_from is not None:
         for derived in derived_from:
             derived_item_content = read(derived)
             derived_stac = json.loads(derived_item_content.decode("UTF-8"))

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -46,11 +46,27 @@ def test_create_item_when_resupplying(subtests: SubTests, tmp_path: Path) -> Non
     item_name = "empty"
     existing_item = tmp_path / f"{item_name}.json"
     tiff_path = f"./scripts/tests/data/{item_name}.tiff"
+    derived_from_path = "./scripts/tests/data/fake_item.json"
     created_datetime = "created datetime"
     updated_datetime = "updated datetime"
+    links = [
+        {
+            "href": derived_from_path,
+            "rel": "derived_from",
+            "type": "application/geo+json",
+            "file:checksum": "1220f33d983b9c84d3d0c44f37f4a1b842295a960abcdd3889b898f42988f9e93604",
+        },
+        {
+            "href": "path/to/an/old/derived_from",
+            "rel": "derived_from",
+            "type": "application/geo+json",
+            "file:checksum": "123",
+        },
+    ]
     existing_item_content = {
         "type": "Feature",
         "id": item_name,
+        "links": links,
         "assets": {
             "visual": {
                 "href": tiff_path,
@@ -77,6 +93,7 @@ def test_create_item_when_resupplying(subtests: SubTests, tmp_path: Path) -> Non
         "any GDAL version",
         current_datetime,
         fake_gdal_info,
+        derived_from=[derived_from_path],
         odr_url=tmp_path.as_posix(),
     )
 
@@ -91,6 +108,9 @@ def test_create_item_when_resupplying(subtests: SubTests, tmp_path: Path) -> Non
 
     with subtests.test(msg="assets.visual.updated"):
         assert item.stac["assets"]["visual"]["updated"] == updated_datetime
+
+    with subtests.test(msg="links"):
+        assert len(item.stac["links"]) == 3
 
 
 def test_create_item_when_resupplying_with_changed_file(subtests: SubTests, tmp_path: Path) -> None:

--- a/scripts/tests/data/fake_item.json
+++ b/scripts/tests/data/fake_item.json
@@ -1,0 +1,8 @@
+{
+  "type": "Feature",
+  "id": "Fake Item",
+  "properties": {
+    "start_datetime": "2018-11-30T11:00:00Z",
+    "end_datetime": "2020-01-31T11:00:00Z"
+  }
+}


### PR DESCRIPTION
### Motivation

When a published Item with `derived_from` links is resupplied, its existing list of `derived_from` links may have changed with the resupply. The current implementation would duplicate existing `derived_from` links and left obsolete ones. It will also remove any `derived_from` links in case of the Item is not derived from other Items anymore.

### Modifications

Remove existing `derived_from` links to the STAC Item before processing the current `derived_from` links list.

### Verification

Pytest
Argo Workflows
