### PR TITLE
fix: update hillshade preset enum values TDE-1371

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -42,12 +42,12 @@ jobs:
 
       - name: End to end test - Hillshade Greyscale
         run: |
-          docker run  -v "${{ runner.temp }}:/tmp/" topo-imagery python3 generate_hillshade.py --from-file ./tests/data/hillshade.json --preset greyscale --target /tmp/ --force
+          docker run  -v "${{ runner.temp }}:/tmp/" topo-imagery python3 generate_hillshade.py --from-file ./tests/data/hillshade.json --preset hillshade --target /tmp/ --force
           cmp --silent "${{ runner.temp }}/BK39_10000_0101.tiff" ./scripts/tests/data/output/BK39_10000_0101_greyscale.tiff
 
       - name: End to end test - Hillshade Igor
         run: |
-          docker run  -v "${{ runner.temp }}:/tmp/" topo-imagery python3 generate_hillshade.py --from-file ./tests/data/hillshade.json --preset igor --target /tmp/ --force
+          docker run  -v "${{ runner.temp }}:/tmp/" topo-imagery python3 generate_hillshade.py --from-file ./tests/data/hillshade.json --preset hillshade-igor --target /tmp/ --force
           cmp --silent "${{ runner.temp }}/BK39_10000_0101.tiff" ./scripts/tests/data/output/BK39_10000_0101_igor.tiff
 
       - name: End to end test - Historical Aerial Imagery

--- a/scripts/gdal/gdal_commands.py
+++ b/scripts/gdal/gdal_commands.py
@@ -236,7 +236,7 @@ def get_hillshade_command(preset: str) -> list[str]:
         "MAX_Z_ERROR=0",
     ]
 
-    if preset == HillshadePreset.GREYSCALE.value:
+    if preset == HillshadePreset.DEFAULT.value:
         gdal_command.extend(["-az", "315", "-alt", "45"])
     elif preset == HillshadePreset.IGOR.value:
         gdal_command.extend(["-igor"])

--- a/scripts/gdal/gdal_presets.py
+++ b/scripts/gdal/gdal_presets.py
@@ -90,5 +90,5 @@ class CompressionPreset(str, Enum):
 class HillshadePreset(str, Enum):
     """Enum for the different type of hillshade available for generating from a DEM."""
 
-    GREYSCALE = "greyscale"  # Standard/default mono-directional hillshade
-    IGOR = "igor"  # Whiter hillshade (see http://maperitive.net/docs/Commands/GenerateReliefImageIgor.html)
+    DEFAULT = "hillshade"  # Standard/default mono-directional hillshade
+    IGOR = "hillshade-igor"  # Whiter hillshade (see http://maperitive.net/docs/Commands/GenerateReliefImageIgor.html)


### PR DESCRIPTION
### Motivation

Update `HillshadePreset` values to match use throughout the workflow and remaining code.

### Modifications

`GREYSCALE = "greyscale"` -> `DEFAULT = "hillshade"`
`IGOR = "igor"` -> `IGOR = "hillshade-igor"`

### Verification
existing `pytest` tests and github actions end to end tests.