### PR TITLE
revert: normalize capture-area geometry TDE-1359 (#1288) TDE-1423

### DIFF
--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -15,7 +15,7 @@ def test_merge_polygons() -> None:
     polygons = []
     polygons.append(Polygon([(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0), (0.0, 1.0)]))
     polygons.append(Polygon([(1.0, 1.0), (2.0, 1.0), (2.0, 0.0), (1.0, 0.0), (1.0, 1.0)]))
-    expected_merged_polygon = Polygon([(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0), (0.0, 0.0)])
+    expected_merged_polygon = Polygon([(1.0, 1.0), (0.0, 1.0), (0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (1.0, 1.0)])
     merged_polygons = merge_polygons(polygons, 0)
 
     print(f"Polygon A: {to_feature(polygons[0])}")
@@ -33,7 +33,7 @@ def test_merge_polygons_with_rounding() -> None:
     polygons.append(Polygon([(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0), (0.0, 1.0)]))
     # The following polygon is off by 0.1 to the "right" from the previous one
     polygons.append(Polygon([(1.1, 1.0), (2.0, 1.0), (2.0, 0.0), (1.0, 0.0), (1.1, 1.0)]))
-    expected_merged_polygon = Polygon([(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0), (0.0, 0.0)])
+    expected_merged_polygon = Polygon([(2.0, 1.0), (0.0, 1.0), (0.0, 0.0), (2.0, 0.0), (2.0, 1.0)])
     # By giving a buffer distance of 0.1, we want to correct this margin of error and have the two polygons being merged
     merged_polygons = merge_polygons(polygons, 0.1)
 
@@ -55,6 +55,8 @@ def test_merge_polygons_with_rounding_margin_too_big() -> None:
     merged_polygons = merge_polygons(polygons, 0.01)
     expected_merged_polygon = Polygon(
         [
+            (1.0, 1.0),
+            (0.0, 1.0),
             (0.0, 0.0),
             (2.0, 0.0),
             (2.0, 1.0),
@@ -62,8 +64,6 @@ def test_merge_polygons_with_rounding_margin_too_big() -> None:
             (1.01501863, 0.1501863),
             (1.0, 0.15093536),
             (1.0, 1.0),
-            (0.0, 1.0),
-            (0.0, 0.0),
         ]
     )
 
@@ -214,39 +214,18 @@ def test_capture_area_rounding_decimal_places() -> None:
     )
     capture_area_expected = {
         "geometry": {
+            "type": "Polygon",
             "coordinates": [
                 [
-                    [174.67341848, -37.05127777],
                     [174.67342502, -37.05155033],
                     [174.6734799, -37.05128096],
                     [174.67341848, -37.05127777],
+                    [174.67342502, -37.05155033],
                 ]
             ],
-            "type": "Polygon",
         },
         "type": "Feature",
         "properties": {},
     }
     capture_area = generate_capture_area(polygons, Decimal("1"))
     assert capture_area == capture_area_expected
-
-
-def test_ensure_consistent_geometry() -> None:
-    """Test to ensure removing a polygon from a geometry and putting it back gives the same result."""
-    polygons = []
-    poly_a = Polygon([(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0), (0.0, 1.0)])
-    poly_b = Polygon([(2.0, 1.0), (2.0, 0.0), (1.0, 0.0), (1.0, 1.0), (2.0, 1.0)])
-    polygons.append(poly_a)
-    polygons.append(poly_b)
-    merged_polygons = merge_polygons(polygons, 0)
-
-    print(f"Polygon A: {to_feature(poly_a)}")
-    print(f"Polygon B: {to_feature(poly_b)}")
-    print(f"Merged: {to_feature(merged_polygons)}")
-
-    merged_polygons_without_poly_b = merged_polygons.difference(poly_b)
-    print(f"GeoJSON merged_polygons_without_poly_b: {to_feature(merged_polygons_without_poly_b)}")
-    merged_polygons_with_poly_b_back = merge_polygons([poly_b, merged_polygons_without_poly_b], 0)
-    print(f"GeoJSON result: {to_feature(merged_polygons_with_poly_b_back)}")
-
-    assert merged_polygons_with_poly_b_back.equals_exact(merged_polygons, tolerance=0.0)

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -431,7 +431,7 @@ def test_capture_area_added(fake_collection_metadata: CollectionMetadata, fake_l
 
     with subtests.test():
         assert collection.stac["assets"]["capture_area"]["file:checksum"] in (
-            "122024fd55ea5f9812e80748ee78055893ad7bddbe2b5101dec1cc1b949edc295f51",
+            "1220ba57cd77defc7fa72e140f4faa0846e8905ae443de04aef99bf381d4650c17a0",
             # geos 3.11 - geos 3.12 as yet untested
         )
 
@@ -439,7 +439,7 @@ def test_capture_area_added(fake_collection_metadata: CollectionMetadata, fake_l
         assert "file:size" in collection.stac["assets"]["capture_area"]
 
     with subtests.test():
-        assert collection.stac["assets"]["capture_area"]["file:size"] in (239,)  # geos 3.11 - geos 3.12 as yet untested
+        assert collection.stac["assets"]["capture_area"]["file:size"] in (269,)  # geos 3.11 - geos 3.12 as yet untested
 
 
 def test_should_make_valid_capture_area() -> None:


### PR DESCRIPTION
This reverts commit 0a061ba3910a2ed60aecf8b9ad1ec5ebc5cf80df.

### Motivation

Normalizing as it has been implemented brings some issues into the overall geometry (visual and QGIS artifacts). As discussed and decided, having the capture-area content being different (points ordering) that shows a difference when updating an existing dataset while its geometry is not visually changed should not be a big deal for data consumer.

### Modifications

- Revert https://github.com/linz/topo-imagery/pull/1288

### Verification

None
