### PR TITLE
refactor: make CollectionMetadata a dataclass TDE-1443

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -186,17 +186,17 @@ def main(args: List[str] | None = None) -> None:
         )
         raise NoItemsError(f"Collection {collection_id} has no items")
 
-    collection_metadata: CollectionMetadata = {
-        "category": arguments.category,
-        "region": arguments.region,
-        "gsd": arguments.gsd,
-        "start_datetime": parse_rfc_3339_datetime(start_datetime),
-        "end_datetime": parse_rfc_3339_datetime(end_datetime),
-        "lifecycle": arguments.lifecycle,
-        "geographic_description": arguments.geographic_description,
-        "event_name": arguments.event,
-        "historic_survey_number": arguments.historic_survey_number,
-    }
+    collection_metadata = CollectionMetadata(
+        category=arguments.category,
+        region=arguments.region,
+        gsd=arguments.gsd,
+        start_datetime=parse_rfc_3339_datetime(start_datetime),
+        end_datetime=parse_rfc_3339_datetime(end_datetime),
+        lifecycle=arguments.lifecycle,
+        geographic_description=arguments.geographic_description,
+        event_name=arguments.event,
+        historic_survey_number=arguments.historic_survey_number,
+    )
 
     collection = create_collection(
         collection_id=collection_id,

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -71,9 +71,9 @@ class ImageryCollection:
             "license": "CC-BY-4.0",
             "links": [{"rel": "self", "href": "./collection.json", "type": "application/json"}],
             "providers": [],
-            "linz:lifecycle": metadata["lifecycle"],
-            "linz:geospatial_category": metadata["category"],
-            "linz:region": metadata["region"],
+            "linz:lifecycle": metadata.lifecycle,
+            "linz:geospatial_category": metadata.category,
+            "linz:region": metadata.region,
             "linz:security_classification": "unclassified",
             "linz:slug": linz_slug,
             "created": created_datetime,
@@ -81,9 +81,9 @@ class ImageryCollection:
         }
 
         # Optional metadata
-        if event_name := metadata.get("event_name"):
+        if event_name := metadata.event_name:
             self.stac["linz:event_name"] = event_name
-        if geographic_description := metadata.get("geographic_description"):
+        if geographic_description := metadata.geographic_description:
             self.stac["linz:geographic_description"] = geographic_description
 
         # If the providers passed has already a LINZ provider: add its default roles to it
@@ -155,7 +155,7 @@ class ImageryCollection:
         if self.capture_area:
             polygons.append(shape(self.capture_area["geometry"]))
         # The GSD is measured in meters (e.g., `0.3m`)
