### PR TITLE
refactor: improve pytest parametrized tests output TDE-1464

### DIFF
--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -12,7 +12,7 @@ from boto3 import client
 from moto import mock_aws
 from moto.s3.responses import DEFAULT_REGION_NAME
 from mypy_boto3_s3 import S3Client
-from pytest import CaptureFixture, mark
+from pytest import CaptureFixture, mark, param
 from pytest_subtests import SubTests
 from shapely.predicates import is_valid
 
@@ -66,41 +66,46 @@ def test_title_description_id_created_on_init(fake_collection_context: Collectio
 @mark.parametrize(
     "category, gsd, expected_title, expected_description",
     [
-        (
+        param(
             "dem-hillshade",
             Decimal(8),
             "New Zealand 8m DEM Hillshade",
             "Hillshade generated from the New Zealand Contour-Derived 8m DEM using GDAL’s "
             "default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
+            id="8m DEM Hillshade",
         ),
-        (
+        param(
             "dem-hillshade-igor",
             Decimal(8),
             "New Zealand 8m DEM Hillshade - Igor",
             "Hillshade generated from the New Zealand Contour-Derived 8m DEM using the -igor option in GDAL. "
             "This renders a softer hillshade that tries to minimize effects on other map features.",
+            id="8m DEM Hillshade Igor",
         ),
-        (
+        param(
             "dem-hillshade",
             Decimal(1),
             "New Zealand DEM Hillshade",
             "Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no "
             "1m DEM data exists) using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
+            id="1m/8m DEM Hillshade",
         ),
-        (
+        param(
             "dem-hillshade-igor",
             Decimal(1),
             "New Zealand DEM Hillshade - Igor",
             "Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no "
             "1m DEM data exists) using the -igor option in GDAL. This renders a softer hillshade that tries to "
             "minimize effects on other map features.",
+            id="1m/8m DEM Hillshade Igor",
         ),
-        (
+        param(
             "dem-hillshade",
             Decimal(0.25),
             "New Zealand DEM Hillshade",
             "Hillshade generated from the New Zealand LiDAR 0.25m DEM and New Zealand Contour-Derived 8m DEM (where no "
             "0.25m DEM data exists) using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
+            id="0.25m/8m DEM Hillshade",
         ),
     ],
 )
@@ -117,10 +122,10 @@ def test_hillshade_title_and_description(
     fake_collection_context.gsd = gsd
     collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
 
-    with subtests.test(msg=f"{gsd}m DEM Hillshade Title"):
+    with subtests.test(msg="title"):
         assert collection.stac["title"] == expected_title
 
-    with subtests.test(msg=f"{gsd}m DEM Hillshade Description"):
+    with subtests.test(msg="description"):
         assert collection.stac["description"] == expected_description
 
 


### PR DESCRIPTION
### Motivation

When running `pytest`, the `parametrized` tests output is difficult to read. For example:
```shell
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd0-New Zealand 8m DEM Hillshade-Hillshade generated from the New Zealand Contour-Derived 8m DEM using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] [8m DEM Hillshade Title] SUBPASS [  7%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd0-New Zealand 8m DEM Hillshade-Hillshade generated from the New Zealand Contour-Derived 8m DEM using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] [8m DEM Hillshade Description] SUBPASS [  7%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd0-New Zealand 8m DEM Hillshade-Hillshade generated from the New Zealand Contour-Derived 8m DEM using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] PASSED [  7%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-igor-gsd1-New Zealand 8m DEM Hillshade - Igor-Hillshade generated from the New Zealand Contour-Derived 8m DEM using the -igor option in GDAL. This renders a softer hillshade that tries to minimize effects on other map features.] [8m DEM Hillshade Title] SUBPASS [ 10%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-igor-gsd1-New Zealand 8m DEM Hillshade - Igor-Hillshade generated from the New Zealand Contour-Derived 8m DEM using the -igor option in GDAL. This renders a softer hillshade that tries to minimize effects on other map features.] [8m DEM Hillshade Description] SUBPASS [ 10%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-igor-gsd1-New Zealand 8m DEM Hillshade - Igor-Hillshade generated from the New Zealand Contour-Derived 8m DEM using the -igor option in GDAL. This renders a softer hillshade that tries to minimize effects on other map features.] PASSED [ 10%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd2-New Zealand DEM Hillshade-Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no 1m DEM data exists) using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] [1m DEM Hillshade Title] SUBPASS [ 14%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd2-New Zealand DEM Hillshade-Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no 1m DEM data exists) using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] [1m DEM Hillshade Description] SUBPASS [ 14%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd2-New Zealand DEM Hillshade-Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no 1m DEM data exists) using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] PASSED [ 14%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-igor-gsd3-New Zealand DEM Hillshade - Igor-Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no 1m DEM data exists) using the -igor option in GDAL. This renders a softer hillshade that tries to minimize effects on other map features.] [1m DEM Hillshade Title] SUBPASS [ 17%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-igor-gsd3-New Zealand DEM Hillshade - Igor-Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no 1m DEM data exists) using the -igor option in GDAL. This renders a softer hillshade that tries to minimize effects on other map features.] [1m DEM Hillshade Description] SUBPASS [ 17%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-igor-gsd3-New Zealand DEM Hillshade - Igor-Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no 1m DEM data exists) using the -igor option in GDAL. This renders a softer hillshade that tries to minimize effects on other map features.] PASSED [ 17%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd4-New Zealand DEM Hillshade-Hillshade generated from the New Zealand LiDAR 0.25m DEM and New Zealand Contour-Derived 8m DEM (where no 0.25m DEM data exists) using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] [0.25m DEM Hillshade Title] SUBPASS [ 21%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd4-New Zealand DEM Hillshade-Hillshade generated from the New Zealand LiDAR 0.25m DEM and New Zealand Contour-Derived 8m DEM (where no 0.25m DEM data exists) using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] [0.25m DEM Hillshade Description] SUBPASS [ 21%]
scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[dem-hillshade-gsd4-New Zealand DEM Hillshade-Hillshade generated from the New Zealand LiDAR 0.25m DEM and New Zealand Contour-Derived 8m DEM (where no 0.25m DEM data exists) using GDAL\u2019s default hillshading parameters of 315\u02da azimuth and 45\u02da elevation angle.] PASSED [ 21%]
```

### Modifications

- Use [`pytest.param`](https://docs.pytest.org/en/stable/example/parametrize.html#set-marks-or-test-id-for-individual-parametrized-test) to specify a test ID:
   ```shell
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[8m DEM Hillshade] [title] SUBPASS                                                                                                                        [  7%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[8m DEM Hillshade] [description] SUBPASS                                                                                                                  [  7%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[8m DEM Hillshade] PASSED                                                                                                                                 [  7%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[8m DEM Hillshade Igor] [title] SUBPASS                                                                                                                   [ 10%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[8m DEM Hillshade Igor] [description] SUBPASS                                                                                                             [ 10%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[8m DEM Hillshade Igor] PASSED                                                                                                                            [ 10%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[1m/8m DEM Hillshade] [title] SUBPASS                                                                                                                     [ 14%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[1m/8m DEM Hillshade] [description] SUBPASS                                                                                                               [ 14%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[1m/8m DEM Hillshade] PASSED                                                                                                                              [ 14%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[1m/8m DEM Hillshade Igor] [title] SUBPASS                                                                                                                [ 17%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[1m/8m DEM Hillshade Igor] [description] SUBPASS                                                                                                          [ 17%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[1m/8m DEM Hillshade Igor] PASSED                                                                                                                         [ 17%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[0.25m/8m DEM Hillshade] [title] SUBPASS                                                                                                                  [ 21%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[0.25m/8m DEM Hillshade] [description] SUBPASS                                                                                                            [ 21%]
   scripts/stac/imagery/tests/collection_test.py::test_hillshade_title_and_description[0.25m/8m DEM Hillshade] PASSED  
   ```
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

- run `pytest`
