### PR TITLE
refactor: `ImageryCollection.from_file()` only handles loading the STAC metadata TDE-1443

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -45,7 +45,6 @@ WARN_NO_PUBLISHED_CAPTURE_AREA = "no_published_capture_area"
 
 class ImageryCollection:
     stac: dict[str, Any]
-    metadata: CollectionMetadata
     capture_area: dict[str, Any] | None = None
     published_location: str | None = None
 
@@ -104,12 +103,11 @@ class ImageryCollection:
         self.add_providers(merge_provider_roles(providers))
 
     @classmethod
-    def from_file(cls, path: str, metadata: CollectionMetadata) -> "ImageryCollection":
+    def from_file(cls, path: str) -> "ImageryCollection":
         """Load an ImageryCollection object from a STAC Collection file.
 
         Args:
             path: The path to the STAC Collection file to load.
-            metadata: The metadata of the Collection.
 
         Returns:
             The ImageryCollection loaded from the file.
@@ -117,16 +115,7 @@ class ImageryCollection:
         file_content = read(path)
         stac_from_file = json.loads(file_content.decode("UTF-8"))
         collection = cls.__new__(cls)
-        if metadata.collection_id != stac_from_file["id"]:
-            raise ValueError(f"Collection ID mismatch: input={metadata.collection_id} != existing={stac_from_file['id']}")
-        if metadata.linz_slug != stac_from_file["linz:slug"]:
-            get_log().warn(
-                f"Collection LINZ slug mismatch: input={metadata.linz_slug} != "
-                f"existing={stac_from_file['linz:slug']}."
-                "Keeping existing Collection linz_slug."
-            )
         collection.stac = stac_from_file
-        collection.metadata = metadata
         collection.published_location = os.path.dirname(path)
         capture_area_path = os.path.join(collection.published_location, CAPTURE_AREA_FILE_NAME)
         # Some published datasets may not have a capture-area.geojson file (TDE-988)

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -116,6 +116,11 @@ class ImageryCollection:
         stac_from_file = json.loads(file_content.decode("UTF-8"))
         collection = cls.__new__(cls)
         collection.stac = stac_from_file
+        collection.published_location = os.path.dirname(path)
+        capture_area_path = os.path.join(collection.published_location, CAPTURE_AREA_FILE_NAME)
+        # Some published datasets may not have a capture-area.geojson file (TDE-988)
+        if exists(capture_area_path):
+            collection.capture_area = json.loads(read(capture_area_path))
         return collection
 
     def add_capture_area(self, polygons: list[BaseGeometry], target: str, artifact_target: str = "/tmp") -> None:

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -103,40 +103,19 @@ class ImageryCollection:
         self.add_providers(merge_provider_roles(providers))
 
     @classmethod
-    def from_file(cls, file_name: str, metadata: CollectionMetadata, updated_datetime: str) -> "ImageryCollection":
-        """Load an ImageryCollection from a Collection file.
+    def from_file(cls, path: str) -> "ImageryCollection":
+        """Load an ImageryCollection object from a STAC Collection file.
 
         Args:
-            file_name: The s3 URL or local path of the Collection file to load.
+            path: The path to the STAC Collection file to load.
 
         Returns:
-            The loaded ImageryCollection.
+            The ImageryCollection loaded from the file.
         """
-        file_content = read(file_name)
+        file_content = read(path)
         stac_from_file = json.loads(file_content.decode("UTF-8"))
-        stac_from_file["updated"] = updated_datetime
-        if metadata.collection_id != stac_from_file["id"]:
-            raise ValueError(f"Collection ID mismatch: {metadata.collection_id} != {stac_from_file['id']}")
-        if metadata.linz_slug != stac_from_file["linz:slug"]:
-            get_log().warn(
-                f"Collection LINZ slug mismatch: {metadata.linz_slug} != {stac_from_file['linz:slug']}."
-                "Existing Collection linz_slug will be used."
-            )
-            metadata.linz_slug = stac_from_file["linz:slug"]
-        collection = cls(
-            metadata=metadata,
-            created_datetime=stac_from_file["created"],
-            updated_datetime=stac_from_file["updated"],
-        )
-        # Override STAC from the original collection
+        collection = cls.__new__(cls)
         collection.stac = stac_from_file
