### PR TITLE
feat: use supplied capture area TDE-1604

### DIFF
--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -196,7 +196,6 @@ def get_geometry_from_geojson(geojson: dict[str, Any], file_path: str) -> shapel
     :return: A Shapely BaseGeometry object if successful, otherwise raises an exception.
     """
     get_log().debug(f"importing geometry from {file_path}")
-    # capture_area = json.loads(read(supplied_capture_area))
     try:
         return shapely.geometry.shape(geojson["features"][0]["geometry"])
     except (IndexError, KeyError) as e:

--- a/scripts/cli/cli_helper.py
+++ b/scripts/cli/cli_helper.py
@@ -199,7 +199,7 @@ def get_geometry_from_geojson(geojson: dict[str, Any], file_path: str) -> shapel
     try:
         return shapely.geometry.shape(geojson["features"][0]["geometry"])
     except (IndexError, KeyError) as e:
-        error_message = "The supplied GeoJSON does not contain a valid geometry."
+        error_message = "The supplied GeoJSON does not contain a valid geometry:"
         get_log().error(
             error_message,
             file=file_path,

--- a/scripts/cli/tests/cli_helper_test.py
+++ b/scripts/cli/tests/cli_helper_test.py
@@ -2,8 +2,17 @@ from datetime import datetime
 
 from pytest import raises
 from pytest_subtests import SubTests
+from shapely.geometry import MultiPolygon
 
-from scripts.cli.cli_helper import TileFiles, coalesce_multi_single, get_tile_files, parse_list, valid_date
+
+from scripts.cli.cli_helper import (
+    TileFiles,
+    coalesce_multi_single,
+    get_geometry_from_geojson,
+    get_tile_files,
+    parse_list,
+    valid_date,
+)
 
 
 def test_get_tile_files(subtests: SubTests) -> None:
@@ -88,3 +97,41 @@ def test_valid_date_invalid_string() -> None:
     with raises(Exception) as e:
         valid_date("foo")
         assert str(e.value) == "not a valid date: foo"
+
+
+def test_get_geometry_from_geojson() -> None:
+    geom = MultiPolygon(
+        [[[(175.326912, -41.66861622), (175.33531971, -41.67266055), (175.3351674, -41.6684487), (175.326912, -41.66861622)]]]
+    )
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [
+                            [
+                                [175.326912, -41.66861622],
+                                [175.33531971, -41.67266055],
+                                [175.3351674, -41.6684487],
+                                [175.326912, -41.66861622],
+                            ]
+                        ]
+                    ],
+                },
+            }
+        ],
+    }
+    assert get_geometry_from_geojson(geojson, "/tmp/test/test.geojson") == geom
+
+
+def test_get_geometry_from_invalid_geojson() -> None:
+    geojson = {
+        "foo": "bar",
+    }
+    with raises(Exception) as e:
+        get_geometry_from_geojson(geojson, "/tmp/test/test.geojson")
+        assert str(e.value) == "The supplied GeoJSON does not contain a valid geometry. /tmp/test/test.geojson"

--- a/scripts/cli/tests/cli_helper_test.py
+++ b/scripts/cli/tests/cli_helper_test.py
@@ -4,7 +4,6 @@ from pytest import raises
 from pytest_subtests import SubTests
 from shapely.geometry import MultiPolygon
 
-
 from scripts.cli.cli_helper import (
     TileFiles,
     coalesce_multi_single,

--- a/scripts/cli/tests/cli_helper_test.py
+++ b/scripts/cli/tests/cli_helper_test.py
@@ -104,10 +104,12 @@ def test_get_geometry_from_geojson() -> None:
     )
     geojson = {
         "type": "FeatureCollection",
+        "name": "foo",
+        "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
         "features": [
             {
                 "type": "Feature",
-                "properties": {},
+                "properties": {"Id": 0},
                 "geometry": {
                     "type": "MultiPolygon",
                     "coordinates": [

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -182,8 +182,8 @@ def main(args: List[str] | None = None) -> None:
     polygons = []
 
     if supplied_capture_area:
-        capture_area = json.loads(read(supplied_capture_area))
-        polygons.append(get_geometry_from_geojson(capture_area, supplied_capture_area))
+        content = json.loads(read(supplied_capture_area))
+        polygons.append(get_geometry_from_geojson(content, supplied_capture_area))
 
     for key, result in get_object_parallel_multithreading(
         bucket_name_from_path(uri), files_to_read, s3_client, arguments.concurrency

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -248,6 +248,7 @@ def main(args: List[str] | None = None) -> None:
         item_polygons=polygons,
         uri=uri,
         odr_url=arguments.odr_url,
+        supplied_capture_area=supplied_capture_area,
     )
 
     destination = os.path.join(uri, COLLECTION_FILE_NAME)

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -154,7 +154,7 @@ def parse_args(args: List[str] | None) -> Namespace:
     parser.add_argument(
         "--supplied-capture-area",
         dest="supplied_capture_area",
-        help="Optional externally supplied capture area",
+        help="Optional externally supplied EPSG:4326 capture area",
         required=False,
         nargs="?",
     )

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -392,10 +392,6 @@ class ImageryCollection:
             "file:checksum": file_checksum,
             "file:size": len(capture_area_content),
         }
-        print("==============================")
-        print(supplied_capture_area)
-        print("==============================")
-        print(capture_area)
         self.stac.setdefault("assets", {})["capture_area"] = capture_area
 
         # Save `capture-area.geojson` in target

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -347,7 +347,9 @@ class ImageryCollection:
 
         return components
 
-    def add_capture_area(self, polygons: list[BaseGeometry], target: str, artifact_target: str = "/tmp") -> None:
+    def add_capture_area(
+        self, polygons: list[BaseGeometry], target: str, supplied_capture_area: str | None, artifact_target: str = "/tmp"
+    ) -> None:
         """Add the capture area of the Collection.
         If the Collection is an update of a published dataset, the existing capture area will be merged with the new one.
         The `href` or path of the capture-area.geojson is always set as the relative `./capture-area.geojson`
