### PR TITLE
feat: keep existing collection description TDE-1498

### DIFF
--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -121,6 +121,13 @@ def parse_args(args: List[str] | None) -> Namespace:
         required=False,
     )
     parser.add_argument(
+        "--keep-description",
+        dest="keep_description",
+        help="Keep the description of the existing Collection as is.",
+        type=str_to_bool,
+        required=False,
+    )
+    parser.add_argument(
         "--keep-title",
         dest="keep_title",
         help="Keep the title of the existing Collection as is.",
@@ -219,6 +226,7 @@ def main(args: List[str] | None = None) -> None:
         add_title_suffix=arguments.add_title_suffix,
         add_capture_dates=arguments.capture_dates,
         delete_existing_items=arguments.delete_all_existing_items,
+        keep_description=arguments.keep_description,
         keep_title=arguments.keep_title,
     )
 

--- a/scripts/stac/imagery/collection_context.py
+++ b/scripts/stac/imagery/collection_context.py
@@ -30,6 +30,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
         event_name (str | None): Event name, if applicable.
         historic_survey_number (str | None): Historic survey number, if applicable.
         add_title_suffix (bool): Whether to add a suffix based on lifecycle status.
+        keep_description (bool): Whether to keep the original description.
         keep_title (bool): Whether to keep the original title.
         add_capture_dates (bool): Whether to link the capture dates file to the Collection.
         delete_existing_items (bool): Whether to delete existing items in the collection.
@@ -48,6 +49,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
     event_name: str | None = None
     historic_survey_number: str | None = None
     add_title_suffix: bool = True