-
-        collection.published_location = os.path.dirname(file_name)
-        capture_area_path = os.path.join(collection.published_location, CAPTURE_AREA_FILE_NAME)
-        # Some published datasets may not have a capture-area.geojson file (TDE-988)
-        if exists(capture_area_path):
-            collection.capture_area = json.loads(read(capture_area_path))
-
         return collection
 
     def add_capture_area(self, polygons: list[BaseGeometry], target: str, artifact_target: str = "/tmp") -> None:

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -104,7 +104,7 @@ class ImageryCollection:
         self.add_providers(merge_provider_roles(providers))
 
     @classmethod
-    def from_file(cls, path: str, metadata: CollectionMetadata) -> "ImageryCollection":
+    def from_file(cls, path: str) -> "ImageryCollection":
         """Load an ImageryCollection object from a STAC Collection file.
 
         Args:
@@ -117,16 +117,7 @@ class ImageryCollection:
         file_content = read(path)
         stac_from_file = json.loads(file_content.decode("UTF-8"))
         collection = cls.__new__(cls)
-        if metadata.collection_id != stac_from_file["id"]:
-            raise ValueError(f"Collection ID mismatch: input={metadata.collection_id} != existing={stac_from_file['id']}")
-        if metadata.linz_slug != stac_from_file["linz:slug"]:
-            get_log().warn(
-                f"Collection LINZ slug mismatch: input={metadata.linz_slug} != "
-                f"existing={stac_from_file['linz:slug']}."
-                "Keeping existing Collection linz_slug."
-            )
         collection.stac = stac_from_file
-        collection.metadata = metadata
         collection.published_location = os.path.dirname(path)
         capture_area_path = os.path.join(collection.published_location, CAPTURE_AREA_FILE_NAME)
         # Some published datasets may not have a capture-area.geojson file (TDE-988)

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -45,6 +45,7 @@ WARN_NO_PUBLISHED_CAPTURE_AREA = "no_published_capture_area"
 
 class ImageryCollection:
     stac: dict[str, Any]
+    metadata: CollectionMetadata
     capture_area: dict[str, Any] | None = None
     published_location: str | None = None
 
@@ -103,11 +104,12 @@ class ImageryCollection:
         self.add_providers(merge_provider_roles(providers))
 
     @classmethod
-    def from_file(cls, path: str) -> "ImageryCollection":
+    def from_file(cls, path: str, metadata: CollectionMetadata) -> "ImageryCollection":
         """Load an ImageryCollection object from a STAC Collection file.
 
         Args:
             path: The path to the STAC Collection file to load.
+            metadata: The metadata of the Collection.
 
         Returns:
             The ImageryCollection loaded from the file.
@@ -115,7 +117,16 @@ class ImageryCollection:
         file_content = read(path)
         stac_from_file = json.loads(file_content.decode("UTF-8"))
         collection = cls.__new__(cls)
+        if metadata.collection_id != stac_from_file["id"]:
+            raise ValueError(f"Collection ID mismatch: input={metadata.collection_id} != existing={stac_from_file['id']}")
+        if metadata.linz_slug != stac_from_file["linz:slug"]:
+            get_log().warn(
+                f"Collection LINZ slug mismatch: input={metadata.linz_slug} != "
+                f"existing={stac_from_file['linz:slug']}."
+                "Keeping existing Collection linz_slug."
+            )
         collection.stac = stac_from_file
