### PR TITLE
feat: add dataset domain TDE-1542

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -17,7 +17,7 @@ from scripts.gdal.gdal_footprint import SUFFIX_FOOTPRINT
 from scripts.logging.time_helper import time_in_ms
 from scripts.stac.imagery.collection import COLLECTION_FILE_NAME
 from scripts.stac.imagery.collection_context import CollectionContext
-from scripts.stac.imagery.constants import DATA_CATEGORIES, DATA_SUBTYPES, HUMAN_READABLE_REGIONS, LAND
+from scripts.stac.imagery.constants import DATA_CATEGORIES, DATA_DOMAINS, HUMAN_READABLE_REGIONS, LAND
 from scripts.stac.imagery.create_stac import create_collection
 
 if TYPE_CHECKING:
@@ -48,11 +48,11 @@ def parse_args(args: List[str] | None) -> Namespace:
         choices=DATA_CATEGORIES.keys(),
     )
     parser.add_argument(
-        "--subtype",
-        dest="subtype",
-        help="Dataset subtype",
+        "--domain",
+        dest="domain",
+        help="Dataset domain",
         default=LAND,
-        choices=DATA_SUBTYPES.keys(),
+        choices=DATA_DOMAINS.keys(),
     )
     parser.add_argument(
         "--region",
@@ -205,7 +205,7 @@ def main(args: List[str] | None = None) -> None:
 
     collection_context = CollectionContext(
         category=arguments.category,
-        subtype=arguments.subtype,
+        domain=arguments.domain,
         region=arguments.region,
         gsd=arguments.gsd,
         lifecycle=arguments.lifecycle,

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -17,7 +17,7 @@ from scripts.gdal.gdal_footprint import SUFFIX_FOOTPRINT
 from scripts.logging.time_helper import time_in_ms
 from scripts.stac.imagery.collection import COLLECTION_FILE_NAME
 from scripts.stac.imagery.collection_context import CollectionContext
-from scripts.stac.imagery.constants import DATA_CATEGORIES, HUMAN_READABLE_REGIONS
+from scripts.stac.imagery.constants import DATA_CATEGORIES, DATA_SUBTYPES, HUMAN_READABLE_REGIONS, LAND
 from scripts.stac.imagery.create_stac import create_collection
 
 if TYPE_CHECKING:
@@ -43,9 +43,16 @@ def parse_args(args: List[str] | None) -> Namespace:
     parser.add_argument(
         "--category",
         dest="category",
-        help="Dataset category description",
+        help="Dataset category",
         required=True,
         choices=DATA_CATEGORIES.keys(),
+    )
+    parser.add_argument(
+        "--subtype",
+        dest="subtype",
+        help="Dataset subtype",
+        default=LAND,
+        choices=DATA_SUBTYPES.keys(),
     )
     parser.add_argument(
         "--region",
@@ -198,6 +205,7 @@ def main(args: List[str] | None = None) -> None:
 
     collection_context = CollectionContext(
         category=arguments.category,
+        subtype=arguments.subtype,
         region=arguments.region,
         gsd=arguments.gsd,
         lifecycle=arguments.lifecycle,

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -21,6 +21,7 @@ def fake_linz_slug() -> str:
 def fake_collection_context() -> Iterator[CollectionContext]:
     yield CollectionContext(
         category="rural-aerial-photos",
+        subtype="land",
         region="hawkes-bay",
         gsd=Decimal("0.3"),
         lifecycle="completed",

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -21,7 +21,7 @@ def fake_linz_slug() -> str:
 def fake_collection_context() -> Iterator[CollectionContext]:
     yield CollectionContext(
         category="rural-aerial-photos",
-        subtype="land",
+        domain="land",
         region="hawkes-bay",
         gsd=Decimal("0.3"),
         lifecycle="completed",

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -289,11 +289,11 @@ class ImageryCollection:
             DSM: "Digital Surface Model",
         }
 
-        subtype_prefix = DATA_DOMAINS[self.domain]
+        domain_prefix = DATA_DOMAINS[self.domain]
         desc_prefix = ""
         # domain is only used for DEM/DSM categories
-        if category in {DEM, DSM, DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR} and subtype_prefix:
-            desc_prefix = f"{subtype_prefix} "
+        if category in {DEM, DSM, DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR} and domain_prefix:
+            desc_prefix = f"{domain_prefix} "
 
         if category in base_descriptions:
             desc = f"{desc_prefix}{base_descriptions[category]} within the {region} region captured in {date}"

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -17,7 +17,7 @@ from scripts.stac.imagery.capture_area import generate_capture_area
 from scripts.stac.imagery.collection_context import CollectionContext
 from scripts.stac.imagery.constants import (
     DATA_CATEGORIES,
-    DATA_SUBTYPES,
+    DATA_DOMAINS,
     DEM,
     DEM_HILLSHADE,
     DEM_HILLSHADE_IGOR,
@@ -59,7 +59,7 @@ class MissingMetadataError(Exception):
 class ImageryCollection:
     stac: dict[str, Any]
     gsd: Decimal
-    subtype: str
+    domain: str
     capture_area: dict[str, Any] | None = None
     publish_capture_area = True
     published_location: str | None = None
@@ -75,7 +75,7 @@ class ImageryCollection:
             context.collection_id = str(ulid.ULID())
 
         self.gsd = context.gsd
-        self.subtype = context.subtype
+        self.domain = context.domain
         self.add_title_suffix = context.add_title_suffix
 
         self.stac = {
@@ -164,7 +164,7 @@ class ImageryCollection:
 
         self.stac["updated"] = updated_datetime
         self.gsd = context.gsd
-        self.subtype = context.subtype
+        self.domain = context.domain
         self.add_title_suffix = context.add_title_suffix
 
     def set_title(self) -> None:
@@ -229,7 +229,7 @@ class ImageryCollection:
                 region,
                 "-" if geographic_description else None,
                 geographic_description,
-                DATA_SUBTYPES[self.subtype],
+                DATA_DOMAINS[self.domain],
                 "LiDAR",
                 gsd_str,
                 DATA_CATEGORIES[category],
@@ -240,7 +240,7 @@ class ImageryCollection:
         elif category in {DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR}:
             components = [
                 region,
-                DATA_SUBTYPES[self.subtype],
+                DATA_DOMAINS[self.domain],
                 gsd_str,
                 DATA_CATEGORIES[category],
             ]
@@ -289,9 +289,9 @@ class ImageryCollection:
             DSM: "Digital Surface Model",
         }
 
-        subtype_prefix = DATA_SUBTYPES[self.subtype]
+        subtype_prefix = DATA_DOMAINS[self.domain]
         desc_prefix = ""
-        # subtype is only used for DEM/DSM categories
+        # domain is only used for DEM/DSM categories
         if category in {DEM, DSM, DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR} and subtype_prefix:
             desc_prefix = f"{subtype_prefix} "
 

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -290,7 +290,10 @@ class ImageryCollection:
         }
 
         subtype_prefix = DATA_SUBTYPES[self.subtype]
-        desc_prefix = f"{subtype_prefix} " if subtype_prefix else ""
+        desc_prefix = ""
+        # subtype is only used for DEM/DSM categories
+        if category in {DEM, DSM, DEM_HILLSHADE, DEM_HILLSHADE_IGOR, DSM_HILLSHADE, DSM_HILLSHADE_IGOR} and subtype_prefix:
+            desc_prefix = f"{subtype_prefix} "
 
         if category in base_descriptions:
             desc = f"{desc_prefix}{base_descriptions[category]} within the {region} region captured in {date}"

--- a/scripts/stac/imagery/collection_context.py
+++ b/scripts/stac/imagery/collection_context.py
@@ -35,6 +35,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
     """
 
     category: str
+    subtype: str
     region: str
     gsd: Decimal
     lifecycle: str

--- a/scripts/stac/imagery/collection_context.py
+++ b/scripts/stac/imagery/collection_context.py
@@ -18,6 +18,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
 
     Attributes:
         category (str): The category of the dataset (e.g., "satellite-imagery").
+        domain (str): The domain of the dataset (e.g., "land").
         region (str): The region of the dataset (e.g., "auckland").
         gsd (Decimal): Ground Sample Distance in meters.
         lifecycle (str): Lifecycle status of the dataset (e.g., "completed").
@@ -35,7 +36,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
     """
 
     category: str
-    subtype: str
+    domain: str
     region: str
     gsd: Decimal
     lifecycle: str

--- a/scripts/stac/imagery/constants.py
+++ b/scripts/stac/imagery/constants.py
@@ -1,3 +1,4 @@
+# CATEGORIES
 AERIAL_PHOTOS = "aerial-photos"
 SCANNED_AERIAL_PHOTOS = "scanned-aerial-photos"
 RURAL_AERIAL_PHOTOS = "rural-aerial-photos"
@@ -9,6 +10,10 @@ DEM_HILLSHADE = "dem-hillshade"
 DEM_HILLSHADE_IGOR = "dem-hillshade-igor"
 DSM_HILLSHADE = "dsm-hillshade"
 DSM_HILLSHADE_IGOR = "dsm-hillshade-igor"
+# SUBTYPES
+LAND = "land"
+COASTAL = "coastal"
+
 
 DATA_CATEGORIES = {
     AERIAL_PHOTOS: "Aerial Photos",
@@ -22,6 +27,11 @@ DATA_CATEGORIES = {
     DEM_HILLSHADE_IGOR: "DEM Hillshade - Igor",
     DSM_HILLSHADE: "DSM Hillshade",
     DSM_HILLSHADE_IGOR: "DSM Hillshade - Igor",
+}
+
+DATA_SUBTYPES = {
+    LAND: "",
+    COASTAL: "Coastal",
 }
 
 HUMAN_READABLE_REGIONS = {

--- a/scripts/stac/imagery/constants.py
+++ b/scripts/stac/imagery/constants.py
@@ -10,7 +10,7 @@ DEM_HILLSHADE = "dem-hillshade"
 DEM_HILLSHADE_IGOR = "dem-hillshade-igor"
 DSM_HILLSHADE = "dsm-hillshade"
 DSM_HILLSHADE_IGOR = "dsm-hillshade-igor"
-# SUBTYPES
+# DOMAINS
 LAND = "land"
 COASTAL = "coastal"
 
@@ -29,7 +29,7 @@ DATA_CATEGORIES = {
     DSM_HILLSHADE_IGOR: "DSM Hillshade - Igor",
 }
 
-DATA_SUBTYPES = {
+DATA_DOMAINS = {
     LAND: "",
     COASTAL: "Coastal",
 }

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -64,7 +64,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="rural-aerial-photos",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -78,7 +78,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="dem",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -92,7 +92,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="dsm",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -106,7 +106,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="satellite-imagery",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -120,7 +120,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="scanned-aerial-photos",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -135,7 +135,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="rural-aerial-photos",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -150,7 +150,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="rural-aerial-photos",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -167,7 +167,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -184,7 +184,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="satellite-imagery",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -201,7 +201,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="preview",
                 linz_slug=fake_linz_slug(),
@@ -215,7 +215,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="rural-aerial-photos",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="ongoing",
                 linz_slug=fake_linz_slug(),
@@ -229,7 +229,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="rural-aerial-photos",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="ongoing",
                 linz_slug=fake_linz_slug(),
@@ -244,7 +244,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="rural-aerial-photos",
-                subtype="land",
+                domain="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -260,7 +260,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade",
-                subtype="land",
+                domain="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -277,7 +277,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade-igor",
-                subtype="land",
+                domain="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -294,7 +294,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm-hillshade",
-                subtype="land",
+                domain="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -311,7 +311,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm-hillshade-igor",
-                subtype="land",
+                domain="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -328,7 +328,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade",
-                subtype="land",
+                domain="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -345,7 +345,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade-igor",
-                subtype="land",
+                domain="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -363,7 +363,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade",
-                subtype="land",
+                domain="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -380,7 +380,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem",
-                subtype="coastal",
+                domain="coastal",
                 region="bay-of-plenty",
                 geographic_description="Tauranga",
                 lifecycle="completed",
@@ -395,7 +395,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade",
-                subtype="coastal",
+                domain="coastal",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -412,7 +412,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade-igor",
-                subtype="coastal",
+                domain="coastal",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -941,7 +941,7 @@ def test_update_metadata(fake_collection_context: CollectionContext, subtests: S
     old_slug = collection.stac["linz:slug"]
     new_metadata = CollectionContext(
         category="rural-aerial-photos",
-        subtype="land",
+        domain="land",
         region="hawkes-bay",
         gsd=Decimal("0.3"),
         lifecycle="ongoing",

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -64,6 +64,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="rural-aerial-photos",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -77,6 +78,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="dem",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -90,6 +92,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="dsm",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -103,6 +106,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="satellite-imagery",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -116,6 +120,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="scanned-aerial-photos",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -130,6 +135,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="rural-aerial-photos",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -144,6 +150,7 @@ def test_metadata_initialised(fake_collection_context: CollectionContext, subtes
         param(
             CollectionContext(
                 category="rural-aerial-photos",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -160,6 +167,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -176,6 +184,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="satellite-imagery",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -192,6 +201,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="preview",
                 linz_slug=fake_linz_slug(),
@@ -205,6 +215,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="rural-aerial-photos",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="ongoing",
                 linz_slug=fake_linz_slug(),
@@ -218,6 +229,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="rural-aerial-photos",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="ongoing",
                 linz_slug=fake_linz_slug(),
@@ -232,6 +244,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="rural-aerial-photos",
+                subtype="land",
                 region="hawkes-bay",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -247,6 +260,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade",
+                subtype="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -263,6 +277,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade-igor",
+                subtype="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -279,6 +294,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm-hillshade",
+                subtype="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -295,6 +311,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dsm-hillshade-igor",
+                subtype="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -311,6 +328,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade",
+                subtype="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -327,6 +345,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade-igor",
+                subtype="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -344,6 +363,7 @@ published as a record of the Cyclone Gabrielle event.",
         param(
             CollectionContext(
                 category="dem-hillshade",
+                subtype="land",
                 region="new-zealand",
                 lifecycle="completed",
                 linz_slug=fake_linz_slug(),
@@ -356,6 +376,56 @@ published as a record of the Cyclone Gabrielle event.",
             "Hillshade generated from the New Zealand LiDAR 0.25m DEM "
             "using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
             id="0.25m DEM Hillshade",
+        ),
+        param(
+            CollectionContext(
+                category="dem",
+                subtype="coastal",
+                region="bay-of-plenty",
+                geographic_description="Tauranga",
+                lifecycle="completed",
+                linz_slug=fake_linz_slug(),
+                gsd=Decimal("1"),
+                collection_id="a-random-collection-id",
+            ),
+            "Bay of Plenty - Tauranga Coastal LiDAR 1m DEM (2023)",
+            "Coastal Digital Elevation Model within the Bay of Plenty region captured in 2023.",
+            id="Coastal DEM",
+        ),
+        param(
+            CollectionContext(
+                category="dem-hillshade",
+                subtype="coastal",
+                region="new-zealand",
+                lifecycle="completed",
+                linz_slug=fake_linz_slug(),
+                gsd=Decimal("1"),
+                collection_id="a-random-collection-id",
+                geographic_description="",
+                event_name="",
+            ),
+            "New Zealand Coastal 1m DEM Hillshade",
+            "Coastal Hillshade generated from the New Zealand LiDAR 1m DEM "
+            "using GDAL’s default hillshading parameters of 315˚ azimuth and 45˚ elevation angle.",
+            id="Coastal 1m DEM Hillshade",
+        ),
+        param(
+            CollectionContext(
+                category="dem-hillshade-igor",
+                subtype="coastal",
+                region="new-zealand",
+                lifecycle="completed",
+                linz_slug=fake_linz_slug(),
+                gsd=Decimal("1"),
+                collection_id="a-random-collection-id",
+                geographic_description="",
+                event_name="",
+            ),
+            "New Zealand Coastal 1m DEM Hillshade - Igor",
+            "Coastal Hillshade generated from the New Zealand LiDAR 1m DEM "
+            "using the -igor option in GDAL. This renders a softer hillshade that tries to "
+            "minimize effects on other map features.",
+            id="Coastal 1m DEM Hillshade Igor",
         ),
     ],
 )
@@ -871,6 +941,7 @@ def test_update_metadata(fake_collection_context: CollectionContext, subtests: S
     old_slug = collection.stac["linz:slug"]
     new_metadata = CollectionContext(
         category="rural-aerial-photos",
+        subtype="land",
         region="hawkes-bay",
         gsd=Decimal("0.3"),
         lifecycle="ongoing",

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -93,7 +93,7 @@ def test_should_create_coastal_collection_file(item: ImageryItem, fake_collectio
         "--collection-id",
         "abc",
         "--category",
-        "urban-aerial-photos",
+        "dem",
         "--subtype",
         "coastal",
         "--region",
@@ -114,9 +114,9 @@ def test_should_create_coastal_collection_file(item: ImageryItem, fake_collectio
     # Call script's main function
     main(args)
 
-    # Verify collection.json has been created
+    # Verify collection.json has been created with "Coastal" information
     resp = s3_client.get_object(Bucket="stacfiles", Key="collection.json")
-    assert '"type": "Collection"' in resp["Body"].read().decode("utf-8")
+    assert "Coastal" in resp["Body"].read().decode("utf-8")
 
 
 @mock_aws

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -94,7 +94,7 @@ def test_should_create_coastal_collection_file(item: ImageryItem, fake_collectio
         "abc",
         "--category",
         "dem",
-        "--subtype",
+        "--domain",
         "coastal",
         "--region",
         "hawkes-bay",

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -80,6 +80,46 @@ def test_should_create_collection_file(item: ImageryItem, fake_collection_contex
 
 
 @mock_aws
+def test_should_create_coastal_collection_file(item: ImageryItem, fake_collection_context: CollectionContext) -> None:
+    # Mock AWS S3
+    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="stacfiles")
+    item.add_collection("abc")
+    write("s3://stacfiles/item.json", dict_to_json_bytes(item.stac))
+    # CLI arguments
+    args = [
+        "--uri",
+        "s3://stacfiles/",
+        "--collection-id",
+        "abc",
+        "--category",
+        "urban-aerial-photos",
+        "--subtype",
+        "coastal",
+        "--region",
+        "hawkes-bay",
+        "--gsd",
+        "1m",
+        "--lifecycle",
+        "ongoing",
+        "--producer",
+        "Placeholder",
+        "--licensor",
+        "Placeholder",
+        "--concurrency",
+        "25",
+        "--linz-slug",
+        fake_collection_context.linz_slug,
+    ]
+    # Call script's main function
+    main(args)
+
+    # Verify collection.json has been created
+    resp = s3_client.get_object(Bucket="stacfiles", Key="collection.json")
+    assert '"type": "Collection"' in resp["Body"].read().decode("utf-8")
+
+
+@mock_aws
 def test_should_fail_if_collection_has_no_matching_items(
     item: ImageryItem, fake_collection_context: CollectionContext, capsys: CaptureFixture[str], subtests: SubTests
 ) -> None:


### PR DESCRIPTION
### Motivation

Some datasets share the same category (for example, "DEM") but diverge on their domain such as the Coastal datasets.

### Modifications

- add a dataset domain to handle Collection Title and Description. Default domain is "Land" and is not visible in the generated data.

See https://github.com/linz/elevation/pull/420
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Automated tests
Argo Workflows
<!-- TODO: Say how you tested your changes. -->
