### PR TITLE
feat: titles and descriptions for hillshade products TDE-1378

### DIFF
--- a/scripts/stac/imagery/metadata_constants.py
+++ b/scripts/stac/imagery/metadata_constants.py
@@ -46,6 +46,8 @@ SATELLITE_IMAGERY = "satellite-imagery"
 URBAN_AERIAL_PHOTOS = "urban-aerial-photos"
 DEM = "dem"
 DSM = "dsm"
+DEM_HILLSHADE = "dem-hillshade"
+DEM_HILLSHADE_IGOR = "dem-hillshade-igor"
 
 DATA_CATEGORIES = {
     AERIAL_PHOTOS: "Aerial Photos",
@@ -55,8 +57,9 @@ DATA_CATEGORIES = {
     URBAN_AERIAL_PHOTOS: "Urban Aerial Photos",
     DEM: "DEM",
     DSM: "DSM",
+    DEM_HILLSHADE: "DEM Hillshade",
+    DEM_HILLSHADE_IGOR: "DEM Hillshade Igor",
 }
-
 
 HUMAN_READABLE_REGIONS = {
     "antarctica": "Antarctica",
@@ -79,4 +82,9 @@ HUMAN_READABLE_REGIONS = {
     "waikato": "Waikato",
     "wellington": "Wellington",
     "west-coast": "West Coast",
+}
+
+LIFECYCLE_SUFFIXES = {
+    "preview": "- Preview",
+    "ongoing": "- Draft",
 }


### PR DESCRIPTION
### Motivation

In order to generate a national hillshade product, we need suitable titles and descriptions for these datasets.

### Modifications

* Implement tests for new DEM hillshade descriptions and titles.
* Add suitable constants to metadata_constants.py
* Update collection.py `ImageryCollection()` `_title()` and `_description()` methods to support two new DEM hillshade types.
* Refactor changed methods in collection.py for consistency and flow.

### Verification
Newly implemented unit tests.