### PR TITLE
feat: add resolution argument to gdalbuildvrt TDE-1383

### DIFF
--- a/scripts/gdal/gdal_commands.py
+++ b/scripts/gdal/gdal_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from linz_logger import get_log
 
 from scripts.gdal.gdal_bands import get_gdal_band_offset
@@ -71,22 +73,29 @@ def get_cutline_command(cutline: str | None) -> list[str]:
     return gdal_command
 
 
-def get_build_vrt_command(files: list[str], output: str = "output.vrt", add_alpha: bool = False) -> list[str]:
+def get_build_vrt_command(
+    files: list[str], output: str = "output.vrt", add_alpha: bool = False, resolution: list[int] | None = None
+) -> list[str]:
     """Build a VRT from a list of tiff files.
 
     Args:
         files: list of tiffs to build the vrt from
         output: the name of the VRT generated. Defaults to "output.vrt".
         add_alpha: use `-addalpha`. Defaults to False.
+        resolution: set user-defined resolution [xres, yres], e.g. [1, 1]
 
     Returns:
         The GDAL command to build the VRT.
     """
     # `-allow_projection_difference` is passed to workaround different coordinate system descriptions within the same EPSG
     # Having the same EPSG code for all images is already checked by `linz/argo-tasks` `tile-index-validate`
-    gdal_command = ["gdalbuildvrt", "-resolution", "highest", "-strict", "-allow_projection_difference"]
+    gdal_command = ["gdalbuildvrt", "-strict", "-allow_projection_difference"]
     if add_alpha:
         gdal_command.append("-addalpha")
+    if resolution is not None:
+        gdal_command.extend(["-resolution", "user", "-tr"])
+        gdal_command.extend(str(xy) for xy in resolution)
+
     gdal_command.append(output)
     gdal_command += files
 

--- a/scripts/gdal/gdal_commands.py
+++ b/scripts/gdal/gdal_commands.py
@@ -121,7 +121,7 @@ def get_alpha_command() -> list[str]:
     ]
 
 
-def get_transform_srs_command(source_epsg: str, target_epsg: str) -> list[str]:
+def get_transform_srs_command(source_epsg: int, target_epsg: int) -> list[str]:
     """Get a `gdalwarp` command to transform the srs.
 
     Args:

--- a/scripts/gdal/gdal_commands.py
+++ b/scripts/gdal/gdal_commands.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 from linz_logger import get_log
 
 from scripts.gdal.gdal_bands import get_gdal_band_offset
@@ -74,7 +76,7 @@ def get_cutline_command(cutline: str | None) -> list[str]:
 
 
 def get_build_vrt_command(
-    files: list[str], output: str = "output.vrt", add_alpha: bool = False, resolution: list[int] | None = None
+    files: list[str], output: str = "output.vrt", add_alpha: bool = False, resolution: list[Decimal] | None = None
 ) -> list[str]:
     """Build a VRT from a list of tiff files.
 

