### PR TITLE
fix: should not raise error when cutline is empty TDE-1392

### DIFF
--- a/scripts/standardising.py
+++ b/scripts/standardising.py
@@ -49,7 +49,7 @@ class StandardisingConfig:
     scale_to_resolution: list[Decimal] | None = None
 
     def __post_init__(self) -> None:
-        if self.cutline is not None and not self.cutline.endswith((".fgb", ".geojson")):
+        if self.cutline and not self.cutline.endswith((".fgb", ".geojson")):
             raise ValueError(f"Only .fgb or .geojson cutlines are supported: {self.cutline}")
         if self.scale_to_resolution is not None and len(self.scale_to_resolution) != 2:
             raise ValueError(f"scale_to_resolution must be exactly two items [xres, yres]: {self.scale_to_resolution}")


### PR DESCRIPTION
### Motivation

If user pass argument `--cutline=''` the standardising_validate script should not raise an error and should avoid the cutline value.

### Modifications

- fix bug

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
