### PR TITLE
feat: support national DSM hillshades TDE-1455

### DIFF
--- a/scripts/stac/imagery/collection_context.py
+++ b/scripts/stac/imagery/collection_context.py
@@ -8,6 +8,8 @@ from scripts.stac.imagery.constants import (
     DEM_HILLSHADE,
     DEM_HILLSHADE_IGOR,
     DSM,
+    DSM_HILLSHADE,
+    DSM_HILLSHADE_IGOR,
     HUMAN_READABLE_REGIONS,
     LIFECYCLE_SUFFIXES,
     RURAL_AERIAL_PHOTOS,
@@ -149,12 +151,11 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
                 lifecycle_suffix,
             ]
 
-        elif category in {DEM_HILLSHADE, DEM_HILLSHADE_IGOR}:
+        elif category in {DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR}:
             components = [
                 region,
-                gsd_str if self.gsd == 8 else None,
-                "DEM Hillshade",
-                "- Igor" if category == DEM_HILLSHADE_IGOR else None,
+                gsd_str,  # if self.gsd == 8 else None,
+                DATA_CATEGORIES[category],
             ]
 
         else:
@@ -201,7 +202,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
 
         if category in base_descriptions:
             desc = f"{base_descriptions[category]} within the {region} region captured in {date}"
-        elif category.startswith(DEM_HILLSHADE):
+        elif category in {DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR}:
             desc = self._description_hillshade
         else:
             raise SubtypeParameterError(category)
@@ -215,22 +216,26 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
         """Generates the description for hillshade datasets."""
 
         region = HUMAN_READABLE_REGIONS[self.region]
-        category = self.category
+        category = DATA_CATEGORIES[self.category]
+        category_prefix = category[0:3]  # e.g. "dem" or "dsm"
+        category_suffix = category[4:]  # e.g. "hillshade" or "hillshade-igor"
         gsd_str = f"{self.gsd}{GSD_UNIT}"
 
-        if category == DEM_HILLSHADE_IGOR:
+        if category_suffix == "Hillshade":
+            shading_option = "GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle"
+        else:
             shading_option = (
                 "the -igor option in GDAL. "
                 "This renders a softer hillshade that tries to minimize effects on other map features"
             )
-        else:
-            shading_option = "GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle"
 
         components = [
             "Hillshade generated from the",
-            f"{region} LiDAR {gsd_str} DEM and" if gsd_str != "8m" else None,
-            f"{region} Contour-Derived 8m DEM",
-            f"(where no {self.gsd}m DEM data exists)" if gsd_str != "8m" else None,
+            region,
+            "LiDAR" if gsd_str != "8m" else "Contour-Derived",
+            gsd_str,
+            category_prefix,
+            # f"(where no {self.gsd}m DEM data exists)" if gsd_str != "8m" else None,
             "using",
             shading_option,
         ]

--- a/scripts/stac/imagery/collection_context.py
+++ b/scripts/stac/imagery/collection_context.py
@@ -154,7 +154,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
         elif category in {DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR}:
             components = [
                 region,
-                gsd_str,  # if self.gsd == 8 else None,
+                gsd_str,
                 DATA_CATEGORIES[category],
             ]
 
@@ -235,7 +235,6 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
             "LiDAR" if gsd_str != "8m" else "Contour-Derived",
             gsd_str,
             category_prefix,
-            # f"(where no {self.gsd}m DEM data exists)" if gsd_str != "8m" else None,
             "using",
             shading_option,
         ]

--- a/scripts/stac/imagery/constants.py
+++ b/scripts/stac/imagery/constants.py
@@ -7,6 +7,8 @@ DEM = "dem"
 DSM = "dsm"
 DEM_HILLSHADE = "dem-hillshade"
 DEM_HILLSHADE_IGOR = "dem-hillshade-igor"
+DSM_HILLSHADE = "dsm-hillshade"
+DSM_HILLSHADE_IGOR = "dsm-hillshade-igor"
 
 DATA_CATEGORIES = {
     AERIAL_PHOTOS: "Aerial Photos",
@@ -17,7 +19,9 @@ DATA_CATEGORIES = {
     DEM: "DEM",
     DSM: "DSM",
     DEM_HILLSHADE: "DEM Hillshade",
-    DEM_HILLSHADE_IGOR: "DEM Hillshade Igor",
+    DEM_HILLSHADE_IGOR: "DEM Hillshade - Igor",
+    DSM_HILLSHADE: "DSM Hillshade",
+    DSM_HILLSHADE_IGOR: "DSM Hillshade - Igor",
 }
 
 HUMAN_READABLE_REGIONS = {

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -83,29 +83,45 @@ def test_title_description_id_created_on_init(fake_collection_context: Collectio
             id="8m DEM Hillshade Igor",
         ),
         param(
+            "dsm-hillshade",
+            Decimal(1),
+            "New Zealand 1m DSM Hillshade",
+            "Hillshade generated from the New Zealand LiDAR 1m DSM using GDAL’s "
+            "default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
+            id="1m DSM Hillshade",
+        ),
+        param(
+            "dsm-hillshade-igor",
+            Decimal(1),
+            "New Zealand 1m DSM Hillshade - Igor",
+            "Hillshade generated from the New Zealand LiDAR 1m DSM using the -igor option in GDAL. "
+            "This renders a softer hillshade that tries to minimize effects on other map features.",
+            id="1m DSM Hillshade Igor",
+        ),
+        param(
             "dem-hillshade",
             Decimal(1),
-            "New Zealand DEM Hillshade",
-            "Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no "
-            "1m DEM data exists) using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
-            id="1m/8m DEM Hillshade",
+            "New Zealand 1m DEM Hillshade",
+            "Hillshade generated from the New Zealand LiDAR 1m DEM "
+            "using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
+            id="1m DEM Hillshade",
         ),
         param(
             "dem-hillshade-igor",
             Decimal(1),
-            "New Zealand DEM Hillshade - Igor",
-            "Hillshade generated from the New Zealand LiDAR 1m DEM and New Zealand Contour-Derived 8m DEM (where no "
-            "1m DEM data exists) using the -igor option in GDAL. This renders a softer hillshade that tries to "
+            "New Zealand 1m DEM Hillshade - Igor",
+            "Hillshade generated from the New Zealand LiDAR 1m DEM "
+            "using the -igor option in GDAL. This renders a softer hillshade that tries to "
             "minimize effects on other map features.",
-            id="1m/8m DEM Hillshade Igor",
+            id="1m DEM Hillshade Igor",
         ),
         param(
             "dem-hillshade",
             Decimal(0.25),
-            "New Zealand DEM Hillshade",
-            "Hillshade generated from the New Zealand LiDAR 0.25m DEM and New Zealand Contour-Derived 8m DEM (where no "
-            "0.25m DEM data exists) using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
-            id="0.25m/8m DEM Hillshade",
+            "New Zealand 0.25m DEM Hillshade",
+            "Hillshade generated from the New Zealand LiDAR 0.25m DEM "
+            "using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
+            id="0.25m DEM Hillshade",
         ),
     ],
 )


### PR DESCRIPTION
### Motivation

As a Basemaps user
I want national DSM hillshades (1m and unspecified resolution, standard and igor)
So that I can view/accentuate terrain detail in a variety of basemaps.
### Modifications

- add description/title templates for DSM hillshades in collection context
- add test cases for DSM hillshades
- add constants for DSM hillshades

### Verification

Added tests, run workflows using PR container