--- a/scripts/gdal/gdal_commands.py
+++ b/scripts/gdal/gdal_commands.py
@@ -84,7 +84,7 @@ def get_build_vrt_command(files: list[str], output: str = "output.vrt", add_alph
     """
     # `-allow_projection_difference` is passed to workaround different coordinate system descriptions within the same EPSG
     # Having the same EPSG code for all images is already checked by `linz/argo-tasks` `tile-index-validate`
-    gdal_command = ["gdalbuildvrt", "-strict", "-allow_projection_difference"]
+    gdal_command = ["gdalbuildvrt", "-resolution", "highest", "-strict", "-allow_projection_difference"]
     if add_alpha:
         gdal_command.append("-addalpha")
     gdal_command.append(output)

--- a/scripts/gdal/gdal_commands.py
+++ b/scripts/gdal/gdal_commands.py
@@ -84,7 +84,7 @@ def get_build_vrt_command(
         files: list of tiffs to build the vrt from
         output: the name of the VRT generated. Defaults to "output.vrt".
         add_alpha: use `-addalpha`. Defaults to False.
-        resolution: set user-defined resolution [xres, yres], e.g. [1, 1]
+        resolution: set user-defined resolution [xres, yres], e.g. [1, 1]. Defaults to None = no scaling.
 
     Returns:
         The GDAL command to build the VRT.

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -26,9 +26,9 @@ def str_to_bool(value: str) -> bool:
 
 
 def str_to_list_or_none(values: str) -> list[Decimal] | None:
-    if values is None or values == "":
+    if not values:
         return None
-    result = [Decimal(val) for val in values.split(",")]
+    result = [Decimal(value) for value in values.split(",")]
     if len(result) != 2:
         raise argparse.ArgumentTypeError(f"Invalid list - must be blank or exactly 2 values x,y. Received: {values}")
     return result
@@ -160,13 +160,7 @@ def main() -> None:
 
     gdal_version = os.environ["GDAL_VERSION"]
 
-    tiff_files = run_standardising(
-        tile_files,
-        standardising_config,
-        concurrency,
-        gdal_version,
-        arguments.target,
-    )
+    tiff_files = run_standardising(tile_files, standardising_config, concurrency, gdal_version, arguments.target)
 
     if len(tiff_files) == 0:
         get_log().info("no_tiff_to_process", action="standardise_validate", reason="skipped")

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 from datetime import datetime, timezone
+from decimal import Decimal
 
 from linz_logger import get_log
 
@@ -22,6 +23,15 @@ def str_to_bool(value: str) -> bool:
     if value == "false":
         return False
     raise argparse.ArgumentTypeError(f"Invalid boolean (must be exactly 'true' or 'false'): {value}")
+
+
+def str_to_list_or_none(values: str) -> list[Decimal] | None:
+    if values is None or values == "":
+        return None
+    result = [Decimal(val) for val in values.split(",")]
+    if len(result) != 2:
+        raise argparse.ArgumentTypeError(f"Invalid list (must be blank or exactly 2 values): {values}")
+    return result
 
 
 def parse_args() -> argparse.Namespace:
@@ -78,6 +88,14 @@ def parse_args() -> argparse.Namespace:
         ),
         required=False,
         default=datetime.now(timezone.utc).strftime(RFC_3339_DATETIME_FORMAT),
+    )
+    parser.add_argument(
+        "--scale-to-resolution",
+        dest="scale_to_resolution",
+        type=str_to_list_or_none,
+        nargs="?",
+        help="Scale to x,y resolution (leave blank for no scaling)",
+        required=False,
     )
     return parser.parse_args()
 
@@ -140,6 +158,7 @@ def main() -> None:
         arguments.create_footprints,
         gdal_version,
         arguments.target,
+        arguments.scale_to_resolution,
     )
 
     if len(tiff_files) == 0:

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import tempfile
 from decimal import Decimal
@@ -85,20 +87,21 @@ def run_standardising(
     return standardized_tiffs
 
 
-def create_vrt(source_tiffs: list[str], target_path: str, add_alpha: bool = False) -> str:
+def create_vrt(source_tiffs: list[str], target_path: str, add_alpha: bool = False, resolution: list[int] | None = None) -> str:
     """Create a VRT from a list of tiffs files
 
     Args:
         source_tiffs: list of tiffs to create the VRT from
         target_path: path of the generated VRT
         add_alpha: add alpha band to the VRT. Defaults to False.
+        resolution: set user-defined resolution [xres, yres], e.g. [1, 1]
 
     Returns:
         the path to the VRT created
     """
     # Create the `vrt` file
     vrt_path = os.path.join(target_path, "source.vrt")
-    run_gdal(command=get_build_vrt_command(files=source_tiffs, output=vrt_path, add_alpha=add_alpha))
+    run_gdal(command=get_build_vrt_command(files=source_tiffs, output=vrt_path, add_alpha=add_alpha, resolution=resolution))
     return vrt_path
 
 

--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -87,7 +87,9 @@ def run_standardising(
     return standardized_tiffs
 
 
-def create_vrt(source_tiffs: list[str], target_path: str, add_alpha: bool = False, resolution: list[int] | None = None) -> str:
+def create_vrt(
+    source_tiffs: list[str], target_path: str, add_alpha: bool = False, resolution: list[Decimal] | None = None
+) -> str:
     """Create a VRT from a list of tiffs files
 
     Args:
@@ -140,6 +142,7 @@ def standardising(
     footprint_file_path = os.path.join(target_output, footprint_file_name)
     tiff = FileTiff(files.inputs, preset, files.includeDerived)
     tiff.set_path_standardised(standardized_file_path)
+    resolution = [gsd, gsd]
 
     # Already proccessed can skip processing
     if exists(standardized_file_path):
@@ -170,7 +173,7 @@ def standardising(
                 vrt_add_alpha = False
 
         # Start from base VRT
-        input_file = create_vrt(source_tiffs, tmp_path, add_alpha=vrt_add_alpha)
+        input_file = create_vrt(source_tiffs, tmp_path, add_alpha=vrt_add_alpha, resolution=resolution)
 
         # Apply cutline
         if cutline:


### PR DESCRIPTION
### Motivation

To generate a national combined hillshade product, we need to be able to combine inputs of differing resolutions and ensure consistent output.
The default settings of `gdalbuildvrt` will average all input resolutions. This change implements a more suitable setting for our use-case.

### Modifications
Add optional `resolution` argument to  `get_build_vrt_command()`, which will in turn add `-resolution user -tr <xres> <yres>` arguments to the respective GDAL command.

`standardising()` now accepts a list `scale_to_resolution = [x_res, y_res]` to support the above.

### Verification

Manual test run with combined DEM hillshades.
