### PR TITLE
fix: handle optional flags from Argo TDE-1346

### DIFF
--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -136,3 +136,20 @@ def str_to_gsd(value: str) -> Decimal:
         )
 
     return Decimal(number_value)
+
+
+def str_to_bool(value: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise argparse.ArgumentTypeError(f"Invalid boolean (must be exactly 'true' or 'false'): {value}")
+
+
+def str_to_list_or_none(values: str) -> list[Decimal] | None:
+    if not values:
+        return None
+    result = [Decimal(value) for value in values.split(",")]
+    if len(result) != 2:
+        raise argparse.ArgumentTypeError(f"Invalid list - must be blank or exactly 2 values x,y. Received: {values}")
+    return result

--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -139,6 +139,21 @@ def str_to_gsd(value: str) -> Decimal:
 
 
 def str_to_bool(value: str) -> bool:
+    """Transform a string to a boolean value
+
+    Example:
+        >>> str_to_bool("true")
+        True
+
+    Args:
+        str: string representing a boolean value
+
+    Raises:
+        ArgumentTypeError: if the string is not "true" or "false"
+
+    Returns:
+        bool: True if "true", False if "false"
+    """
     if value == "true":
         return True
     if value == "false":
@@ -147,6 +162,23 @@ def str_to_bool(value: str) -> bool:
 
 
 def str_to_list_or_none(values: str) -> list[Decimal] | None:
+    """Transform a string to an empty list of list with 2 values. Return None if the string is empty.
+
+    Example:
+        >>> str_to_list_or_none('2,4')
+        [Decimal('2'), Decimal('4')]
+        >>> str_to_list_or_none('') is None
+        True
+
+    Args:
+        str: string representing a list or an empty string
+
+    Raises:
+        ArgumentTypeError: if the string is not empty and does not contain exactly 2 values
+
+    Returns:
+        None or a list of 2 values
+    """
     if not values:
         return None
     result = [Decimal(value) for value in values.split(",")]

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -103,7 +103,6 @@ def parse_args(args: List[str] | None) -> Namespace:
         help="Add a capture-dates.geojson.gz file to the collection assets",
         type=str_to_bool,
         required=False,
-        default=False,
     )
     parser.add_argument(
         "--add-title-suffix",
@@ -111,7 +110,6 @@ def parse_args(args: List[str] | None) -> Namespace:
         help="Add a title suffix to the collection title based on the lifecycle. For example, '[TITLE] - Preview'",
         type=str_to_bool,
         required=False,
-        default=False,
     )
     parser.add_argument(
         "--current-datetime",
@@ -131,7 +129,6 @@ def parse_args(args: List[str] | None) -> Namespace:
 def main(args: List[str] | None = None) -> None:
     start_time = time_in_ms()
     arguments = parse_args(args)
-    print("capture dates:", arguments.capture_dates)
     uri = arguments.uri
     collection_id = arguments.collection_id
 

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -10,7 +10,7 @@ import shapely.ops
 from boto3 import client
 from linz_logger import get_log
 
-from scripts.cli.cli_helper import coalesce_multi_single, str_to_gsd
+from scripts.cli.cli_helper import coalesce_multi_single, str_to_bool, str_to_gsd
 from scripts.datetimes import RFC_3339_DATETIME_FORMAT, parse_rfc_3339_datetime
 from scripts.files.files_helper import SUFFIX_FOOTPRINT, SUFFIX_JSON
 from scripts.files.fs_s3 import bucket_name_from_path, get_object_parallel_multithreading, list_files_in_uri
@@ -100,16 +100,18 @@ def parse_args(args: List[str] | None) -> Namespace:
     parser.add_argument(
         "--capture-dates",
         dest="capture_dates",
-        action="store_true",
         help="Add a capture-dates.geojson.gz file to the collection assets",
+        type=str_to_bool,
         required=False,
+        default=False,
     )
     parser.add_argument(
         "--add-title-suffix",
         dest="add_title_suffix",
-        action="store_true",
         help="Add a title suffix to the collection title based on the lifecycle. For example, '[TITLE] - Preview'",
+        type=str_to_bool,
         required=False,
+        default=False,
     )
     parser.add_argument(
         "--current-datetime",
@@ -129,6 +131,7 @@ def parse_args(args: List[str] | None) -> Namespace:
 def main(args: List[str] | None = None) -> None:
     start_time = time_in_ms()
     arguments = parse_args(args)
+    print("capture dates:", arguments.capture_dates)
     uri = arguments.uri
     collection_id = arguments.collection_id
 

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -2,11 +2,18 @@ import argparse
 import os
 import sys
 from datetime import datetime, timezone
-from decimal import Decimal
 
 from linz_logger import get_log
 
-from scripts.cli.cli_helper import InputParameterError, is_argo, load_input_files, str_to_gsd, valid_date
+from scripts.cli.cli_helper import (
+    InputParameterError,
+    is_argo,
+    load_input_files,
+    str_to_bool,
+    str_to_gsd,
+    str_to_list_or_none,
+    valid_date,
+)
 from scripts.datetimes import RFC_3339_DATETIME_FORMAT, format_rfc_3339_nz_midnight_datetime_string
 from scripts.files.file_tiff import FileTiff
 from scripts.files.files_helper import SUFFIX_JSON, ContentType
@@ -15,23 +22,6 @@ from scripts.gdal.gdal_helper import get_srs, get_vfs_path
 from scripts.json_codec import dict_to_json_bytes
 from scripts.stac.imagery.create_stac import create_item
 from scripts.standardising import StandardisingConfig, run_standardising
-
-
-def str_to_bool(value: str) -> bool:
-    if value == "true":
-        return True
-    if value == "false":
-        return False
-    raise argparse.ArgumentTypeError(f"Invalid boolean (must be exactly 'true' or 'false'): {value}")
-
-
-def str_to_list_or_none(values: str) -> list[Decimal] | None:
-    if not values:
-        return None
-    result = [Decimal(value) for value in values.split(",")]
-    if len(result) != 2:
-        raise argparse.ArgumentTypeError(f"Invalid list - must be blank or exactly 2 values x,y. Received: {values}")
-    return result
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
### Motivation
Argo Workflows supplies single quotes where parameters are not supplied, which can happen if a workflow template is used by multiple workflows. This breaks optional parameters in argparse.

### Modifications

Convert Argo string to boolean to control adding the capture dates file and the title suffix, in line with how the capture area creation (footprint) is handled.

### Verification

Ran workflow in Argo and locally on the command line.