@@ -355,6 +357,7 @@ class ImageryCollection:
         Args:
             polygons: list of BaseGeometries
             target: location where the capture-area.geojson file will be saved
+            supplied_capture_area: Optional externally supplied capture area
             artifact_target: location where the capture-area.geojson artifact file will be saved.
             This is useful for Argo Workflow in order to expose the file to the user for testing/validation purpose.
         """
@@ -375,8 +378,14 @@ class ImageryCollection:
         capture_area = {
             "href": f"./{CAPTURE_AREA_FILE_NAME}",
             "title": "Capture area",
-            "description": "Boundary of the total capture area for this collection. Excludes nodata areas in the source "
-            "data. Geometries are simplified.",
+            "description": (
+                "Boundary of the total capture area for this collection provided by the data supplier. "
+                "May include some areas of nodata where capture was attempted but unsuccessful. "
+                "Geometries are simplified."
+                if supplied_capture_area
+                else "Boundary of the total capture area for this collection. Excludes nodata areas in the source "
+                "data. Geometries are simplified."
+            ),
             "type": ContentType.GEOJSON,
             "roles": ["metadata"],
             "file:checksum": file_checksum,

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -357,7 +357,7 @@ class ImageryCollection:
         Args:
             polygons: list of BaseGeometries
             target: location where the capture-area.geojson file will be saved
-            supplied_capture_area: optional externally supplied capture area
+            supplied_capture_area: optional externally supplied capture area to identify which description to use
             artifact_target: location where the capture-area.geojson artifact file will be saved.
             This is useful for Argo Workflow in order to expose the file to the user for testing/validation purpose.
         """
@@ -369,6 +369,7 @@ class ImageryCollection:
             )
             return
         # If published dataset with a capture-area update, merge the existing capture area with the new one
+        print(self.capture_area)
         if self.capture_area and self.capture_area.get("geometry"):
             polygons.append(shape(self.capture_area["geometry"]))
         # The GSD is measured in meters (e.g., `0.3m`)

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -369,7 +369,7 @@ class ImageryCollection:
             )
             return
         # If published dataset with a capture-area update, merge the existing capture area with the new one
-        if self.capture_area:
+        if self.capture_area and self.capture_area.get("geometry"):
             polygons.append(shape(self.capture_area["geometry"]))
         # The GSD is measured in meters (e.g., `0.3m`)
         capture_area_document = generate_capture_area(polygons, self.gsd)

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -357,7 +357,7 @@ class ImageryCollection:
         Args:
             polygons: list of BaseGeometries
             target: location where the capture-area.geojson file will be saved