+        collection.metadata = metadata
         collection.published_location = os.path.dirname(path)
         capture_area_path = os.path.join(collection.published_location, CAPTURE_AREA_FILE_NAME)
         # Some published datasets may not have a capture-area.geojson file (TDE-988)

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -67,7 +67,17 @@ def create_collection(  # pylint: disable=too-many-arguments
     if odr_url:
         existing_collection_path = os.path.join(odr_url, COLLECTION_FILE_NAME)
         get_log().info("Retrieving existing Collection", path=existing_collection_path)
-        collection = ImageryCollection.from_file(existing_collection_path, collection_metadata)
+        collection = ImageryCollection.from_file(existing_collection_path)
+        if collection_metadata.collection_id != collection.stac["id"]:
+            raise ValueError(
+                f"Collection ID mismatch: input={collection_metadata.collection_id} != existing={collection.stac['id']}"
+            )
+        if collection_metadata.linz_slug != collection.stac["linz:slug"]:
+            get_log().warn(
+                f"Collection LINZ slug mismatch: input={collection_metadata.linz_slug} != "
+                f"existing={collection.stac['linz:slug']}."
+                "Keeping existing Collection linz_slug."
+            )
         collection.stac["updated"] = current_datetime
         published_items = collection.get_items_stac()
         stac_items = merge_item_list_for_resupply(collection, published_items, stac_items)

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -8,11 +8,11 @@ from shapely.geometry.base import BaseGeometry
 
 from scripts.files import fs
 from scripts.files.files_helper import get_file_name_from_path
-from scripts.files.fs import NoSuchFileError, exists, read
+from scripts.files.fs import NoSuchFileError, read
 from scripts.files.geotiff import get_extents
 from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo
-from scripts.stac.imagery.collection import CAPTURE_AREA_FILE_NAME, COLLECTION_FILE_NAME, ImageryCollection
+from scripts.stac.imagery.collection import COLLECTION_FILE_NAME, ImageryCollection
 from scripts.stac.imagery.item import ImageryItem, STACAsset, STACProcessing, STACProcessingSoftware
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole
@@ -79,11 +79,6 @@ def create_collection(  # pylint: disable=too-many-arguments
                 "Keeping existing Collection linz_slug."
             )
         collection.stac["updated"] = current_datetime
-        collection.published_location = os.path.dirname(existing_collection_path)
-        capture_area_path = os.path.join(collection.published_location, CAPTURE_AREA_FILE_NAME)
-        # Some published datasets may not have a capture-area.geojson file (TDE-988)
-        if exists(capture_area_path):
-            collection.capture_area = json.loads(read(capture_area_path))
         published_items = collection.get_items_stac()
         stac_items = merge_item_list_for_resupply(collection, published_items, stac_items)
 

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -67,17 +67,7 @@ def create_collection(  # pylint: disable=too-many-arguments
     if odr_url:
         existing_collection_path = os.path.join(odr_url, COLLECTION_FILE_NAME)
         get_log().info("Retrieving existing Collection", path=existing_collection_path)
-        collection = ImageryCollection.from_file(existing_collection_path)
-        if collection_metadata.collection_id != collection.stac["id"]:
-            raise ValueError(
-                f"Collection ID mismatch: input={collection_metadata.collection_id} != existing={collection.stac['id']}"
-            )
-        if collection_metadata.linz_slug != collection.stac["linz:slug"]:
-            get_log().warn(
-                f"Collection LINZ slug mismatch: input={collection_metadata.linz_slug} != "
-                f"existing={collection.stac['linz:slug']}."
-                "Keeping existing Collection linz_slug."
-            )
+        collection = ImageryCollection.from_file(existing_collection_path, collection_metadata)
         collection.stac["updated"] = current_datetime
         published_items = collection.get_items_stac()
         stac_items = merge_item_list_for_resupply(collection, published_items, stac_items)

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -67,7 +67,18 @@ def create_collection(  # pylint: disable=too-many-arguments
     if odr_url:
         existing_collection_path = os.path.join(odr_url, COLLECTION_FILE_NAME)
         get_log().info("Retrieving existing Collection", path=existing_collection_path)
-        collection = ImageryCollection.from_file(existing_collection_path, collection_metadata)
+        collection = ImageryCollection.from_file(existing_collection_path)
+        if collection_metadata.collection_id != collection.stac["id"]:
+            raise ValueError(
+                f"Collection ID mismatch: input={collection_metadata.collection_id} != existing={collection.stac['id']}"
+            )
+        if collection_metadata.linz_slug != collection.stac["linz:slug"]:
+            get_log().warn(
+                f"Collection LINZ slug mismatch: input={collection_metadata.linz_slug} != "
+                f"existing={collection.stac['linz:slug']}."
+                "Keeping existing Collection linz_slug."
+            )
+        collection.metadata = collection_metadata
         collection.stac["updated"] = current_datetime
         published_items = collection.get_items_stac()
         stac_items = merge_item_list_for_resupply(collection, published_items, stac_items)

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -8,11 +8,11 @@ from shapely.geometry.base import BaseGeometry
 
 from scripts.files import fs
 from scripts.files.files_helper import get_file_name_from_path
-from scripts.files.fs import NoSuchFileError, read
+from scripts.files.fs import NoSuchFileError, exists, read
 from scripts.files.geotiff import get_extents
 from scripts.gdal.gdal_helper import gdal_info
 from scripts.gdal.gdalinfo import GdalInfo
-from scripts.stac.imagery.collection import COLLECTION_FILE_NAME, ImageryCollection
+from scripts.stac.imagery.collection import CAPTURE_AREA_FILE_NAME, COLLECTION_FILE_NAME, ImageryCollection
 from scripts.stac.imagery.item import ImageryItem, STACAsset, STACProcessing, STACProcessingSoftware
 from scripts.stac.imagery.metadata_constants import CollectionMetadata
 from scripts.stac.imagery.provider import Provider, ProviderRole
@@ -65,9 +65,25 @@ def create_collection(  # pylint: disable=too-many-arguments
         an ImageryCollection object
     """
     if odr_url:
-        collection = ImageryCollection.from_file(
-            os.path.join(odr_url, COLLECTION_FILE_NAME), collection_metadata, current_datetime
-        )
+        existing_collection_path = os.path.join(odr_url, COLLECTION_FILE_NAME)
+        get_log().info("Retrieving existing Collection", path=existing_collection_path)
+        collection = ImageryCollection.from_file(existing_collection_path)
+        if collection_metadata.collection_id != collection.stac["id"]:
+            raise ValueError(
+                f"Collection ID mismatch: input={collection_metadata.collection_id} != existing={collection.stac['id']}"
+            )
+        if collection_metadata.linz_slug != collection.stac["linz:slug"]:
+            get_log().warn(
+                f"Collection LINZ slug mismatch: input={collection_metadata.linz_slug} != "
+                f"existing={collection.stac['linz:slug']}."
+                "Keeping existing Collection linz_slug."
+            )
+        collection.stac["updated"] = current_datetime
+        collection.published_location = os.path.dirname(existing_collection_path)
+        capture_area_path = os.path.join(collection.published_location, CAPTURE_AREA_FILE_NAME)
+        # Some published datasets may not have a capture-area.geojson file (TDE-988)
+        if exists(capture_area_path):
+            collection.capture_area = json.loads(read(capture_area_path))
         published_items = collection.get_items_stac()
         stac_items = merge_item_list_for_resupply(collection, published_items, stac_items)
 

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -528,7 +528,6 @@ def test_reset_extent(fake_collection_metadata: CollectionMetadata) -> None:
 
 
 def test_get_items_from_collection(tmp_path: Path, fake_collection_metadata: CollectionMetadata) -> None:
-    current_datetime = any_epoch_datetime_string()
     created_datetime = any_epoch_datetime_string()
 
     existing_item_path = tmp_path / "item_a.json"
@@ -563,7 +562,8 @@ def test_get_items_from_collection(tmp_path: Path, fake_collection_metadata: Col
     existing_collection_path = tmp_path / "collection.json"
     existing_collection_path.write_text(json.dumps(existing_collection_content))
 
-    collection = ImageryCollection.from_file(existing_collection_path.as_posix(), fake_collection_metadata, current_datetime)
+    collection = ImageryCollection.from_file(existing_collection_path.as_posix())
+    collection.published_location = os.path.dirname(existing_collection_path.as_posix())
     collection_items = collection.get_items_stac()
     assert len(collection_items) == 1
     assert collection_items[0] == existing_item

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -563,7 +563,6 @@ def test_get_items_from_collection(tmp_path: Path, fake_collection_metadata: Col
     existing_collection_path.write_text(json.dumps(existing_collection_content))
 
     collection = ImageryCollection.from_file(existing_collection_path.as_posix())
-    collection.published_location = os.path.dirname(existing_collection_path.as_posix())
     collection_items = collection.get_items_stac()
     assert len(collection_items) == 1
     assert collection_items[0] == existing_item

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -562,7 +562,7 @@ def test_get_items_from_collection(tmp_path: Path, fake_collection_metadata: Col
     existing_collection_path = tmp_path / "collection.json"
     existing_collection_path.write_text(json.dumps(existing_collection_content))
 
-    collection = ImageryCollection.from_file(existing_collection_path.as_posix())
+    collection = ImageryCollection.from_file(existing_collection_path.as_posix(), fake_collection_metadata)
     collection_items = collection.get_items_stac()
     assert len(collection_items) == 1
     assert collection_items[0] == existing_item

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -562,7 +562,7 @@ def test_get_items_from_collection(tmp_path: Path, fake_collection_metadata: Col
     existing_collection_path = tmp_path / "collection.json"
     existing_collection_path.write_text(json.dumps(existing_collection_content))
 
-    collection = ImageryCollection.from_file(existing_collection_path.as_posix(), fake_collection_metadata)
+    collection = ImageryCollection.from_file(existing_collection_path.as_posix())
     collection_items = collection.get_items_stac()
     assert len(collection_items) == 1
     assert collection_items[0] == existing_item


### PR DESCRIPTION
### Motivation

`ImageryCollection.from_file()` should only handle loading the STAC metadata from the existing Collection file and not doing any other logic.

### Modifications

- Move extra logic where loading the collection is called from.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Automated tests