+    keep_description: bool = False
     keep_title: bool = False
     add_capture_dates: bool = False
     delete_existing_items: bool = False

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -40,6 +40,7 @@ def create_collection(
         item_polygons: list of polygons of the items linked to the Collection
         uri: path of the dataset
         add_capture_dates: whether to add the capture-dates file to the Collection. Defaults to False.
+        keep_description: whether to keep the description in the existing Collection. Defaults to False.
         keep_title: whether to keep the title in the existing Collection. Defaults to False.
         odr_url: path of the published dataset. Defaults to None.
 
@@ -83,7 +84,8 @@ def create_collection(
     # At this stage the title and description can be set using the temporal extent for the dates
     if not collection_context.keep_title or not odr_url:
         collection.set_title()
-    collection.set_description()
+    if not collection_context.keep_description or not odr_url:
+        collection.set_description()
 
     if collection_context.add_capture_dates:
         collection.add_capture_dates(uri)

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -478,6 +478,77 @@ def test_create_collection_resupply_delete_existing_items(
         assert existing_item_link not in collection.stac["links"]
 
 
+def test_create_collection_resupply_keep_description(
+    fake_collection_context: CollectionContext,
+    tmp_path: Path,
+) -> None:
+    created_datetime = any_epoch_datetime()
+    created_datetime_string = format_rfc_3339_datetime_string(created_datetime)
+    existing_collection_content = {
+        "type": "Collection",
+        "stac_version": STAC_VERSION,
+        "id": fake_collection_context.collection_id,
+        "description": "existing description",
+        "linz:slug": fake_collection_context.linz_slug,
+        "created": created_datetime_string,
+        "updated": created_datetime_string,
+        "links": [
+            {
+                "rel": "root",
+                "href": "https://somewhere.s3.ap-southeast-2.amazonaws.com/catalog.json",
+                "type": "application/json",
+            },
+            {"rel": "self", "href": "./collection.json", "type": "application/json"},
+        ],
+    }
+    existing_collection_path = tmp_path / "collection.json"
+    existing_collection_path.write_text(json.dumps(existing_collection_content))
+
+    updated_datetime_string = format_rfc_3339_datetime_string(created_datetime + timedelta(days=1))
+
+    fake_item = {
+        "type": "Feature",
+        "id": "fake_item",
+        "properties": {"start_datetime": "2024-09-02T12:00:00Z", "end_datetime": "2024-09-02T12:00:00Z"},
+        "links": [{"href": "./fake_item.json", "rel": "self", "type": "application/geo+json"}],
+        "bbox": [174.5656855, -41.1625951, 174.8593132, -40.8342068],
+    }
+
+    fake_collection_context.keep_description = True
+    collection = create_collection(
+        collection_context=fake_collection_context,
+        current_datetime=updated_datetime_string,
+        stac_items=[fake_item],
+        item_polygons=[],
+        uri="test",
+        odr_url=tmp_path.as_posix(),
+    )
+
+    assert collection.stac["description"] == existing_collection_content["description"]
+
+
+def test_create_collection_new_keep_description(fake_collection_context: CollectionContext) -> None:
+    current_datetime = any_epoch_datetime_string()
+    fake_item = {
+        "type": "Feature",
+        "id": "fake_item",
+        "properties": {"start_datetime": "2024-09-02T12:00:00Z", "end_datetime": "2024-09-02T12:00:00Z"},
+        "links": [{"href": "./fake_item.json", "rel": "self", "type": "application/geo+json"}],
+        "bbox": [174.5656855, -41.1625951, 174.8593132, -40.8342068],
+    }
+    fake_collection_context.keep_description = True
+    # create_collection without ODR URL
+    collection = create_collection(
+        collection_context=fake_collection_context,
+        current_datetime=current_datetime,
+        stac_items=[fake_item],
+        item_polygons=[],
+        uri="test",
+    )
+
+    assert collection.stac["description"]
+
+
 def test_create_collection_resupply_keep_title(
     fake_collection_context: CollectionContext,
     tmp_path: Path,

--- a/scripts/stac/imagery/tests/create_stac_test.py
+++ b/scripts/stac/imagery/tests/create_stac_test.py
@@ -478,7 +478,7 @@ def test_create_collection_resupply_delete_existing_items(
         assert existing_item_link not in collection.stac["links"]
 
 
-def test_create_collection_resupply_keep_description(
+def test_create_collection_resupply_keep_desc_title(
     fake_collection_context: CollectionContext,
     tmp_path: Path,
 ) -> None:
@@ -489,76 +489,6 @@ def test_create_collection_resupply_keep_description(
         "stac_version": STAC_VERSION,
         "id": fake_collection_context.collection_id,
         "description": "existing description",
-        "linz:slug": fake_collection_context.linz_slug,
-        "created": created_datetime_string,
-        "updated": created_datetime_string,
-        "links": [
-            {
-                "rel": "root",
-                "href": "https://somewhere.s3.ap-southeast-2.amazonaws.com/catalog.json",
-                "type": "application/json",
-            },
-            {"rel": "self", "href": "./collection.json", "type": "application/json"},
-        ],
-    }
-    existing_collection_path = tmp_path / "collection.json"
-    existing_collection_path.write_text(json.dumps(existing_collection_content))
-
-    updated_datetime_string = format_rfc_3339_datetime_string(created_datetime + timedelta(days=1))
-
-    fake_item = {
-        "type": "Feature",
-        "id": "fake_item",
-        "properties": {"start_datetime": "2024-09-02T12:00:00Z", "end_datetime": "2024-09-02T12:00:00Z"},
-        "links": [{"href": "./fake_item.json", "rel": "self", "type": "application/geo+json"}],
-        "bbox": [174.5656855, -41.1625951, 174.8593132, -40.8342068],
-    }
-
-    fake_collection_context.keep_description = True
-    collection = create_collection(
-        collection_context=fake_collection_context,
-        current_datetime=updated_datetime_string,
-        stac_items=[fake_item],
-        item_polygons=[],
-        uri="test",
-        odr_url=tmp_path.as_posix(),
-    )
-
-    assert collection.stac["description"] == existing_collection_content["description"]
-
-
-def test_create_collection_new_keep_description(fake_collection_context: CollectionContext) -> None:
-    current_datetime = any_epoch_datetime_string()
-    fake_item = {
-        "type": "Feature",
-        "id": "fake_item",
-        "properties": {"start_datetime": "2024-09-02T12:00:00Z", "end_datetime": "2024-09-02T12:00:00Z"},
-        "links": [{"href": "./fake_item.json", "rel": "self", "type": "application/geo+json"}],
-        "bbox": [174.5656855, -41.1625951, 174.8593132, -40.8342068],
-    }
-    fake_collection_context.keep_description = True
-    # create_collection without ODR URL
-    collection = create_collection(
-        collection_context=fake_collection_context,
-        current_datetime=current_datetime,
-        stac_items=[fake_item],
-        item_polygons=[],
-        uri="test",
-    )
-
-    assert collection.stac["description"]
-
-
-def test_create_collection_resupply_keep_title(
-    fake_collection_context: CollectionContext,
-    tmp_path: Path,
-) -> None:
-    created_datetime = any_epoch_datetime()
-    created_datetime_string = format_rfc_3339_datetime_string(created_datetime)
-    existing_collection_content = {
-        "type": "Collection",
-        "stac_version": STAC_VERSION,
-        "id": fake_collection_context.collection_id,
         "title": "existing title",
         "linz:slug": fake_collection_context.linz_slug,
         "created": created_datetime_string,
@@ -585,6 +515,7 @@ def test_create_collection_resupply_keep_title(
         "bbox": [174.5656855, -41.1625951, 174.8593132, -40.8342068],
     }
 
+    fake_collection_context.keep_description = True
     fake_collection_context.keep_title = True
     collection = create_collection(
         collection_context=fake_collection_context,
@@ -595,10 +526,11 @@ def test_create_collection_resupply_keep_title(
         odr_url=tmp_path.as_posix(),
     )
 
+    assert collection.stac["description"] == existing_collection_content["description"]
     assert collection.stac["title"] == existing_collection_content["title"]
 
 
-def test_create_collection_new_keep_title(fake_collection_context: CollectionContext) -> None:
+def test_create_collection_new_keep_desc_title(fake_collection_context: CollectionContext) -> None:
     current_datetime = any_epoch_datetime_string()
     fake_item = {
         "type": "Feature",
@@ -607,6 +539,7 @@ def test_create_collection_new_keep_title(fake_collection_context: CollectionCon
         "links": [{"href": "./fake_item.json", "rel": "self", "type": "application/geo+json"}],
         "bbox": [174.5656855, -41.1625951, 174.8593132, -40.8342068],
     }
+    fake_collection_context.keep_description = True
     fake_collection_context.keep_title = True
     # create_collection without ODR URL
     collection = create_collection(
@@ -617,6 +550,7 @@ def test_create_collection_new_keep_title(fake_collection_context: CollectionCon
         uri="test",
     )
 
+    assert collection.stac["description"]
     assert collection.stac["title"]
 
 


### PR DESCRIPTION
### Motivation

:mega: **Note:** this is linked to https://github.com/linz/topo-workflows/pull/1052 which will use this flag.

The DEM merged hillshades need a custom description in the same way that some datasets need a custom title. Add an option to keep existing descriptions (load them from the ODR URL).

### Modifications

Added a new flag `--keep-description` when updating the collection for the merged hillshades.

### Verification

Unit tests and tested with a workflow. The collection was created with the existing description.