-            supplied_capture_area: Optional externally supplied capture area
+            supplied_capture_area: optional externally supplied capture area
             artifact_target: location where the capture-area.geojson artifact file will be saved.
             This is useful for Argo Workflow in order to expose the file to the user for testing/validation purpose.
         """

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -379,13 +379,22 @@ class ImageryCollection:
             "href": f"./{CAPTURE_AREA_FILE_NAME}",
             "title": "Capture area",
             "description": (
-                "Boundary of the total capture area for this collection provided by the data supplier. "
-                "May include some areas of nodata where capture was attempted but unsuccessful. "
-                "Geometries are simplified."
-                if supplied_capture_area
-                else "Boundary of the total capture area for this collection. Excludes nodata areas in the source "
-                "data. Geometries are simplified."
+                "Boundary of the total capture area for this collection"
+                f"{(' provided by the data supplier. '
+                    'May include some areas of nodata where capture was attempted but unsuccessful.')
+                if supplied_capture_area else '. Excludes nodata areas in the source data.'}"
+                " Geometries are simplified."
             ),
+            #
+            #
+            # "description": (
+            #     "Boundary of the total capture area for this collection provided by the data supplier. "
+            #     "May include some areas of nodata where capture was attempted but unsuccessful. "
+            #     "Geometries are simplified."
+            #     if supplied_capture_area
+            #     else "Boundary of the total capture area for this collection. Excludes nodata areas in the source "
+            #     "data. Geometries are simplified."
+            # ),
             "type": ContentType.GEOJSON,
             "roles": ["metadata"],
             "file:checksum": file_checksum,

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -392,6 +392,10 @@ class ImageryCollection:
             "file:checksum": file_checksum,
             "file:size": len(capture_area_content),
         }
+        print("==============================")
+        print(supplied_capture_area)
+        print("==============================")
+        print(capture_area)
         self.stac.setdefault("assets", {})["capture_area"] = capture_area
 
         # Save `capture-area.geojson` in target

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -385,16 +385,6 @@ class ImageryCollection:
                 if supplied_capture_area else '. Excludes nodata areas in the source data.'}"
                 " Geometries are simplified."
             ),
-            #
-            #
-            # "description": (
-            #     "Boundary of the total capture area for this collection provided by the data supplier. "
-            #     "May include some areas of nodata where capture was attempted but unsuccessful. "
-            #     "Geometries are simplified."
-            #     if supplied_capture_area
-            #     else "Boundary of the total capture area for this collection. Excludes nodata areas in the source "
-            #     "data. Geometries are simplified."
-            # ),
             "type": ContentType.GEOJSON,
             "roles": ["metadata"],
             "file:checksum": file_checksum,

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -369,7 +369,6 @@ class ImageryCollection:
             )
             return
         # If published dataset with a capture-area update, merge the existing capture area with the new one
-        print(self.capture_area)
         if self.capture_area and self.capture_area.get("geometry"):
             polygons.append(shape(self.capture_area["geometry"]))
         # The GSD is measured in meters (e.g., `0.3m`)

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -40,7 +40,6 @@ def create_collection(
         odr_url: path of the published dataset. Defaults to None.
         supplied_capture_area: Externally supplied capture area, if applicable. Defaults to None.
 
-
     Returns:
         an ImageryCollection object
     """

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -39,9 +39,6 @@ def create_collection(
         stac_items: list of STAC Items to be added as links to the Collection
         item_polygons: list of polygons of the items linked to the Collection
         uri: path of the dataset
-        add_capture_dates: whether to add the capture-dates file to the Collection. Defaults to False.
-        keep_description: whether to keep the description in the existing Collection. Defaults to False.
-        keep_title: whether to keep the title in the existing Collection. Defaults to False.
         odr_url: path of the published dataset. Defaults to None.
 
     Returns:

--- a/scripts/stac/imagery/create_stac.py
+++ b/scripts/stac/imagery/create_stac.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, TypeAlias
+from typing import Any
 
 from linz_logger import get_log
 from shapely.geometry.base import BaseGeometry
@@ -18,9 +18,6 @@ from scripts.stac.link import Link, Relation
 from scripts.stac.util import checksum
 from scripts.stac.util.media_type import StacMediaType
 
-JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
-JSON_Dict: TypeAlias = dict[str, "JSON"]
-
 
 def create_collection(
     collection_context: CollectionContext,
@@ -29,6 +26,7 @@ def create_collection(
     item_polygons: list[BaseGeometry],
     uri: str,
     odr_url: str | None = None,
+    supplied_capture_area: str | None = None,
 ) -> ImageryCollection:
     """Create an ImageryCollection object.
     If `item_polygons` is not empty, it will add a generated capture area to the collection.
@@ -40,6 +38,8 @@ def create_collection(
         item_polygons: list of polygons of the items linked to the Collection
         uri: path of the dataset
         odr_url: path of the published dataset. Defaults to None.
+        supplied_capture_area: Externally supplied capture area, if applicable. Defaults to None.
+
 
     Returns:
         an ImageryCollection object
@@ -88,7 +88,7 @@ def create_collection(
         collection.add_capture_dates(uri)
 
     if item_polygons:
-        collection.add_capture_area(item_polygons, uri)
+        collection.add_capture_area(item_polygons, uri, supplied_capture_area)
         get_log().info(
             "Capture area created",
         )

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -261,10 +261,9 @@ def test_should_make_compliant_capture_area(subtests: SubTests) -> None:
     ]
 
     merged_polygons = merge_polygons(polygons, 0.1)
-    mp = cast(MultiPolygon, merged_polygons)
 
     with subtests.test(msg="Valid geometry"):
         assert is_valid(merged_polygons)
 
     with subtests.test(msg="Is counterclockwise"):
-        assert is_ccw(get_exterior_ring(mp.geoms[0]))
+        assert is_ccw(get_exterior_ring(merged_polygons.geoms[0]))

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -129,7 +129,7 @@ def test_generate_capture_area_not_rounded() -> None:
     assert capture_area_expected != capture_area_result
 
 
-def test_capture_area_orientation_polygon() -> None:
+def test_capture_area_orientation_polygon(subtests: SubTests) -> None:
     # Test the orientation of the capture area
     # The polygon capture area should be the same as the polygon and not reversed
     polygons = []
@@ -151,11 +151,15 @@ def test_capture_area_orientation_polygon() -> None:
         )
     )
     capture_area = generate_capture_area(polygons, Decimal("0.05"))
-    assert is_ccw(get_exterior_ring(shape(capture_area["geometry"])))
-    assert is_valid((shape(capture_area["geometry"])))
+
+    with subtests.test(msg="Is counterclockwise"):
+        assert is_ccw(get_exterior_ring(shape(capture_area["geometry"])))
+
+    with subtests.test(msg="Valid geometry"):
+        assert is_valid((shape(capture_area["geometry"])))
 
 
-def test_capture_area_orientation_multipolygon() -> None:
+def test_capture_area_orientation_multipolygon(subtests: SubTests) -> None:
     # Test the orientation of the capture area
     # The multipolygon capture area polygons should be the same as the polygon and not reversed
     polygons = []
@@ -192,8 +196,12 @@ def test_capture_area_orientation_multipolygon() -> None:
     )
     capture_area = generate_capture_area(polygons, Decimal("0.05"))
     mp_geom = cast(MultiPolygon, shape(capture_area["geometry"]))
-    assert is_ccw(get_exterior_ring(mp_geom.geoms[0]))
-    assert is_valid((shape(capture_area["geometry"])))
+
+    with subtests.test(msg="Valid geometry"):
+        assert is_ccw(get_exterior_ring(mp_geom.geoms[0]))
+
+    with subtests.test(msg="Valid geometry"):
+        assert is_valid((shape(capture_area["geometry"])))
 
 
 def test_capture_area_rounding_decimal_places() -> None:
@@ -252,9 +260,13 @@ def test_should_make_compliant_capture_area(subtests: SubTests) -> None:
         ),
     ]
 
-    capture_area = merge_polygons(polygons, 0.1)
+    merged_polygons = merge_polygons(polygons, 0.1)
+    # print(type(merged_polygons))
+    mp_geom = cast(MultiPolygon, merged_polygons)
+    # print(type(mp_geom))
+
     with subtests.test(msg="Valid geometry"):
-        assert is_valid(capture_area)
+        assert is_valid(merged_polygons)
 
     with subtests.test(msg="Is counterclockwise"):
-        assert is_ccw(get_exterior_ring(capture_area.geoms[0]))
+        assert is_ccw(get_exterior_ring(mp_geom.geoms[0]))

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -261,12 +261,10 @@ def test_should_make_compliant_capture_area(subtests: SubTests) -> None:
     ]
 
     merged_polygons = merge_polygons(polygons, 0.1)
-    # print(type(merged_polygons))
-    mp_geom = cast(MultiPolygon, merged_polygons)
-    # print(type(mp_geom))
+    mp = cast(MultiPolygon, merged_polygons)
 
     with subtests.test(msg="Valid geometry"):
         assert is_valid(merged_polygons)
 
     with subtests.test(msg="Is counterclockwise"):
-        assert is_ccw(get_exterior_ring(mp_geom.geoms[0]))
+        assert is_ccw(get_exterior_ring(mp.geoms[0]))

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -704,7 +704,7 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
         assert collection.stac["assets"]["capture_area"]["file:size"] in (269,)  # geos 3.11 - geos 3.12 as yet untested
 
 
-def supplied_capture_area_with_odr_url(fake_collection_context: CollectionContext) -> None:
+def test_supplied_capture_area_with_odr_url(fake_collection_context: CollectionContext) -> None:
     collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
     collection.capture_area = {
         "geometry": {

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -659,6 +659,7 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
     )
     with tempfile.TemporaryDirectory() as tmp_path:
         artifact_path = os.path.join(tmp_path, "tmp")
+        collection.add_capture_area(polygons, tmp_path, None, artifact_path)
         file_target = os.path.join(tmp_path, file_name)
         file_artifact = os.path.join(artifact_path, file_name)
         with subtests.test():
@@ -704,57 +705,57 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
         assert collection.stac["assets"]["capture_area"]["file:size"] in (269,)  # geos 3.11 - geos 3.12 as yet untested
 
 
-# def test_supplied_capture_area_description(fake_collection_context: CollectionContext) -> None:
-#
-#     collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
-#
-#     polygons = []
-#     polygons.append(
-#         shapely.geometry.shape(
-#             {
-#                 "type": "MultiPolygon",
-#                 "coordinates": [
-#                     [
-#                         [
-#                             [178.259659571653, -38.40831927359251],
-#                             [178.26012930415902, -38.41478071250544],
-#                             [178.26560430668172, -38.41453416326152],
-#                             [178.26513409076952, -38.40807278109057],
-#                             [178.259659571653, -38.40831927359251],
-#                         ]
-#                     ]
-#                 ],
-#             }
-#         )
-#     )
-#     polygons.append(
-#         shapely.geometry.shape(
-#             {
-#                 "type": "MultiPolygon",
-#                 "coordinates": [
-#                     [
-#                         [
-#                             [178.25418498567294, -38.40856551170436],
-#                             [178.25465423474975, -38.41502700730107],
-#                             [178.26012930415902, -38.41478071250544],
-#                             [178.259659571653, -38.40831927359251],
-#                             [178.25418498567294, -38.40856551170436],
-#                         ]
-#                     ]
-#                 ],
-#             }
-#         )
-#     )
-#     with tempfile.TemporaryDirectory() as tmp_path:
-#         artifact_path = os.path.join(tmp_path, "tmp")
-#         collection.add_capture_area(polygons, tmp_path, "test", artifact_path)
-#         print(collection.stac["assets"]["capture_area"]["description"])
-#
-#     assert (
-#         collection.stac["assets"]["capture_area"]["description"] == "Boundary of the total capture area for "
-#         "this collection provided by the data supplier. May include some areas of nodata where capture was attempted "
-#         "but unsuccessful. Geometries are simplified."
-#     )
+def test_supplied_capture_area_description(fake_collection_context: CollectionContext) -> None:
+
+    collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
+
+    polygons = []
+    polygons.append(
+        shapely.geometry.shape(
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [178.259659571653, -38.40831927359251],
+                            [178.26012930415902, -38.41478071250544],
+                            [178.26560430668172, -38.41453416326152],
+                            [178.26513409076952, -38.40807278109057],
+                            [178.259659571653, -38.40831927359251],
+                        ]
+                    ]
+                ],
+            }
+        )
+    )
+    polygons.append(
+        shapely.geometry.shape(
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [178.25418498567294, -38.40856551170436],
+                            [178.25465423474975, -38.41502700730107],
+                            [178.26012930415902, -38.41478071250544],
+                            [178.259659571653, -38.40831927359251],
+                            [178.25418498567294, -38.40856551170436],
+                        ]
+                    ]
+                ],
+            }
+        )
+    )
+    with tempfile.TemporaryDirectory() as tmp_path:
+        artifact_path = os.path.join(tmp_path, "tmp")
+        collection.add_capture_area(polygons, tmp_path, "test", artifact_path)
+        print(collection.stac["assets"]["capture_area"]["description"])
+
+    assert (
+        collection.stac["assets"]["capture_area"]["description"] == "Boundary of the total capture area for "
+        "this collection provided by the data supplier. May include some areas of nodata where capture was attempted "
+        "but unsuccessful. Geometries are simplified."
+    )
 
 
 def test_should_not_add_capture_area(

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -617,7 +617,6 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
     collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
     file_name = "capture-area.geojson"
 
-
     polygons = []
     polygons.append(
         shapely.geometry.shape(

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -617,6 +617,7 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
     collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
     file_name = "capture-area.geojson"
 
+
     polygons = []
     polygons.append(
         shapely.geometry.shape(
@@ -656,7 +657,7 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
     )
     with tempfile.TemporaryDirectory() as tmp_path:
         artifact_path = os.path.join(tmp_path, "tmp")
-        collection.add_capture_area(polygons, tmp_path, artifact_path)
+        collection.add_capture_area(polygons, tmp_path, None, artifact_path)
         file_target = os.path.join(tmp_path, file_name)
         file_artifact = os.path.join(artifact_path, file_name)
         with subtests.test():
@@ -737,7 +738,7 @@ def test_should_not_add_capture_area(
         artifact_path = os.path.join(tmp_path, "tmp")
         collection.published_location = "s3://bucket/dataset/collection.json"
         collection.publish_capture_area = False
-        collection.add_capture_area(polygons, tmp_path, artifact_path)
+        collection.add_capture_area(polygons, tmp_path, None, artifact_path)
         logs = json.loads(capsys.readouterr().out)
         assert WARN_NO_PUBLISHED_CAPTURE_AREA in logs["msg"]
         file_target = os.path.join(tmp_path, file_name)

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -28,6 +28,9 @@ from scripts.stac.util.STAC_VERSION import STAC_VERSION
 from scripts.stac.util.stac_extensions import StacExtensions
 from scripts.tests.datetimes_test import any_epoch_datetime_string
 
+# TODO: reduce duplication of geometries
+# pylint: disable=too-many-lines
+
 
 def test_metadata_initialised(fake_collection_context: CollectionContext, subtests: SubTests) -> None:
     fake_collection_context.event_name = "Forest Assessment"
@@ -656,7 +659,7 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
     )
     with tempfile.TemporaryDirectory() as tmp_path:
         artifact_path = os.path.join(tmp_path, "tmp")
-        collection.add_capture_area(polygons, tmp_path, None, artifact_path)
+        collection.add_capture_area(polygons, tmp_path, "test", artifact_path)
         file_target = os.path.join(tmp_path, file_name)
         file_artifact = os.path.join(artifact_path, file_name)
         with subtests.test():
@@ -700,6 +703,58 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
 
     with subtests.test():
         assert collection.stac["assets"]["capture_area"]["file:size"] in (269,)  # geos 3.11 - geos 3.12 as yet untested
+
+
+def test_supplied_capture_area_description(fake_collection_context: CollectionContext) -> None:
+
+    collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
+
+    polygons = []
+    polygons.append(
+        shapely.geometry.shape(
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [178.259659571653, -38.40831927359251],
+                            [178.26012930415902, -38.41478071250544],
+                            [178.26560430668172, -38.41453416326152],
+                            [178.26513409076952, -38.40807278109057],
+                            [178.259659571653, -38.40831927359251],
+                        ]
+                    ]
+                ],
+            }
+        )
+    )
+    polygons.append(
+        shapely.geometry.shape(
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [178.25418498567294, -38.40856551170436],
+                            [178.25465423474975, -38.41502700730107],
+                            [178.26012930415902, -38.41478071250544],
+                            [178.259659571653, -38.40831927359251],
+                            [178.25418498567294, -38.40856551170436],
+                        ]
+                    ]
+                ],
+            }
+        )
+    )
+    with tempfile.TemporaryDirectory() as tmp_path:
+        artifact_path = os.path.join(tmp_path, "tmp")
+        collection.add_capture_area(polygons, tmp_path, "test", artifact_path)
+
+    assert (
+        collection.stac["assets"]["capture_area"]["description"] == "Boundary of the total capture area for "
+        "this collection provided by the data supplier. May include some areas of nodata where capture was attempted "
+        "but unsuccessful. Geometries are simplified."
+    )
 
 
 def test_should_not_add_capture_area(

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -659,7 +659,6 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
     )
     with tempfile.TemporaryDirectory() as tmp_path:
         artifact_path = os.path.join(tmp_path, "tmp")
-        collection.add_capture_area(polygons, tmp_path, "test", artifact_path)
         file_target = os.path.join(tmp_path, file_name)
         file_artifact = os.path.join(artifact_path, file_name)
         with subtests.test():
@@ -705,56 +704,57 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
         assert collection.stac["assets"]["capture_area"]["file:size"] in (269,)  # geos 3.11 - geos 3.12 as yet untested
 
 
-def test_supplied_capture_area_description(fake_collection_context: CollectionContext) -> None:
-
-    collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
-
-    polygons = []
-    polygons.append(
-        shapely.geometry.shape(
-            {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [178.259659571653, -38.40831927359251],
-                            [178.26012930415902, -38.41478071250544],
-                            [178.26560430668172, -38.41453416326152],
-                            [178.26513409076952, -38.40807278109057],
-                            [178.259659571653, -38.40831927359251],
-                        ]
-                    ]
-                ],
-            }
-        )
-    )
-    polygons.append(
-        shapely.geometry.shape(
-            {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [178.25418498567294, -38.40856551170436],
-                            [178.25465423474975, -38.41502700730107],
-                            [178.26012930415902, -38.41478071250544],
-                            [178.259659571653, -38.40831927359251],
-                            [178.25418498567294, -38.40856551170436],
-                        ]
-                    ]
-                ],
-            }
-        )
-    )
-    with tempfile.TemporaryDirectory() as tmp_path:
-        artifact_path = os.path.join(tmp_path, "tmp")
-        collection.add_capture_area(polygons, tmp_path, "test", artifact_path)
-
-    assert (
-        collection.stac["assets"]["capture_area"]["description"] == "Boundary of the total capture area for "
-        "this collection provided by the data supplier. May include some areas of nodata where capture was attempted "
-        "but unsuccessful. Geometries are simplified."
-    )
+# def test_supplied_capture_area_description(fake_collection_context: CollectionContext) -> None:
+#
+#     collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
+#
+#     polygons = []
+#     polygons.append(
+#         shapely.geometry.shape(
+#             {
+#                 "type": "MultiPolygon",
+#                 "coordinates": [
+#                     [
+#                         [
+#                             [178.259659571653, -38.40831927359251],
+#                             [178.26012930415902, -38.41478071250544],
+#                             [178.26560430668172, -38.41453416326152],
+#                             [178.26513409076952, -38.40807278109057],
+#                             [178.259659571653, -38.40831927359251],
+#                         ]
+#                     ]
+#                 ],
+#             }
+#         )
+#     )
+#     polygons.append(
+#         shapely.geometry.shape(
+#             {
+#                 "type": "MultiPolygon",
+#                 "coordinates": [
+#                     [
+#                         [
+#                             [178.25418498567294, -38.40856551170436],
+#                             [178.25465423474975, -38.41502700730107],
+#                             [178.26012930415902, -38.41478071250544],
+#                             [178.259659571653, -38.40831927359251],
+#                             [178.25418498567294, -38.40856551170436],
+#                         ]
+#                     ]
+#                 ],
+#             }
+#         )
+#     )
+#     with tempfile.TemporaryDirectory() as tmp_path:
+#         artifact_path = os.path.join(tmp_path, "tmp")
+#         collection.add_capture_area(polygons, tmp_path, "test", artifact_path)
+#         print(collection.stac["assets"]["capture_area"]["description"])
+#
+#     assert (
+#         collection.stac["assets"]["capture_area"]["description"] == "Boundary of the total capture area for "
+#         "this collection provided by the data supplier. May include some areas of nodata where capture was attempted "
+#         "but unsuccessful. Geometries are simplified."
+#     )
 
 
 def test_should_not_add_capture_area(

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -704,7 +704,7 @@ def test_capture_area_added(fake_collection_context: CollectionContext, subtests
         assert collection.stac["assets"]["capture_area"]["file:size"] in (269,)  # geos 3.11 - geos 3.12 as yet untested
 
 
-def test_supplied_capture_area_with_odr_url(fake_collection_context: CollectionContext) -> None:
+def test_supplied_capture_area_with_existing_capture_area(fake_collection_context: CollectionContext) -> None:
     collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
     collection.capture_area = {
         "geometry": {
@@ -745,8 +745,10 @@ def test_supplied_capture_area_with_odr_url(fake_collection_context: CollectionC
     with tempfile.TemporaryDirectory() as tmp_path:
         artifact_path = os.path.join(tmp_path, "tmp")
         collection.add_capture_area(polygons, tmp_path, "path/to/supplied-capture-area.geojson", artifact_path)
+        capture_area_file = json.loads(read(f"{tmp_path}/capture-area.geojson"))
 
-    assert collection.capture_area["geometry"] == {
+    assert capture_area_file["geometry"] == {
+        "type": "Polygon",
         "coordinates": [
             [
                 [175.33070754, -38.23087459],
@@ -758,7 +760,6 @@ def test_supplied_capture_area_with_odr_url(fake_collection_context: CollectionC
                 [175.33070754, -38.23087459],
             ]
         ],
-        "type": "Polygon",
     }
 
 

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -124,15 +124,17 @@ def report_non_visual_qa_errors(file: FileTiff) -> None:
 def main() -> None:
     arguments = parse_args()
 
+    create_footprints = arguments.create_footprings
+
     if arguments.supplied_capture_area:
-        arguments.create_footprints = False
+        create_footprints = False
 
     standardising_config = StandardisingConfig(
         gdal_preset=arguments.preset,
         source_epsg=arguments.source_epsg,
         target_epsg=arguments.target_epsg,
         gsd=arguments.gsd,
-        create_footprints=arguments.create_footprints,
+        create_footprints=create_footprints,
         cutline=arguments.cutline,
         scale_to_resolution=arguments.scale_to_resolution,
     )

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -58,13 +58,6 @@ def parse_args() -> argparse.Namespace:
         required=True,
     )
     parser.add_argument("--cutline", dest="cutline", help="Optional cutline to cut imagery to", required=False, nargs="?")
-    parser.add_argument(
-        "--supplied-capture-area",
-        dest="supplied_capture_area",
-        help="Optional externally supplied capture area",
-        required=False,
-        nargs="?",
-    )
     parser.add_argument("--collection-id", dest="collection_id", help="Unique id for collection", required=True)
     parser.add_argument(
         "--start-datetime",
@@ -124,17 +117,12 @@ def report_non_visual_qa_errors(file: FileTiff) -> None:
 def main() -> None:
     arguments = parse_args()
 
-    create_footprints = arguments.create_footprints
-
-    if arguments.supplied_capture_area:
-        create_footprints = False
-
     standardising_config = StandardisingConfig(
         gdal_preset=arguments.preset,
         source_epsg=arguments.source_epsg,
         target_epsg=arguments.target_epsg,
         gsd=arguments.gsd,
-        create_footprints=create_footprints,
+        create_footprints=arguments.create_footprints,
         cutline=arguments.cutline,
         scale_to_resolution=arguments.scale_to_resolution,
     )

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -58,6 +58,9 @@ def parse_args() -> argparse.Namespace:
         required=True,
     )
     parser.add_argument("--cutline", dest="cutline", help="Optional cutline to cut imagery to", required=False, nargs="?")
+    parser.add_argument(
+        "--supplied-capture-area", dest="supplied_capture_area", help="Optional externally supplied capture area", required=False, nargs="?"
+    )
     parser.add_argument("--collection-id", dest="collection_id", help="Unique id for collection", required=True)
     parser.add_argument(
         "--start-datetime",
@@ -116,6 +119,9 @@ def report_non_visual_qa_errors(file: FileTiff) -> None:
 
 def main() -> None:
     arguments = parse_args()
+
+    if arguments.supplied_capture_area:
+        arguments.create_footprints = False
 
     standardising_config = StandardisingConfig(
         gdal_preset=arguments.preset,

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -124,7 +124,7 @@ def report_non_visual_qa_errors(file: FileTiff) -> None:
 def main() -> None:
     arguments = parse_args()
 
-    create_footprints = arguments.create_footprings
+    create_footprints = arguments.create_footprints
 
     if arguments.supplied_capture_area:
         create_footprints = False

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -59,7 +59,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--cutline", dest="cutline", help="Optional cutline to cut imagery to", required=False, nargs="?")
     parser.add_argument(
-        "--supplied-capture-area", dest="supplied_capture_area", help="Optional externally supplied capture area", required=False, nargs="?"
+        "--supplied-capture-area",
+        dest="supplied_capture_area",
+        help="Optional externally supplied capture area",
+        required=False,
+        nargs="?",
     )
     parser.add_argument("--collection-id", dest="collection_id", help="Unique id for collection", required=True)
     parser.add_argument(


### PR DESCRIPTION
### Motivation

For 3D Coastal mapping datasets the capture areas automatically generated when standardising are very complex. This change is to allow a simpler capture area to be added when creating a collection rather than calculating it from the TIFF footprints.

### Modifications

Added a new parameter `supplied_capture_area` to be used by the `create-collection` step.

### Verification

Unit tests.
Ran workflows manually against topo-imagery PR container.