-        capture_area_document = generate_capture_area(polygons, self.metadata["gsd"])
+        capture_area_document = generate_capture_area(polygons, self.metadata.gsd)
         capture_area_content: bytes = dict_to_json_bytes(capture_area_document)
         file_checksum = checksum.multihash_as_hex(capture_area_content)
         capture_area = {
@@ -355,24 +355,24 @@ class ImageryCollection:
             Dataset Title
         """
         # format optional metadata
-        geographic_description = self.metadata.get("geographic_description")
-        historic_survey_number = self.metadata.get("historic_survey_number")
+        geographic_description = self.metadata.geographic_description
+        historic_survey_number = self.metadata.historic_survey_number
 
         # format region
-        region = HUMAN_READABLE_REGIONS[self.metadata["region"]]
+        region = HUMAN_READABLE_REGIONS[self.metadata.region]
 
         # format date
-        start_year = self.metadata["start_datetime"].year
-        end_year = self.metadata["end_datetime"].year
+        start_year = self.metadata.start_datetime.year
+        end_year = self.metadata.end_datetime.year
         date = f"({start_year})" if start_year == end_year else f"({start_year}-{end_year})"
 
         # format gsd
-        gsd_str = f"{self.metadata['gsd']}{GSD_UNIT}"
+        gsd_str = f"{self.metadata.gsd}{GSD_UNIT}"
 
         # determine suffix based on its lifecycle
-        lifecycle_suffix = LIFECYCLE_SUFFIXES.get(self.metadata.get("lifecycle", "")) if add_suffix else None
+        lifecycle_suffix = LIFECYCLE_SUFFIXES.get(self.metadata.lifecycle, "") if add_suffix else None
 
-        category = self.metadata["category"]
+        category = self.metadata.category
 
         if category == SCANNED_AERIAL_PHOTOS:
             if not historic_survey_number:
@@ -409,13 +409,13 @@ class ImageryCollection:
         elif category in {DEM_HILLSHADE, DEM_HILLSHADE_IGOR}:
             components = [
                 region,
-                gsd_str if self.metadata["gsd"] == 8 else None,
+                gsd_str if self.metadata.gsd == 8 else None,
                 "DEM Hillshade",
                 "- Igor" if category == DEM_HILLSHADE_IGOR else None,
             ]
 
         else:
-            raise SubtypeParameterError(self.metadata["category"])
+            raise SubtypeParameterError(self.metadata.category)
 
         return " ".join(filter(None, components))
 
@@ -435,14 +435,14 @@ class ImageryCollection:
             Dataset Description
         """
         # format date
-        start_year = self.metadata["start_datetime"].year
-        end_year = self.metadata["end_datetime"].year
+        start_year = self.metadata.start_datetime.year
+        end_year = self.metadata.end_datetime.year
         date = str(start_year) if start_year == end_year else f"{start_year}-{end_year}"
 
         # format region
-        region = HUMAN_READABLE_REGIONS[self.metadata["region"]]
+        region = HUMAN_READABLE_REGIONS[self.metadata.region]
 
-        category = self.metadata["category"]
+        category = self.metadata.category
         if category in {URBAN_AERIAL_PHOTOS, RURAL_AERIAL_PHOTOS}:
             date = f"the {date} flying season"
 
@@ -462,7 +462,7 @@ class ImageryCollection:
         else:
             raise SubtypeParameterError(category)
 
-        if event := self.metadata.get("event_name"):
+        if event := self.metadata.event_name:
             desc = f"{desc}, published as a record of the {event} event."
         else:
             desc = f"{desc}."
@@ -472,9 +472,9 @@ class ImageryCollection:
     def _hillshade_description(self) -> str:
         """Generates the description for hillshade datasets."""
 
-        region = HUMAN_READABLE_REGIONS[self.metadata["region"]]
-        category = self.metadata["category"]
-        gsd_str = f"{self.metadata["gsd"]}{GSD_UNIT}"
+        region = HUMAN_READABLE_REGIONS[self.metadata.region]
+        category = self.metadata.category
+        gsd_str = f"{self.metadata.gsd}{GSD_UNIT}"
 
         if category == DEM_HILLSHADE_IGOR:
             shading_option = (
@@ -488,7 +488,7 @@ class ImageryCollection:
             "Hillshade generated from the",
             f"{region} LiDAR {gsd_str} DEM and" if gsd_str != "8m" else None,
             f"{region} Contour-Derived 8m DEM",
-            f"(where no {self.metadata["gsd"]}m DEM data exists)" if gsd_str != "8m" else None,
+            f"(where no {self.metadata.gsd}m DEM data exists)" if gsd_str != "8m" else None,
             "using",
             shading_option,
         ]

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -462,10 +462,7 @@ class ImageryCollection:
         else:
             raise SubtypeParameterError(category)
 
-        if event := self.metadata.event_name:
-            desc = f"{desc}, published as a record of the {event} event."
-        else:
-            desc = f"{desc}."
+        desc += f", published as a record of the {self.metadata.event_name} event." if self.metadata.event_name else "."
 
         return desc
 

--- a/scripts/stac/imagery/metadata_constants.py
+++ b/scripts/stac/imagery/metadata_constants.py
@@ -1,9 +1,10 @@
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import TypedDict
 
 
-class CollectionMetadata(TypedDict):
+@dataclass
+class CollectionMetadata:  # pylint:disable=too-many-instance-attributes
     """
     Used to generate dataset collection titles and descriptions.
 
@@ -24,9 +25,9 @@ class CollectionMetadata(TypedDict):
     start_datetime: datetime
     end_datetime: datetime
     lifecycle: str
-    geographic_description: str | None
-    event_name: str | None
-    historic_survey_number: str | None
+    geographic_description: str | None = None
+    event_name: str | None = None
+    historic_survey_number: str | None = None
 
 
 class SubtypeParameterError(Exception):

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -32,8 +32,8 @@ from scripts.tests.datetimes_test import any_epoch_datetime_string
 def test_title_description_id_created_on_init(
     fake_collection_metadata: CollectionMetadata, fake_linz_slug: str, subtests: SubTests
 ) -> None:
-    fake_collection_metadata["event_name"] = "Forest Assessment"
-    fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
+    fake_collection_metadata.event_name = "Forest Assessment"
+    fake_collection_metadata.geographic_description = "Hawke's Bay Forest Assessment"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -115,9 +115,9 @@ def test_hillshade_title_and_description(
     expected_title: str,
     expected_description: str,
 ) -> None:
-    fake_collection_metadata["region"] = "new-zealand"
-    fake_collection_metadata["category"] = category
-    fake_collection_metadata["gsd"] = gsd
+    fake_collection_metadata.region = "new-zealand"
+    fake_collection_metadata.category = category
+    fake_collection_metadata.gsd = gsd
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -515,7 +515,7 @@ def test_should_make_valid_capture_area() -> None:
 
 
 def test_event_name_is_present(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["event_name"] = "Forest Assessment"
+    fake_collection_metadata.event_name = "Forest Assessment"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -523,7 +523,7 @@ def test_event_name_is_present(fake_collection_metadata: CollectionMetadata, fak
 
 
 def test_geographic_description_is_present(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
+    fake_collection_metadata.geographic_description = "Hawke's Bay Forest Assessment"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )

--- a/scripts/stac/imagery/tests/conftest.py
+++ b/scripts/stac/imagery/tests/conftest.py
@@ -9,18 +9,14 @@ from scripts.stac.imagery.metadata_constants import CollectionMetadata
 
 @pytest.fixture
 def fake_collection_metadata() -> Iterator[CollectionMetadata]:
-    collection_metadata: CollectionMetadata = {
-        "category": "rural-aerial-photos",
-        "region": "hawkes-bay",
-        "gsd": Decimal("0.3"),
-        "start_datetime": datetime(2023, 1, 1),
-        "end_datetime": datetime(2023, 2, 2),
-        "lifecycle": "completed",
-        "event_name": None,
-        "historic_survey_number": None,
-        "geographic_description": None,
-    }
-    yield collection_metadata
+    yield CollectionMetadata(
+        category="rural-aerial-photos",
+        region="hawkes-bay",
+        gsd=Decimal("0.3"),
+        start_datetime=datetime(2023, 1, 1),
+        end_datetime=datetime(2023, 2, 2),
+        lifecycle="completed",
+    )
 
 
 @pytest.fixture

--- a/scripts/stac/imagery/tests/generate_description_test.py
+++ b/scripts/stac/imagery/tests/generate_description_test.py
@@ -12,7 +12,7 @@ def test_generate_description_imagery(fake_collection_metadata: CollectionMetada
 
 
 def test_generate_description_elevation(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "dem"
+    fake_collection_metadata.category = "dem"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -23,8 +23,8 @@ def test_generate_description_elevation(fake_collection_metadata: CollectionMeta
 def test_generate_description_elevation_geographic_description_input(
     fake_collection_metadata: CollectionMetadata, fake_linz_slug: str
 ) -> None:
-    fake_collection_metadata["category"] = "dem"
-    fake_collection_metadata["geographic_description"] = "Central"
+    fake_collection_metadata.category = "dem"
+    fake_collection_metadata.geographic_description = "Central"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -33,7 +33,7 @@ def test_generate_description_elevation_geographic_description_input(
 
 
 def test_generate_description_satellite_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "satellite-imagery"
+    fake_collection_metadata.category = "satellite-imagery"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -42,8 +42,8 @@ def test_generate_description_satellite_imagery(fake_collection_metadata: Collec
 
 
 def test_generate_description_historic_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "scanned-aerial-photos"
-    fake_collection_metadata["historic_survey_number"] = "SNC8844"
+    fake_collection_metadata.category = "scanned-aerial-photos"
+    fake_collection_metadata.historic_survey_number = "SNC8844"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -52,7 +52,7 @@ def test_generate_description_historic_imagery(fake_collection_metadata: Collect
 
 
 def test_generate_description_event(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )

--- a/scripts/stac/imagery/tests/generate_title_test.py
+++ b/scripts/stac/imagery/tests/generate_title_test.py
@@ -16,7 +16,7 @@ def test_generate_imagery_title(fake_collection_metadata: CollectionMetadata, fa
 
 
 def test_generate_dem_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "dem"
+    fake_collection_metadata.category = "dem"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -25,7 +25,7 @@ def test_generate_dem_title(fake_collection_metadata: CollectionMetadata, fake_l
 
 
 def test_generate_dsm_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "dsm"
+    fake_collection_metadata.category = "dsm"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -34,7 +34,7 @@ def test_generate_dsm_title(fake_collection_metadata: CollectionMetadata, fake_l
 
 
 def test_generate_satellite_imagery_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "satellite-imagery"
+    fake_collection_metadata.category = "satellite-imagery"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -44,8 +44,8 @@ def test_generate_satellite_imagery_title(fake_collection_metadata: CollectionMe
 
 def test_generate_historic_imagery_title(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     title = "Hawke's Bay 0.3m SNC8844 (2023)"
-    fake_collection_metadata["category"] = "scanned-aerial-photos"
-    fake_collection_metadata["historic_survey_number"] = "SNC8844"
+    fake_collection_metadata.category = "scanned-aerial-photos"
+    fake_collection_metadata.historic_survey_number = "SNC8844"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -55,8 +55,8 @@ def test_generate_historic_imagery_title(fake_collection_metadata: CollectionMet
 def test_generate_historic_imagery_title_missing_number(
     fake_collection_metadata: CollectionMetadata, fake_linz_slug: str
 ) -> None:
-    fake_collection_metadata["category"] = "scanned-aerial-photos"
-    fake_collection_metadata["historic_survey_number"] = None
+    fake_collection_metadata.category = "scanned-aerial-photos"
+    fake_collection_metadata.historic_survey_number = None
     with pytest.raises(MissingMetadataError) as excinfo:
         ImageryCollection(fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug)
 
@@ -64,7 +64,7 @@ def test_generate_historic_imagery_title_missing_number(
 
 
 def test_generate_title_long_date(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["end_datetime"] = datetime(2024, 1, 1)
+    fake_collection_metadata.end_datetime = datetime(2024, 1, 1)
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -73,7 +73,7 @@ def test_generate_title_long_date(fake_collection_metadata: CollectionMetadata, 
 
 
 def test_generate_title_geographic_description(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["geographic_description"] = "Ponsonby"
+    fake_collection_metadata.geographic_description = "Ponsonby"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -82,8 +82,8 @@ def test_generate_title_geographic_description(fake_collection_metadata: Collect
 
 
 def test_generate_title_event_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    fake_collection_metadata.geographic_description = "Hawke's Bay Cyclone Gabrielle"
+    fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -92,9 +92,9 @@ def test_generate_title_event_imagery(fake_collection_metadata: CollectionMetada
 
 
 def test_generate_title_event_elevation(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "dsm"
-    fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    fake_collection_metadata.category = "dsm"
+    fake_collection_metadata.geographic_description = "Hawke's Bay Cyclone Gabrielle"
+    fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -103,9 +103,9 @@ def test_generate_title_event_elevation(fake_collection_metadata: CollectionMeta
 
 
 def test_generate_title_event_satellite_imagery(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "satellite-imagery"
-    fake_collection_metadata["geographic_description"] = "Hawke's Bay Cyclone Gabrielle"
-    fake_collection_metadata["event_name"] = "Cyclone Gabrielle"
+    fake_collection_metadata.category = "satellite-imagery"
+    fake_collection_metadata.geographic_description = "Hawke's Bay Cyclone Gabrielle"
+    fake_collection_metadata.event_name = "Cyclone Gabrielle"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -114,8 +114,8 @@ def test_generate_title_event_satellite_imagery(fake_collection_metadata: Collec
 
 
 def test_generate_dsm_title_preview(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["category"] = "dsm"
-    fake_collection_metadata["lifecycle"] = "preview"
+    fake_collection_metadata.category = "dsm"
+    fake_collection_metadata.lifecycle = "preview"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -124,7 +124,7 @@ def test_generate_dsm_title_preview(fake_collection_metadata: CollectionMetadata
 
 
 def test_generate_imagery_title_draft(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["lifecycle"] = "ongoing"
+    fake_collection_metadata.lifecycle = "ongoing"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -134,7 +134,7 @@ def test_generate_imagery_title_draft(fake_collection_metadata: CollectionMetada
 
 def test_generate_imagery_title_without_suffix(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
     # `ongoing` lifecycle nominal case adds a suffix
-    fake_collection_metadata["lifecycle"] = "ongoing"
+    fake_collection_metadata.lifecycle = "ongoing"
     collection = ImageryCollection(
         metadata=fake_collection_metadata,
         created_datetime=any_epoch_datetime_string(),
@@ -147,8 +147,8 @@ def test_generate_imagery_title_without_suffix(fake_collection_metadata: Collect
 
 
 def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["geographic_description"] = ""
-    fake_collection_metadata["event_name"] = ""
+    fake_collection_metadata.geographic_description = ""
+    fake_collection_metadata.event_name = ""
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )
@@ -157,8 +157,8 @@ def test_generate_imagery_title_empty_optional_str(fake_collection_metadata: Col
 
 
 def test_generate_imagery_title_with_event(fake_collection_metadata: CollectionMetadata, fake_linz_slug: str) -> None:
-    fake_collection_metadata["geographic_description"] = "Hawke's Bay Forest Assessment"
-    fake_collection_metadata["event_name"] = "Forest Assessment"
+    fake_collection_metadata.geographic_description = "Hawke's Bay Forest Assessment"
+    fake_collection_metadata.event_name = "Forest Assessment"
     collection = ImageryCollection(
         fake_collection_metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug
     )

--- a/scripts/stac/imagery/tests/item_test.py
+++ b/scripts/stac/imagery/tests/item_test.py
@@ -111,17 +111,15 @@ def test_update_item_checksum(subtests: SubTests, tmp_path: Path, fake_imagery_i
 
 # pylint: disable=duplicate-code
 def test_imagery_add_collection(fake_linz_slug: str, subtests: SubTests) -> None:
-    metadata: CollectionMetadata = {
-        "category": "urban-aerial-photos",
-        "region": "auckland",
-        "gsd": Decimal("0.3"),
-        "start_datetime": datetime(2022, 2, 2),
-        "end_datetime": datetime(2022, 2, 2),
-        "lifecycle": "completed",
-        "event_name": None,
-        "historic_survey_number": None,
-        "geographic_description": None,
-    }
+    metadata = CollectionMetadata(
+        category="urban-aerial-photos",
+        region="auckland",
+        gsd=Decimal("0.3"),
+        start_datetime=datetime(2022, 2, 2),
+        end_datetime=datetime(2022, 2, 2),
+        lifecycle="completed",
+    )
+
     ulid = "fake_ulid"
     collection = ImageryCollection(
         metadata=metadata,

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -164,17 +164,14 @@ def test_should_not_add_if_not_item(fake_linz_slug: str, capsys: CaptureFixture[
     s3_client.create_bucket(Bucket="stacfiles")
     collection_id = "abc"
     # Create mocked "existing" Collection
-    metadata: CollectionMetadata = {
-        "category": "urban-aerial-photos",
-        "region": "hawkes-bay",
-        "gsd": Decimal("1"),
-        "start_datetime": datetime(2023, 9, 20),
-        "end_datetime": datetime(2023, 9, 20),
-        "lifecycle": "ongoing",
-        "event_name": None,
-        "geographic_description": None,
-        "historic_survey_number": None,
-    }
+    metadata = CollectionMetadata(
+        category="urban-aerial-photos",
+        region="hawkes-bay",
+        gsd=Decimal("1"),
+        start_datetime=datetime(2023, 9, 20),
+        end_datetime=datetime(2023, 9, 20),
+        lifecycle="ongoing",
+    )
     existing_collection = ImageryCollection(
         metadata, any_epoch_datetime_string(), any_epoch_datetime_string(), fake_linz_slug, collection_id
     )


### PR DESCRIPTION
### Motivation

Using a `dataclass` gives advantages such as type safety at runtime, attributes access vs dictionary lookups, supports default values, IDE hints are better, etc.

### Modifications

- Convert `CollectionMetadata` from a `TypedDict` to a `dataclass`
The caveat is that the linter complains about too many instance attributes.
I've thought about splitting it up into few other dataclass, but it makes it more readable and maintainable.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Automatic tests
<!-- TODO: Say how you tested your changes. -->
