### PR TITLE
refactor: group arguments used to create Collection TDE-1443

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -16,8 +16,7 @@ from scripts.files.files_helper import SUFFIX_JSON
 from scripts.files.fs_s3 import bucket_name_from_path, get_object_parallel_multithreading, list_files_in_uri
 from scripts.gdal.gdal_footprint import SUFFIX_FOOTPRINT
 from scripts.logging.time_helper import time_in_ms
-from scripts.stac.imagery.collection import CollectionIdentifiers
-from scripts.stac.imagery.collection import COLLECTION_FILE_NAME
+from scripts.stac.imagery.collection import COLLECTION_FILE_NAME, CollectionIdentifiers
 from scripts.stac.imagery.create_stac import CreateCollectionOptions, create_collection
 from scripts.stac.imagery.metadata_constants import DATA_CATEGORIES, HUMAN_READABLE_REGIONS, CollectionMetadata
 

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -16,7 +16,8 @@ from scripts.files.files_helper import SUFFIX_JSON
 from scripts.files.fs_s3 import bucket_name_from_path, get_object_parallel_multithreading, list_files_in_uri
 from scripts.gdal.gdal_footprint import SUFFIX_FOOTPRINT
 from scripts.logging.time_helper import time_in_ms
-from scripts.stac.imagery.create_stac import create_collection
+from scripts.stac.imagery.collection import CollectionIdentifiers
+from scripts.stac.imagery.create_stac import CreateCollectionOptions, create_collection
 from scripts.stac.imagery.metadata_constants import DATA_CATEGORIES, HUMAN_READABLE_REGIONS, CollectionMetadata
 
 if TYPE_CHECKING:
@@ -199,17 +200,17 @@ def main(args: List[str] | None = None) -> None:
     }
 
     collection = create_collection(
-        collection_id=collection_id,
-        linz_slug=arguments.linz_slug,
+        collection_identifiers=CollectionIdentifiers(arguments.linz_slug, collection_id),
         collection_metadata=collection_metadata,
         current_datetime=arguments.current_datetime,
         producers=coalesce_multi_single(arguments.producer_list, arguments.producer),
         licensors=coalesce_multi_single(arguments.licensor_list, arguments.licensor),
         stac_items=items_to_add,
         item_polygons=polygons,
-        add_capture_dates=arguments.capture_dates,
+        options=CreateCollectionOptions(
+            add_capture_dates=arguments.capture_dates, add_title_suffix=arguments.add_title_suffix
+        ),
         uri=uri,
-        add_title_suffix=arguments.add_title_suffix,
         odr_url=arguments.odr_url,
     )
 

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -16,7 +16,7 @@ from scripts.files.files_helper import SUFFIX_JSON
 from scripts.files.fs_s3 import bucket_name_from_path, get_object_parallel_multithreading, list_files_in_uri
 from scripts.gdal.gdal_footprint import SUFFIX_FOOTPRINT
 from scripts.logging.time_helper import time_in_ms
-from scripts.stac.imagery.collection import COLLECTION_FILE_NAME, CollectionIdentifiers
+from scripts.stac.imagery.collection import COLLECTION_FILE_NAME
 from scripts.stac.imagery.create_stac import CreateCollectionOptions, create_collection
 from scripts.stac.imagery.metadata_constants import DATA_CATEGORIES, HUMAN_READABLE_REGIONS, CollectionMetadata
 
@@ -194,13 +194,14 @@ def main(args: List[str] | None = None) -> None:
         start_datetime=parse_rfc_3339_datetime(start_datetime),
         end_datetime=parse_rfc_3339_datetime(end_datetime),
         lifecycle=arguments.lifecycle,
