### PR TITLE
fix(standardise-validate): allow empty string from Argo for start and end dates TDE-1346

### DIFF
--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -80,7 +80,9 @@ def is_argo() -> bool:
     return bool(environ.get("ARGO_TEMPLATE"))
 
 
-def valid_date(s: str) -> datetime:
+def valid_date(s: str) -> datetime | None:
+    if not s:
+        return None
     try:
         return parse_rfc_3339_date(s)
     except ValueError as e:

--- a/scripts/cli/tests/cli_helper_test.py
+++ b/scripts/cli/tests/cli_helper_test.py
@@ -1,6 +1,9 @@
+from datetime import datetime
+
+from pytest import raises
 from pytest_subtests import SubTests
 
-from scripts.cli.cli_helper import TileFiles, coalesce_multi_single, get_tile_files, parse_list
+from scripts.cli.cli_helper import TileFiles, coalesce_multi_single, get_tile_files, parse_list, valid_date
 
 
 def test_get_tile_files(subtests: SubTests) -> None:
@@ -71,3 +74,17 @@ def test_coalesce_nothing() -> None:
     single_item = ""
     coalesced_list = coalesce_multi_single(multi_items, single_item)
     assert coalesced_list == []
+
+
+def test_valid_date_empty_string() -> None:
+    assert valid_date("") is None
+
+
+def test_valid_date_valid_string() -> None:
+    assert isinstance(valid_date("2024-11-21"), datetime)
+
+
+def test_valid_date_invalid_string() -> None:
+    with raises(Exception) as e:
+        valid_date("foo")
+        assert str(e.value) == "not a valid date: foo"


### PR DESCRIPTION
### Motivation

Argo Workflows supplies single quotes for optional parameters, which are not valid dates. These are handled later in the `standardise_validate.py` code.

### Modifications

Allow an empty string to be accepted by the command line parser for the start and end dates.

### Verification

Added unit tests. Tested from Argo Workflows using a PR container.