### PR TITLE
ci: stop using GITHUB_TOKEN for release-please TDE-1584

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-containers:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.label.name == 'container' }}
     permissions:
       id-token: write

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   build-containers:
     runs-on: ubuntu-latest
-    environment:
-      name: prod
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.label.name == 'container' }}
     permissions:
       id-token: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,8 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -17,12 +19,14 @@ jobs:
         id: release
         with:
           release-type: python
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LI_GITHUB_ACTION_TOKEN }}
           pull-request-title-pattern: "release: ${version}"
 
   publish-release:
     needs: release-please
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### Change:

Stop using `GITHUB_TOKEN` for release-please.
