### PR TITLE
fix: deprecated artifact action TDE-1379

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -78,7 +78,7 @@ jobs:
           empty_target_directory="$(find "${{ runner.temp }}/tmp-empty" -maxdepth 0 -type d -empty)"
           [[ -n "$empty_target_directory" ]]
 
-      - uses: actions/upload-artifact@v3.1.3
+      - uses: actions/upload-artifact@v4.6.0
         with:
           name: gdal-output
           path: ${{ runner.temp }}/*.tiff


### PR DESCRIPTION
### Motivation

Github is deprecating v3 of the artifact actions.

### Modifications

Update version of upload-artifact to current latest version number 4.6.0

### Verification

Ran action without the `if: failure()` condition and it successfully uploaded all artifacts.
