### PR TITLE
feat: reset Collection extents TDE-1359

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -196,10 +196,7 @@ class ImageryCollection:
         Args:
             item_bbox: bounding box of an item added to the Collection
         """
-        if "extent" not in self.stac:
-            self.update_extent(bbox=item_bbox)
-            return
-        if self.stac["extent"]["spatial"]["bbox"] == [None]:
+        if not self.stac.get("extent", {}).get("spatial", {}).get("bbox"):
             self.update_extent(bbox=item_bbox)
             return
 
@@ -219,10 +216,7 @@ class ImageryCollection:
             item_start_datetime: start date of an item added to the Collection
             item_end_datetime: end date of an item added to the Collection
         """
-        if "extent" not in self.stac:
-            self.update_extent(interval=[item_start_datetime, item_end_datetime])
-            return
-        if self.stac["extent"]["temporal"]["interval"] == [None]:
+        if not self.stac.get("extent", {}).get("temporal", {}).get("interval"):
             self.update_extent(interval=[item_start_datetime, item_end_datetime])
             return
 
@@ -253,17 +247,16 @@ class ImageryCollection:
             interval: datetime interval. Defaults to None.
         """
         if "extent" not in self.stac:
-            self.stac["extent"] = {
-                "spatial": {
-                    "bbox": [bbox],
-                },
-                "temporal": {"interval": [interval]},
-            }
-            return
+            self.reset_extents()
         if bbox:
             self.stac["extent"]["spatial"]["bbox"] = [bbox]
         if interval:
             self.stac["extent"]["temporal"]["interval"] = [interval]
+
+    def reset_extents(self) -> None:
+        """Reset the spatial and temporal extents of the Collection."""
+        self.stac.setdefault("extent", {}).setdefault("spatial", {})["bbox"] = None
+        self.stac.setdefault("extent", {}).setdefault("temporal", {})["interval"] = None
 
     def write_to(self, destination: str) -> None:
         """Write the Collection in JSON format to the specified `destination`.

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -247,13 +247,13 @@ class ImageryCollection:
             interval: datetime interval. Defaults to None.
         """
         if "extent" not in self.stac:
-            self.reset_extents()
+            self.reset_extent()
         if bbox:
             self.stac["extent"]["spatial"]["bbox"] = [bbox]
         if interval:
             self.stac["extent"]["temporal"]["interval"] = [interval]
 
-    def reset_extents(self) -> None:
+    def reset_extent(self) -> None:
         """Reset the spatial and temporal extents of the Collection."""
         self.stac.setdefault("extent", {}).setdefault("spatial", {})["bbox"] = None
         self.stac.setdefault("extent", {}).setdefault("temporal", {})["interval"] = None

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -506,3 +506,14 @@ def test_capture_dates_added(fake_collection_metadata: CollectionMetadata, fake_
         "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         "file:size": 0,
     }
+
+
+def test_reset_extents(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+    collection = ImageryCollection(
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+    )
+    collection.update_temporal_extent("2021-01-27T00:00:00Z", "2021-01-27T00:00:00Z")
+    collection.update_spatial_extent([1799667.5, 5815977.0, 1800422.5, 5814986.0])
+    collection.reset_extents()
+    assert collection.stac["extent"]["spatial"]["bbox"] is None
+    assert collection.stac["extent"]["temporal"]["interval"] is None

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -508,12 +508,12 @@ def test_capture_dates_added(fake_collection_metadata: CollectionMetadata, fake_
     }
 
 
-def test_reset_extents(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_reset_extent(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
     collection.update_temporal_extent("2021-01-27T00:00:00Z", "2021-01-27T00:00:00Z")
     collection.update_spatial_extent([1799667.5, 5815977.0, 1800422.5, 5814986.0])
-    collection.reset_extents()
+    collection.reset_extent()
     assert collection.stac["extent"]["spatial"]["bbox"] is None
     assert collection.stac["extent"]["temporal"]["interval"] is None


### PR DESCRIPTION
### Motivation

When updating an existing Collection, its extents has to be reset in order to be recalculated from the new list of Items.

### Modifications

- Allow to reset the Collection extents without removing its dictionnary entry to avoid potential change in the Collection dictionnary structure/order
- Refactor `update_extent()` for simplification

### Verification

Run unit tests