+        linz_slug=arguments.linz_slug,
+        collection_id=collection_id,
         geographic_description=arguments.geographic_description,
         event_name=arguments.event,
         historic_survey_number=arguments.historic_survey_number,
     )
 
     collection = create_collection(
-        collection_identifiers=CollectionIdentifiers(arguments.linz_slug, collection_id),
         collection_metadata=collection_metadata,
         current_datetime=arguments.current_datetime,
         producers=coalesce_multi_single(arguments.producer_list, arguments.producer),

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,9 +1,12 @@
+from datetime import datetime
+from decimal import Decimal
 from random import choice, randint
 from string import ascii_lowercase
+from typing import Iterator
 
 import pytest
 
-from scripts.stac.imagery.collection import CollectionIdentifiers
+from scripts.stac.imagery.metadata_constants import CollectionMetadata
 
 
 def fake_linz_slug() -> str:
@@ -16,9 +19,14 @@ def fake_linz_slug() -> str:
 
 
 @pytest.fixture
-def fake_collection_identifiers() -> CollectionIdentifiers:
-
-    return CollectionIdentifiers(
-        collection_id="a-random-collection-id",
+def fake_collection_metadata() -> Iterator[CollectionMetadata]:
+    yield CollectionMetadata(
+        category="rural-aerial-photos",
+        region="hawkes-bay",
+        gsd=Decimal("0.3"),
+        start_datetime=datetime(2023, 1, 1),
+        end_datetime=datetime(2023, 2, 2),
+        lifecycle="completed",
         linz_slug=fake_linz_slug(),
+        collection_id="a-random-collection-id",
     )

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -3,8 +3,9 @@ from string import ascii_lowercase
 
 import pytest
 
+from scripts.stac.imagery.collection import CollectionIdentifiers
 
-@pytest.fixture
+
 def fake_linz_slug() -> str:
     random_string = "".join(choice(ascii_lowercase) for _ in range(6))
     start_year = randint(2000, 2009)
@@ -12,3 +13,12 @@ def fake_linz_slug() -> str:
     gsd = choice([0.75, 0.3, 1, 0.075])
 
     return f"a-random-slug-{random_string}_{start_year}-{end_year}_{gsd}m"
+
+
+@pytest.fixture
+def fake_collection_identifiers() -> CollectionIdentifiers:
+
+    return CollectionIdentifiers(
+        collection_id="a-random-collection-id",
+        linz_slug=fake_linz_slug(),
+    )

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -1,6 +1,5 @@
 import json
 import os
-from dataclasses import dataclass
 from typing import Any
 
 import ulid
@@ -44,12 +43,6 @@ GSD_UNIT = "m"
 WARN_NO_PUBLISHED_CAPTURE_AREA = "no_published_capture_area"
 
 
-@dataclass
-class CollectionIdentifiers:
-    linz_slug: str
-    collection_id: str | None = None
-
-
 class ImageryCollection:
     stac: dict[str, Any]
     capture_area: dict[str, Any] | None = None
@@ -60,19 +53,18 @@ class ImageryCollection:
         metadata: CollectionMetadata,
         created_datetime: str,
         updated_datetime: str,
-        identifiers: CollectionIdentifiers,
         providers: list[Provider] | None = None,
         add_title_suffix: bool = True,
     ) -> None:
-        if not identifiers.collection_id:
-            identifiers.collection_id = str(ulid.ULID())
+        if not metadata.collection_id:
+            metadata.collection_id = str(ulid.ULID())
 
         self.metadata = metadata
 
         self.stac = {
             "type": "Collection",
             "stac_version": STAC_VERSION,
-            "id": identifiers.collection_id,
+            "id": metadata.collection_id,
             "title": self._title(add_title_suffix),
             "description": self._description(),
             "license": "CC-BY-4.0",
@@ -82,7 +74,7 @@ class ImageryCollection:
             "linz:geospatial_category": metadata.category,
             "linz:region": metadata.region,
             "linz:security_classification": "unclassified",
-            "linz:slug": identifiers.linz_slug,
+            "linz:slug": metadata.linz_slug,
             "created": created_datetime,
             "updated": updated_datetime,
         }
@@ -123,11 +115,18 @@ class ImageryCollection:
         file_content = read(file_name)
         stac_from_file = json.loads(file_content.decode("UTF-8"))
         stac_from_file["updated"] = updated_datetime
+        if metadata.collection_id != stac_from_file["id"]:
+            raise ValueError(f"Collection ID mismatch: {metadata.collection_id} != {stac_from_file['id']}")
+        if metadata.linz_slug != stac_from_file["linz:slug"]:
+            get_log().warn(
+                f"Collection LINZ slug mismatch: {metadata.linz_slug} != {stac_from_file['linz:slug']}."
+                "Existing Collection linz_slug will be used."
+            )
+            metadata.linz_slug = stac_from_file["linz:slug"]
         collection = cls(
             metadata=metadata,
             created_datetime=stac_from_file["created"],
             updated_datetime=stac_from_file["updated"],
-            identifiers=CollectionIdentifiers(linz_slug=stac_from_file["linz:slug"], collection_id=stac_from_file["id"]),
         )
         # Override STAC from the original collection
         collection.stac = stac_from_file

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -12,7 +12,7 @@ from scripts.files.fs import NoSuchFileError, read
 from scripts.files.geotiff import get_extents
 from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo
-from scripts.stac.imagery.collection import COLLECTION_FILE_NAME, CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.collection import COLLECTION_FILE_NAME, ImageryCollection
 from scripts.stac.imagery.item import ImageryItem, STACAsset, STACProcessing, STACProcessingSoftware
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole
@@ -36,7 +36,6 @@ class CreateCollectionOptions:
 
 
 def create_collection(  # pylint: disable=too-many-arguments
-    collection_identifiers: CollectionIdentifiers,
     collection_metadata: CollectionMetadata,
     current_datetime: str,
     producers: list[str],
@@ -77,7 +76,6 @@ def create_collection(  # pylint: disable=too-many-arguments
             metadata=collection_metadata,
             created_datetime=current_datetime,
             updated_datetime=current_datetime,
-            identifiers=collection_identifiers,
             providers=get_providers(licensors, producers),
             add_title_suffix=options.add_title_suffix,
         )

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -12,7 +12,7 @@ from scripts.files.fs import NoSuchFileError, read
 from scripts.files.geotiff import get_extents
 from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo
-from scripts.stac.imagery.collection import CollectionIdentifiers, COLLECTION_FILE_NAME, ImageryCollection
+from scripts.stac.imagery.collection import COLLECTION_FILE_NAME, CollectionIdentifiers, ImageryCollection
 from scripts.stac.imagery.item import ImageryItem, STACAsset, STACProcessing, STACProcessingSoftware
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -13,12 +13,7 @@ from scripts.files.geotiff import get_extents
 from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo
 from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
-from scripts.stac.imagery.item import (
-    ImageryItem,
-    STACAsset,
-    STACProcessing,
-    STACProcessingSoftware,
-)
+from scripts.stac.imagery.item import ImageryItem, STACAsset, STACProcessing, STACProcessingSoftware
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole
 from scripts.stac.link import Link, Relation

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -1,5 +1,6 @@
 import json
 import os
+from dataclasses import dataclass
 from typing import Any, TypeAlias
 
 from linz_logger import get_log
@@ -11,8 +12,13 @@ from scripts.files.fs import NoSuchFileError, read
 from scripts.files.geotiff import get_extents
 from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo
-from scripts.stac.imagery.collection import ImageryCollection
-from scripts.stac.imagery.item import ImageryItem, STACAsset, STACProcessing, STACProcessingSoftware
+from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.item import (
+    ImageryItem,
+    STACAsset,
+    STACProcessing,
+    STACProcessingSoftware,
+)
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole
 from scripts.stac.link import Link, Relation
@@ -23,36 +29,42 @@ JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | 
 JSON_Dict: TypeAlias = dict[str, "JSON"]
 
 
-# pylint: disable=too-many-arguments
-def create_collection(
-    collection_id: str,
-    linz_slug: str,
+@dataclass
+class CreateCollectionOptions:
+    """Options to be used to create a Collection.
+    add_capture_dates: Link a `capture-dates.geojson` file to the Collection
+    add_title_suffix: Add suffix to the Collection `title`
+    """
+
+    add_capture_dates: bool = False
+    add_title_suffix: bool = False
+
+
+def create_collection(  # pylint: disable=too-many-arguments
+    collection_identifiers: CollectionIdentifiers,
     collection_metadata: CollectionMetadata,
     current_datetime: str,
     producers: list[str],
     licensors: list[str],
     stac_items: list[dict[Any, Any]],
     item_polygons: list[BaseGeometry],
-    add_capture_dates: bool,
+    options: CreateCollectionOptions,
     uri: str,
-    add_title_suffix: bool = False,
     odr_url: str | None = None,
 ) -> ImageryCollection:
     """Create an ImageryCollection object.
     If `item_polygons` is not empty, it will add a generated capture area to the collection.
 
     Args:
-        collection_id: id of the collection
-        linz_slug: the linz:slug attribute for this collection
+        collection_identifiers: identifiers of the collection
         collection_metadata: metadata of the collection
         current_datetime: datetime string that represents the current time when the item is created.
         producers: producers of the dataset
         licensors: licensors of the dataset
         stac_items: items to link to the collection
         item_polygons: polygons of the items linked to the collection
-        add_capture_dates: whether to add a capture-dates.geojson.gz file to the collection assets
+        options: options to be used to create a Collection
         uri: path of the dataset
-        add_title_suffix: whether to add a title suffix to the collection title based on the lifecycle
         odr_url: path of the published dataset. Defaults to None.
 
     Returns:
@@ -70,16 +82,15 @@ def create_collection(
             metadata=collection_metadata,
             created_datetime=current_datetime,
             updated_datetime=current_datetime,
-            linz_slug=linz_slug,
-            collection_id=collection_id,
+            identifiers=collection_identifiers,
             providers=get_providers(licensors, producers),
-            add_title_suffix=add_title_suffix,
+            add_title_suffix=options.add_title_suffix,
         )
 
     for item in stac_items:
         collection.add_item(item)
 
-    if add_capture_dates:
+    if options.add_capture_dates:
         collection.add_capture_dates(uri)
 
     if item_polygons:
@@ -147,7 +158,7 @@ def get_providers(licensors: list[str], producers: list[str]) -> list[Provider]:
     return providers
 
 
-def create_item(
+def create_item(  # pylint: disable=too-many-arguments
     asset_path: str,
     start_datetime: str,
     end_datetime: str,

--- a/scripts/stac/imagery/metadata_constants.py
+++ b/scripts/stac/imagery/metadata_constants.py
@@ -6,17 +6,20 @@ from decimal import Decimal
 @dataclass
 class CollectionMetadata:  # pylint:disable=too-many-instance-attributes
     """
-    Used to generate dataset collection titles and descriptions.
+    Holds the Collection metadata.
 
-    region: Region of Dataset
-    gsd: Dataset Ground Sample Distance
-    start_date: Dataset capture start date
-    end_date: Dataset capture end date
-    lifecycle: Dataset status
-    Optional:
-        geographic_description: Optional geographic_description of dataset, e.g. Hutt City
-        event: Optional details of capture event, e.g. Cyclone Gabrielle
-        historic_survey_number: Optional historic imagery survey number, e.g. SNC88445
+    Attributes:
+        category: The category of the dataset.
+        region: The region the dataset is from.
+        gsd: The Ground Sample Distance of the dataset.
+        start_datetime: The start datetime of the dataset.
+        end_datetime: The end datetime of the dataset.
+        lifecycle: The lifecycle of the dataset.
+        linz_slug: The LINZ slug of the dataset.
+        collection_id: The collection ID.
+        geographic_description: The geographic description of the dataset.
+        event_name: The event name of the dataset.
+        historic_survey_number: The historic survey number of the dataset.
     """
 
     category: str
@@ -25,6 +28,8 @@ class CollectionMetadata:  # pylint:disable=too-many-instance-attributes
     start_datetime: datetime
     end_datetime: datetime
     lifecycle: str
+    linz_slug: str
+    collection_id: str | None = None
     geographic_description: str | None = None
     event_name: str | None = None
     historic_survey_number: str | None = None

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -19,7 +19,7 @@ from scripts.files.files_helper import ContentType
 from scripts.files.fs import read
 from scripts.files.fs_s3 import write
 from scripts.stac.imagery.capture_area import merge_polygons
-from scripts.stac.imagery.collection import WARN_NO_PUBLISHED_CAPTURE_AREA, CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.collection import WARN_NO_PUBLISHED_CAPTURE_AREA, ImageryCollection
 from scripts.stac.imagery.item import ImageryItem, STACAsset
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole
@@ -29,14 +29,10 @@ from scripts.stac.util.stac_extensions import StacExtensions
 from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
-def test_title_description_id_created_on_init(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
-) -> None:
+def test_title_description_id_created_on_init(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     fake_collection_metadata.event_name = "Forest Assessment"
     fake_collection_metadata.geographic_description = "Hawke's Bay Forest Assessment"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     with subtests.test():
         assert collection.stac["title"] == "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
 
@@ -108,7 +104,6 @@ def test_title_description_id_created_on_init(
 )
 def test_hillshade_title_and_description(
     fake_collection_metadata: CollectionMetadata,
-    fake_collection_identifiers: CollectionIdentifiers,
     subtests: SubTests,
     category: str,
     gsd: Decimal,
@@ -118,9 +113,7 @@ def test_hillshade_title_and_description(
     fake_collection_metadata.region = "new-zealand"
     fake_collection_metadata.category = category
     fake_collection_metadata.gsd = gsd
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
 
     with subtests.test(msg=f"{gsd}m DEM Hillshade Title"):
         assert collection.stac["title"] == expected_title
@@ -129,32 +122,20 @@ def test_hillshade_title_and_description(
         assert collection.stac["description"] == expected_description
 
 
-def test_id_parsed_on_init(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
-    assert collection.stac["id"] == fake_collection_identifiers.collection_id
+def test_id_parsed_on_init(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
+    assert collection.stac["id"] == fake_collection_metadata.collection_id
 
 
-def test_bbox_updated_from_none(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_bbox_updated_from_none(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     bbox = [1799667.5, 5815977.0, 1800422.5, 5814986.0]
     collection.update_spatial_extent(bbox)
     assert collection.stac["extent"]["spatial"]["bbox"] == [bbox]
 
 
-def test_bbox_updated_from_existing(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_bbox_updated_from_existing(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     # init bbox
     bbox = [174.889641, -41.217532, 174.902344, -41.203521]
     collection.update_spatial_extent(bbox)
@@ -165,24 +146,16 @@ def test_bbox_updated_from_existing(
     assert collection.stac["extent"]["spatial"]["bbox"] == [[174.889641, -41.217532, 174.922965, -41.203521]]
 
 
-def test_interval_updated_from_none(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_interval_updated_from_none(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     start_datetime = "2021-01-27T00:00:00Z"
     end_datetime = "2021-01-27T00:00:00Z"
     collection.update_temporal_extent(start_datetime, end_datetime)
     assert collection.stac["extent"]["temporal"]["interval"] == [[start_datetime, end_datetime]]
 
 
-def test_interval_updated_from_existing(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_interval_updated_from_existing(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     # init interval
     start_datetime = "2021-01-27T00:00:00Z"
     end_datetime = "2021-01-27T00:00:00Z"
@@ -195,11 +168,9 @@ def test_interval_updated_from_existing(
     assert collection.stac["extent"]["temporal"]["interval"] == [["2021-01-27T00:00:00Z", "2021-02-20T00:00:00Z"]]
 
 
-def test_add_item(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
-) -> None:
+def test_add_item(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     now_string = any_epoch_datetime_string()
-    collection = ImageryCollection(fake_collection_metadata, now_string, now_string, fake_collection_identifiers)
+    collection = ImageryCollection(fake_collection_metadata, now_string, now_string)
     asset_datetimes = {
         "created": any_epoch_datetime_string(),
         "updated": any_epoch_datetime_string(),
@@ -257,13 +228,9 @@ def test_add_item(
             assert item.stac["assets"]["visual"][property_name] == asset_datetimes[property_name]
 
 
-def test_write_collection(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_write_collection(fake_collection_metadata: CollectionMetadata) -> None:
     target = mkdtemp()
-    collectionObj = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collectionObj = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     collection_target = os.path.join(target, "collection.json")
     collectionObj.write_to(collection_target)
     collection = json.loads(read(collection_target))
@@ -272,14 +239,10 @@ def test_write_collection(
     assert collection["title"] == collectionObj.stac["title"]
 
 
-def test_write_collection_special_chars(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_write_collection_special_chars(fake_collection_metadata: CollectionMetadata) -> None:
     target = mkdtemp()
     title = "Manawatū-Whanganui"
-    collectionObj = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collectionObj = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     collectionObj.stac["title"] = title
     collection_target = os.path.join(target, "collection.json")
     collectionObj.write_to(collection_target)
@@ -289,21 +252,15 @@ def test_write_collection_special_chars(
     assert collection["title"] == title
 
 
-def test_add_providers(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_add_providers(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
     collection.add_providers([producer])
 
     assert {"name": "Maxar", "roles": ["producer"]} in collection.stac["providers"]
 
 
-def test_default_provider_roles_are_kept(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
-) -> None:
+def test_default_provider_roles_are_kept(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     # given we are adding a non default role to the default provider
     licensor: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.LICENSOR]}
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
@@ -311,7 +268,6 @@ def test_default_provider_roles_are_kept(
         fake_collection_metadata,
         any_epoch_datetime_string(),
         any_epoch_datetime_string(),
-        fake_collection_identifiers,
         providers=[producer, licensor],
     )
 
@@ -327,16 +283,13 @@ def test_default_provider_roles_are_kept(
         ]
 
 
-def test_default_provider_is_present(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
-) -> None:
+def test_default_provider_is_present(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     # given adding a provider
     producer: Provider = {"name": "Maxar", "roles": [ProviderRole.PRODUCER]}
     collection = ImageryCollection(
         fake_collection_metadata,
         any_epoch_datetime_string(),
         any_epoch_datetime_string(),
-        fake_collection_identifiers,
         providers=[producer],
     )
 
@@ -348,16 +301,13 @@ def test_default_provider_is_present(
         assert {"name": "Maxar", "roles": ["producer"]} in collection.stac["providers"]
 
 
-def test_providers_are_not_duplicated(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_providers_are_not_duplicated(fake_collection_metadata: CollectionMetadata) -> None:
     producer: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.PRODUCER]}
     licensor: Provider = {"name": "Toitū Te Whenua Land Information New Zealand", "roles": [ProviderRole.LICENSOR]}
     collection = ImageryCollection(
         fake_collection_metadata,
         any_epoch_datetime_string(),
         any_epoch_datetime_string(),
-        fake_collection_identifiers,
         providers=[producer, licensor],
     )
     assert len(collection.stac["providers"]) == 1
@@ -367,17 +317,13 @@ def test_providers_are_not_duplicated(
     } in collection.stac["providers"]
 
 
-def test_capture_area_added(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
-) -> None:
+def test_capture_area_added(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     """
     TODO: geos 3.12 changes the topology-preserving simplifier to produce stable results; see
     <https://github.com/libgeos/geos/pull/718>. Once we start using geos 3.12 in CI we can delete the values for 3.11
     below.
     """
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     file_name = "capture-area.geojson"
 
     polygons = []
@@ -467,7 +413,6 @@ def test_capture_area_added(
 
 def test_should_not_add_capture_area(
     fake_collection_metadata: CollectionMetadata,
-    fake_collection_identifiers: CollectionIdentifiers,
     subtests: SubTests,
     capsys: CaptureFixture[str],
 ) -> None:
@@ -475,9 +420,7 @@ def test_should_not_add_capture_area(
     (older datasets haven't been processed with this feature),
     the capture-area is not created as it may miss existing Item footprints.
     """
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     file_name = "capture-area.geojson"
 
     polygons = [
@@ -538,42 +481,26 @@ def test_should_make_valid_capture_area() -> None:
     assert is_valid(capture_area)
 
 
-def test_event_name_is_present(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_event_name_is_present(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata.event_name = "Forest Assessment"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     assert "Forest Assessment" == collection.stac["linz:event_name"]
 
 
-def test_geographic_description_is_present(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_geographic_description_is_present(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata.geographic_description = "Hawke's Bay Forest Assessment"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     assert "Hawke's Bay Forest Assessment" == collection.stac["linz:geographic_description"]
 
 
-def test_linz_slug_is_present(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
-    assert fake_collection_identifiers.linz_slug == collection.stac["linz:slug"]
+def test_linz_slug_is_present(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
+    assert fake_collection_metadata.linz_slug == collection.stac["linz:slug"]
 
 
 @mock_aws
-def test_capture_dates_added(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_capture_dates_added(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="flat")
     write("s3://flat/capture-dates.geojson", b"")
@@ -591,12 +518,8 @@ def test_capture_dates_added(
     }
 
 
-def test_reset_extent(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_reset_extent(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     collection.update_temporal_extent("2021-01-27T00:00:00Z", "2021-01-27T00:00:00Z")
     collection.update_spatial_extent([1799667.5, 5815977.0, 1800422.5, 5814986.0])
     collection.reset_extent()
@@ -604,10 +527,7 @@ def test_reset_extent(
     assert collection.stac["extent"]["temporal"]["interval"] is None
 
 
-def test_get_items_from_collection(
-    tmp_path: Path, fake_collection_identifiers: CollectionIdentifiers, fake_collection_metadata: CollectionMetadata
-) -> None:
-    collection_id = "test_collection"
+def test_get_items_from_collection(tmp_path: Path, fake_collection_metadata: CollectionMetadata) -> None:
     current_datetime = any_epoch_datetime_string()
     created_datetime = any_epoch_datetime_string()
 
@@ -626,8 +546,8 @@ def test_get_items_from_collection(
     existing_collection_content = {
         "type": "Collection",
         "stac_version": STAC_VERSION,
-        "id": collection_id,
-        "linz:slug": fake_collection_identifiers.linz_slug,
+        "id": fake_collection_metadata.collection_id,
+        "linz:slug": fake_collection_metadata.linz_slug,
         "links": [
             {
                 "rel": "root",
@@ -649,12 +569,8 @@ def test_get_items_from_collection(
     assert collection_items[0] == existing_item
 
 
-def test_remove_item_geometry_from_capture_area(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+def test_remove_item_geometry_from_capture_area(fake_collection_metadata: CollectionMetadata) -> None:
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     collection.capture_area = {
         "geometry": {
             "type": "Polygon",

--- a/scripts/stac/imagery/tests/conftest.py
+++ b/scripts/stac/imagery/tests/conftest.py
@@ -1,22 +1,6 @@
-from datetime import datetime
-from decimal import Decimal
-from typing import Any, Iterator
+from typing import Any
 
 import pytest
-
-from scripts.stac.imagery.metadata_constants import CollectionMetadata
-
-
-@pytest.fixture
-def fake_collection_metadata() -> Iterator[CollectionMetadata]:
-    yield CollectionMetadata(
-        category="rural-aerial-photos",
-        region="hawkes-bay",
-        gsd=Decimal("0.3"),
-        start_datetime=datetime(2023, 1, 1),
-        end_datetime=datetime(2023, 2, 2),
-        lifecycle="completed",
-    )
 
 
 @pytest.fixture

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -7,7 +7,7 @@ from pytest_subtests import SubTests
 
 from scripts.datetimes import format_rfc_3339_datetime_string
 from scripts.gdal.gdalinfo import GdalInfo
-from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.create_stac import (
     CreateCollectionOptions,
     create_collection,
@@ -227,13 +227,10 @@ def test_create_item_with_derived_from_datetimes(tmp_path: Path) -> None:
     assert item.stac["properties"]["end_datetime"] == "2024-09-02T12:00:00Z"
 
 
-def test_create_collection(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
-) -> None:
+def test_create_collection(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     current_datetime = any_epoch_datetime_string()
 
     collection = create_collection(
-        collection_identifiers=fake_collection_identifiers,
         collection_metadata=fake_collection_metadata,
         current_datetime=current_datetime,
         producers=[],
@@ -245,7 +242,7 @@ def test_create_collection(
     )
 
     with subtests.test("collection ID"):
-        assert collection.stac["id"] == fake_collection_identifiers.collection_id
+        assert collection.stac["id"] == fake_collection_metadata.collection_id
 
     with subtests.test("created datetime"):
         assert collection.stac["created"] == current_datetime
@@ -256,7 +253,6 @@ def test_create_collection(
 
 def test_create_collection_resupply(
     fake_collection_metadata: CollectionMetadata,
-    fake_collection_identifiers: CollectionIdentifiers,
     subtests: SubTests,
     tmp_path: Path,
 ) -> None:
@@ -265,8 +261,8 @@ def test_create_collection_resupply(
     existing_collection_content = {
         "type": "Collection",
         "stac_version": STAC_VERSION,
-        "id": fake_collection_identifiers.collection_id,
-        "linz:slug": fake_collection_identifiers.linz_slug,
+        "id": fake_collection_metadata.collection_id,
+        "linz:slug": fake_collection_metadata.linz_slug,
         "created": created_datetime_string,
         "updated": created_datetime_string,
     }
@@ -276,7 +272,6 @@ def test_create_collection_resupply(
     updated_datetime_string = format_rfc_3339_datetime_string(created_datetime + timedelta(days=1))
 
     collection = create_collection(
-        collection_identifiers=fake_collection_identifiers,
         collection_metadata=fake_collection_metadata,
         current_datetime=updated_datetime_string,
         producers=[],
@@ -297,7 +292,6 @@ def test_create_collection_resupply(
 
 def test_create_collection_resupply_add_items(
     fake_collection_metadata: CollectionMetadata,
-    fake_collection_identifiers: CollectionIdentifiers,
     subtests: SubTests,
     tmp_path: Path,
 ) -> None:
@@ -326,8 +320,8 @@ def test_create_collection_resupply_add_items(
     existing_collection_content = {
         "type": "Collection",
         "stac_version": STAC_VERSION,
-        "id": fake_collection_identifiers.collection_id,
-        "linz:slug": fake_collection_identifiers.linz_slug,
+        "id": fake_collection_metadata.collection_id,
+        "linz:slug": fake_collection_metadata.linz_slug,
         "links": [
             {
                 "rel": "root",
@@ -365,7 +359,6 @@ def test_create_collection_resupply_add_items(
     updated_datetime_string = any_epoch_datetime_string()
 
     collection = create_collection(
-        collection_identifiers=fake_collection_identifiers,
         collection_metadata=fake_collection_metadata,
         current_datetime=updated_datetime_string,
         producers=[],
@@ -537,9 +530,7 @@ def test_get_items_to_replace() -> None:
     ]
 
 
-def test_merge_item_list_for_resupply(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
-) -> None:
+def test_merge_item_list_for_resupply(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
     published_items = [
         {"type": "Feature", "id": "item_a"},
         {"type": "Feature", "id": "item_b"},
@@ -560,9 +551,7 @@ def test_merge_item_list_for_resupply(
         {"rel": "self", "href": "./collection.json"},
     ]
 
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     collection.stac["links"] = links
     merged_items = merge_item_list_for_resupply(collection, published_items, supplied_items)
 

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -584,9 +584,3 @@ def test_merge_item_list_for_resupply(
     with subtests.test("extent"):
         assert collection.stac["extent"]["spatial"]["bbox"] is None
         assert collection.stac["extent"]["temporal"]["interval"] is None
-    with subtests.test("links"):
-        assert collection.stac["links"] == [{"rel": "self", "href": "./collection.json"}]
-
-    with subtests.test("extent"):
-        assert collection.stac["extent"]["spatial"]["bbox"] is None
-        assert collection.stac["extent"]["temporal"]["interval"] is None

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -7,8 +7,14 @@ from pytest_subtests import SubTests
 
 from scripts.datetimes import format_rfc_3339_datetime_string
 from scripts.gdal.gdalinfo import GdalInfo
-from scripts.stac.imagery.collection import ImageryCollection
-from scripts.stac.imagery.create_stac import create_collection, create_item, get_items_to_replace, merge_item_list_for_resupply
+from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.create_stac import (
+    CreateCollectionOptions,
+    create_collection,
+    create_item,
+    get_items_to_replace,
+    merge_item_list_for_resupply,
+)
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.tests.generators import any_multihash_as_hex
 from scripts.stac.util.STAC_VERSION import STAC_VERSION
@@ -221,26 +227,25 @@ def test_create_item_with_derived_from_datetimes(tmp_path: Path) -> None:
     assert item.stac["properties"]["end_datetime"] == "2024-09-02T12:00:00Z"
 
 
-def test_create_collection(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str, subtests: SubTests) -> None:
-    collection_id = "test_collection"
-
+def test_create_collection(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
+) -> None:
     current_datetime = any_epoch_datetime_string()
 
     collection = create_collection(
-        collection_id=collection_id,
-        linz_slug=fake_linz_slug,
+        collection_identifiers=fake_collection_identifiers,
         collection_metadata=fake_collection_metadata,
         current_datetime=current_datetime,
         producers=[],
         licensors=[],
         stac_items=[],
         item_polygons=[],
-        add_capture_dates=False,
+        options=CreateCollectionOptions(),
         uri="test",
     )
 
     with subtests.test("collection ID"):
-        assert collection.stac["id"] == collection_id
+        assert collection.stac["id"] == fake_collection_identifiers.collection_id
 
     with subtests.test("created datetime"):
         assert collection.stac["created"] == current_datetime
@@ -250,16 +255,18 @@ def test_create_collection(fake_collection_metadata: CollectionMetadata, fake_li
 
 
 def test_create_collection_resupply(
-    fake_collection_metadata: CollectionMetadata, fake_linz_slug: str, subtests: SubTests, tmp_path: Path
+    fake_collection_metadata: CollectionMetadata,
+    fake_collection_identifiers: CollectionIdentifiers,
+    subtests: SubTests,
+    tmp_path: Path,
 ) -> None:
-    collection_id = "test_collection"
     created_datetime = any_epoch_datetime()
     created_datetime_string = format_rfc_3339_datetime_string(created_datetime)
     existing_collection_content = {
         "type": "Collection",
         "stac_version": STAC_VERSION,
-        "id": collection_id,
-        "linz:slug": fake_linz_slug,
+        "id": fake_collection_identifiers.collection_id,
+        "linz:slug": fake_collection_identifiers.linz_slug,
         "created": created_datetime_string,
         "updated": created_datetime_string,
     }
@@ -269,15 +276,14 @@ def test_create_collection_resupply(
     updated_datetime_string = format_rfc_3339_datetime_string(created_datetime + timedelta(days=1))
 
     collection = create_collection(
-        collection_id=collection_id,
-        linz_slug=fake_linz_slug,
+        collection_identifiers=fake_collection_identifiers,
         collection_metadata=fake_collection_metadata,
         current_datetime=updated_datetime_string,
         producers=[],
         licensors=[],
         stac_items=[],
         item_polygons=[],
-        add_capture_dates=False,
+        options=CreateCollectionOptions(),
         uri="test",
         odr_url=tmp_path.as_posix(),
     )
@@ -290,9 +296,11 @@ def test_create_collection_resupply(
 
 
 def test_create_collection_resupply_add_items(
-    fake_collection_metadata: CollectionMetadata, fake_linz_slug: str, subtests: SubTests, tmp_path: Path
+    fake_collection_metadata: CollectionMetadata,
+    fake_collection_identifiers: CollectionIdentifiers,
+    subtests: SubTests,
+    tmp_path: Path,
 ) -> None:
-    collection_id = "test_collection"
     created_datetime_string = any_epoch_datetime_string()
 
     existing_item_path = tmp_path / "item_a.json"
@@ -318,8 +326,8 @@ def test_create_collection_resupply_add_items(
     existing_collection_content = {
         "type": "Collection",
         "stac_version": STAC_VERSION,
-        "id": collection_id,
-        "linz:slug": fake_linz_slug,
+        "id": fake_collection_identifiers.collection_id,
+        "linz:slug": fake_collection_identifiers.linz_slug,
         "links": [
             {
                 "rel": "root",
@@ -357,15 +365,14 @@ def test_create_collection_resupply_add_items(
     updated_datetime_string = any_epoch_datetime_string()
 
     collection = create_collection(
-        collection_id=collection_id,
-        linz_slug=fake_linz_slug,
+        collection_identifiers=fake_collection_identifiers,
         collection_metadata=fake_collection_metadata,
         current_datetime=updated_datetime_string,
         producers=[],
         licensors=[],
         stac_items=[item_to_add],
         item_polygons=[],
-        add_capture_dates=False,
+        options=CreateCollectionOptions(),
         uri="test",
         odr_url=tmp_path.as_posix(),
     )
@@ -531,7 +538,7 @@ def test_get_items_to_replace() -> None:
 
 
 def test_merge_item_list_for_resupply(
-    fake_collection_metadata: CollectionMetadata, fake_linz_slug: str, subtests: SubTests
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests
 ) -> None:
     published_items = [
         {"type": "Feature", "id": "item_a"},
@@ -554,7 +561,7 @@ def test_merge_item_list_for_resupply(
     ]
 
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     collection.stac["links"] = links
     merged_items = merge_item_list_for_resupply(collection, published_items, supplied_items)
@@ -571,6 +578,12 @@ def test_merge_item_list_for_resupply(
             {"type": "Feature", "id": "item_c"},
         ]
 
+    with subtests.test("links"):
+        assert collection.stac["links"] == [{"rel": "self", "href": "./collection.json"}]
+
+    with subtests.test("extent"):
+        assert collection.stac["extent"]["spatial"]["bbox"] is None
+        assert collection.stac["extent"]["temporal"]["interval"] is None
     with subtests.test("links"):
         assert collection.stac["links"] == [{"rel": "self", "href": "./collection.json"}]
 

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -1,70 +1,82 @@
-from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
 def test_generate_description_imagery(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_elevation(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "dem"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_elevation_geographic_description_input(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "dem"
     fake_collection_metadata.geographic_description = "Central"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_satellite_imagery(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "satellite-imagery"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     description = "Satellite imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_historic_imagery(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "scanned-aerial-photos"
     fake_collection_metadata.historic_survey_number = "SNC8844"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     description = "Scanned aerial imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_event(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, \
 published as a record of the Cyclone Gabrielle event."

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -1,60 +1,70 @@
-from scripts.stac.imagery.collection import ImageryCollection
+from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
-def test_generate_description_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_description_imagery(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_elevation(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_description_elevation(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "dem"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
 def test_generate_description_elevation_geographic_description_input(
-    fake_collection_metadata: CollectionMetadata, fake_linz_slug: str
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
 ) -> None:
     fake_collection_metadata["category"] = "dem"
     fake_collection_metadata["geographic_description"] = "Central"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     description = "Digital Elevation Model within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_satellite_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_description_satellite_imagery(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "satellite-imagery"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     description = "Satellite imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_historic_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_description_historic_imagery(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "scanned-aerial-photos"
     fake_collection_metadata["historic_survey_number"] = "SNC8844"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     description = "Scanned aerial imagery within the Hawke's Bay region captured in 2023."
     assert collection.stac["description"] == description
 
 
-def test_generate_description_event(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_description_event(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     description = "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, \
 published as a record of the Cyclone Gabrielle event."

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -2,165 +2,197 @@ from datetime import datetime
 
 import pytest
 
-from scripts.stac.imagery.collection import ImageryCollection
+from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
 from scripts.stac.imagery.metadata_constants import CollectionMetadata, MissingMetadataError
 from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
-def test_generate_imagery_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_imagery_title(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     assert collection.stac["title"] == title
 
 
-def test_generate_dem_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_dem_title(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "dem"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay LiDAR 0.3m DEM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_dsm_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_dsm_title(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "dsm"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_satellite_imagery_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_satellite_imagery_title(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "satellite-imagery"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_historic_imagery_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_historic_imagery_title(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     title = "Hawke's Bay 0.3m SNC8844 (2023)"
     fake_collection_metadata["category"] = "scanned-aerial-photos"
     fake_collection_metadata["historic_survey_number"] = "SNC8844"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     assert collection.stac["title"] == title
 
 
 def test_generate_historic_imagery_title_missing_number(
-    fake_collection_metadata: CollectionMetadata, fake_linz_slug: str
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
 ) -> None:
     fake_collection_metadata["category"] = "scanned-aerial-photos"
     fake_collection_metadata["historic_survey_number"] = None
     with pytest.raises(MissingMetadataError) as excinfo:
-        ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug)
+        ImageryCollection(
+            fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        )
 
     assert "historic_survey_number" in str(excinfo.value)
 
 
-def test_generate_title_long_date(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_title_long_date(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["end_datetime"] = datetime(2024, 1, 1)
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023-2024)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_geographic_description(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_title_geographic_description(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["geographic_description"] = "Ponsonby"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Ponsonby 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_title_event_imagery(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_elevation(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_title_event_elevation(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "dsm"
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay - Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_title_event_satellite_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_title_event_satellite_imagery(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "satellite-imagery"
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_dsm_title_preview(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_dsm_title_preview(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["category"] = "dsm"
     fake_collection_metadata["lifecycle"] = "preview"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay LiDAR 0.3m DSM (2023) - Preview"
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_draft(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_imagery_title_draft(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["lifecycle"] = "ongoing"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023) - Draft"
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_without_suffix(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_imagery_title_without_suffix(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     # `ongoing` lifecycle nominal case adds a suffix
     fake_collection_metadata["lifecycle"] = "ongoing"
     collection = ImageryCollection(
         metadata=fake_collection_metadata,
         created_datetime=any_epoch_datetime_string(),
         updated_datetime=any_epoch_datetime_string(),
-        linz_slug=fake_linz_slug,
+        identifiers=fake_collection_identifiers,
         add_title_suffix=False,
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_imagery_title_empty_optional_str(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["geographic_description"] = ""
     fake_collection_metadata["event_name"] = ""
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_imagery_title_with_event(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
+def test_generate_imagery_title_with_event(
+    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+) -> None:
     fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
     fake_collection_metadata["event_name"] = "Forest Assessment"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
+        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     title = "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -2,164 +2,160 @@ from datetime import datetime
 
 import pytest
 
-from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.metadata_constants import CollectionMetadata, MissingMetadataError
 from scripts.tests.datetimes_test import any_epoch_datetime_string
 
 
-def test_generate_imagery_title(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_generate_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     assert collection.stac["title"] == title
 
 
 def test_generate_dem_title(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "dem"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     title = "Hawke's Bay LiDAR 0.3m DEM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_dsm_title(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_generate_dsm_title(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata.category = "dsm"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Hawke's Bay LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
-def test_generate_satellite_imagery_title(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_generate_satellite_imagery_title(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata.category = "satellite-imagery"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Hawke's Bay 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_historic_imagery_title(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     title = "Hawke's Bay 0.3m SNC8844 (2023)"
     fake_collection_metadata.category = "scanned-aerial-photos"
     fake_collection_metadata.historic_survey_number = "SNC8844"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     assert collection.stac["title"] == title
 
 
-def test_generate_historic_imagery_title_missing_number(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_generate_historic_imagery_title_missing_number(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata.category = "scanned-aerial-photos"
     fake_collection_metadata.historic_survey_number = None
     with pytest.raises(MissingMetadataError) as excinfo:
         ImageryCollection(
-            fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+            fake_collection_metadata,
+            any_epoch_datetime_string(),
+            any_epoch_datetime_string(),
         )
 
     assert "historic_survey_number" in str(excinfo.value)
 
 
-def test_generate_title_long_date(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
-) -> None:
+def test_generate_title_long_date(fake_collection_metadata: CollectionMetadata) -> None:
     fake_collection_metadata.end_datetime = datetime(2024, 1, 1)
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023-2024)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_geographic_description(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.geographic_description = "Ponsonby"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Ponsonby 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_imagery(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.geographic_description = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_elevation(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "dsm"
     fake_collection_metadata.geographic_description = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Hawke's Bay - Hawke's Bay Cyclone Gabrielle LiDAR 0.3m DSM (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_title_event_satellite_imagery(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "satellite-imagery"
     fake_collection_metadata.geographic_description = "Hawke's Bay Cyclone Gabrielle"
     fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Hawke's Bay Cyclone Gabrielle 0.3m Satellite Imagery (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_dsm_title_preview(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.category = "dsm"
     fake_collection_metadata.lifecycle = "preview"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     title = "Hawke's Bay LiDAR 0.3m DSM (2023) - Preview"
     assert collection.stac["title"] == title
 
 
 def test_generate_imagery_title_draft(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.lifecycle = "ongoing"
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023) - Draft"
     assert collection.stac["title"] == title
 
 
 def test_generate_imagery_title_without_suffix(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     # `ongoing` lifecycle nominal case adds a suffix
     fake_collection_metadata.lifecycle = "ongoing"
@@ -167,7 +163,6 @@ def test_generate_imagery_title_without_suffix(
         metadata=fake_collection_metadata,
         created_datetime=any_epoch_datetime_string(),
         updated_datetime=any_epoch_datetime_string(),
-        identifiers=fake_collection_identifiers,
         add_title_suffix=False,
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
@@ -175,24 +170,24 @@ def test_generate_imagery_title_without_suffix(
 
 
 def test_generate_imagery_title_empty_optional_str(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.geographic_description = ""
     fake_collection_metadata.event_name = ""
     collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
+        fake_collection_metadata,
+        any_epoch_datetime_string(),
+        any_epoch_datetime_string(),
     )
     title = "Hawke's Bay 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title
 
 
 def test_generate_imagery_title_with_event(
-    fake_collection_metadata: CollectionMetadata, fake_collection_identifiers: CollectionIdentifiers
+    fake_collection_metadata: CollectionMetadata,
 ) -> None:
     fake_collection_metadata.geographic_description = "Hawke's Bay Forest Assessment"
     fake_collection_metadata.event_name = "Forest Assessment"
-    collection = ImageryCollection(
-        fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
-    )
+    collection = ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string())
     title = "Hawke's Bay Forest Assessment 0.3m Rural Aerial Photos (2023)"
     assert collection.stac["title"] == title

--- a/scripts/stac/imagery/tests/item_test.py
+++ b/scripts/stac/imagery/tests/item_test.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from pytest_subtests import SubTests
 
 from scripts.files.files_helper import get_file_name_from_path
-from scripts.stac.imagery.collection import ImageryCollection
+from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.tests.generators import any_stac_asset, any_stac_processing
@@ -110,7 +110,7 @@ def test_update_item_checksum(subtests: SubTests, tmp_path: Path, fake_imagery_i
 
 
 # pylint: disable=duplicate-code
-def test_imagery_add_collection(fake_linz_slug: str, subtests: SubTests) -> None:
+def test_imagery_add_collection(fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests) -> None:
     metadata: CollectionMetadata = {
         "category": "urban-aerial-photos",
         "region": "auckland",
@@ -122,13 +122,11 @@ def test_imagery_add_collection(fake_linz_slug: str, subtests: SubTests) -> None
         "historic_survey_number": None,
         "geographic_description": None,
     }
-    ulid = "fake_ulid"
     collection = ImageryCollection(
         metadata=metadata,
         created_datetime=any_epoch_datetime_string(),
         updated_datetime=any_epoch_datetime_string(),
-        linz_slug=fake_linz_slug,
-        collection_id=ulid,
+        identifiers=fake_collection_identifiers,
     )
 
     path = "./scripts/tests/data/empty.tiff"
@@ -138,7 +136,7 @@ def test_imagery_add_collection(fake_linz_slug: str, subtests: SubTests) -> None
     item.add_collection(collection.stac["id"])
 
     with subtests.test():
-        assert item.stac["collection"] == ulid
+        assert item.stac["collection"] == fake_collection_identifiers.collection_id
 
     with subtests.test():
         assert {"rel": "collection", "href": "./collection.json", "type": "application/json"} in item.stac["links"]

--- a/scripts/stac/imagery/tests/item_test.py
+++ b/scripts/stac/imagery/tests/item_test.py
@@ -1,6 +1,4 @@
 import json
-from datetime import datetime
-from decimal import Decimal
 from os import environ
 from pathlib import Path
 from typing import Any
@@ -9,7 +7,7 @@ from unittest.mock import patch
 from pytest_subtests import SubTests
 
 from scripts.files.files_helper import get_file_name_from_path
-from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
+from scripts.stac.imagery.collection import ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.tests.generators import any_stac_asset, any_stac_processing
@@ -110,21 +108,12 @@ def test_update_item_checksum(subtests: SubTests, tmp_path: Path, fake_imagery_i
 
 
 # pylint: disable=duplicate-code
-def test_imagery_add_collection(fake_collection_identifiers: CollectionIdentifiers, subtests: SubTests) -> None:
-    metadata = CollectionMetadata(
-        category="urban-aerial-photos",
-        region="auckland",
-        gsd=Decimal("0.3"),
-        start_datetime=datetime(2022, 2, 2),
-        end_datetime=datetime(2022, 2, 2),
-        lifecycle="completed",
-    )
+def test_imagery_add_collection(fake_collection_metadata: CollectionMetadata, subtests: SubTests) -> None:
 
     collection = ImageryCollection(
-        metadata=metadata,
+        metadata=fake_collection_metadata,
         created_datetime=any_epoch_datetime_string(),
         updated_datetime=any_epoch_datetime_string(),
-        identifiers=fake_collection_identifiers,
     )
 
     path = "./scripts/tests/data/empty.tiff"
@@ -134,7 +123,7 @@ def test_imagery_add_collection(fake_collection_identifiers: CollectionIdentifie
     item.add_collection(collection.stac["id"])
 
     with subtests.test():
-        assert item.stac["collection"] == fake_collection_identifiers.collection_id
+        assert item.stac["collection"] == fake_collection_metadata.collection_id
 
     with subtests.test():
         assert {"rel": "collection", "href": "./collection.json", "type": "application/json"} in item.stac["links"]

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -14,7 +14,7 @@ from pytest_subtests import SubTests
 from scripts.collection_from_items import NoItemsError, main
 from scripts.files.fs_s3 import write
 from scripts.json_codec import dict_to_json_bytes
-from scripts.stac.imagery.collection import ImageryCollection
+from scripts.stac.imagery.collection import CollectionIdentifiers, ImageryCollection
 from scripts.stac.imagery.item import ImageryItem
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.tests.generators import any_stac_asset, any_stac_processing
@@ -44,7 +44,7 @@ def setup() -> Iterator[ImageryItem]:
 
 
 @mock_aws
-def test_should_create_collection_file(item: ImageryItem, fake_linz_slug: str) -> None:
+def test_should_create_collection_file(item: ImageryItem, fake_collection_identifiers: CollectionIdentifiers) -> None:
     # Mock AWS S3
     s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="stacfiles")
@@ -71,7 +71,7 @@ def test_should_create_collection_file(item: ImageryItem, fake_linz_slug: str) -
         "--concurrency",
         "25",
         "--linz-slug",
-        fake_linz_slug,
+        fake_collection_identifiers.linz_slug,
     ]
     # Call script's main function
     main(args)
@@ -83,7 +83,7 @@ def test_should_create_collection_file(item: ImageryItem, fake_linz_slug: str) -
 
 @mock_aws
 def test_should_fail_if_collection_has_no_matching_items(
-    item: ImageryItem, fake_linz_slug: str, capsys: CaptureFixture[str], subtests: SubTests
+    item: ImageryItem, fake_collection_identifiers: CollectionIdentifiers, capsys: CaptureFixture[str], subtests: SubTests
 ) -> None:
     # Mock AWS S3
     s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
@@ -116,7 +116,7 @@ def test_should_fail_if_collection_has_no_matching_items(
         "--current-datetime",
         any_epoch_datetime_string(),
         "--linz-slug",
-        fake_linz_slug,
+        fake_collection_identifiers.linz_slug,
     ]
     # Call script's main function
     with raises(NoItemsError):
@@ -158,11 +158,10 @@ def test_should_fail_to_create_collection_file_without_linz_slug(capsys: Capture
 
 
 @mock_aws
-def test_should_not_add_if_not_item(fake_linz_slug: str, capsys: CaptureFixture[str]) -> None:
+def test_should_not_add_if_not_item(fake_collection_identifiers: CollectionIdentifiers, capsys: CaptureFixture[str]) -> None:
     # Mock AWS S3
     s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="stacfiles")
-    collection_id = "abc"
     # Create mocked "existing" Collection
     metadata: CollectionMetadata = {
         "category": "urban-aerial-photos",
@@ -176,15 +175,16 @@ def test_should_not_add_if_not_item(fake_linz_slug: str, capsys: CaptureFixture[
         "historic_survey_number": None,
     }
     existing_collection = ImageryCollection(
-        metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug, collection_id
+        metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_collection_identifiers
     )
     write("s3://stacfiles/collection.json", dict_to_json_bytes(existing_collection.stac))
+    assert fake_collection_identifiers.collection_id is not None
     # CLI arguments
     args = [
         "--uri",
         "s3://stacfiles/",
         "--collection-id",
-        collection_id,
+        fake_collection_identifiers.collection_id,
         "--category",
         "urban-aerial-photos",
         "--region",
@@ -202,7 +202,7 @@ def test_should_not_add_if_not_item(fake_linz_slug: str, capsys: CaptureFixture[
         "--current-datetime",
         any_epoch_datetime_string(),
         "--linz-slug",
-        fake_linz_slug,
+        fake_collection_identifiers.linz_slug,
     ]
     # Call script's main function
     with raises(NoItemsError):
@@ -212,7 +212,7 @@ def test_should_not_add_if_not_item(fake_linz_slug: str, capsys: CaptureFixture[
 
 
 @mock_aws
-def test_should_determine_dates_from_items(item: ImageryItem, fake_linz_slug: str) -> None:
+def test_should_determine_dates_from_items(item: ImageryItem, fake_collection_identifiers: CollectionIdentifiers) -> None:
     # Mock AWS S3
     s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="stacfiles")
@@ -245,7 +245,7 @@ def test_should_determine_dates_from_items(item: ImageryItem, fake_linz_slug: st
         "--current-datetime",
         any_epoch_datetime_string(),
         "--linz-slug",
-        fake_linz_slug,
+        fake_collection_identifiers.linz_slug,
     ]
     # Call script's main function
     main(args)


### PR DESCRIPTION
### Motivation

`create_collection()` has too many arguments and it is difficult to manage them. While having the need of adding even more arguments in the near future, this change is needed.

### Modifications

- Group Collection identifiers `linz_slug` and `id` into the same dataclass
- Group creation options `add_capture_dates` and `add_title_suffix` into the same dataclass

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

linter, typer, and UTs
