### PR TITLE
fix: orient the capture area after making geometry valid TDE-1618

### DIFF
--- a/scripts/stac/imagery/capture_area.py
+++ b/scripts/stac/imagery/capture_area.py
@@ -64,11 +64,13 @@ def merge_polygons(polygons: Sequence[BaseGeometry], buffer_distance: float) -> 
     union_unbuffered = union_buffered.buffer(-buffer_distance, cap_style=BufferCapStyle.flat, join_style=BufferJoinStyle.mitre)
     union_simplified = union_unbuffered.simplify(buffer_distance)
     union_rounded = wkt.loads(wkt.dumps(union_simplified, rounding_precision=8))
+    # Ensure geometry is valid
+    valid_geom = make_valid(union_rounded)
     # Apply right-hand rule winding order (exterior rings should be counter-clockwise) to the geometry
     # Ref: https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6
-    oriented_union_simplified = orient(union_rounded, sign=1.0)
+    oriented_valid_geom = orient(valid_geom, sign=1.0)
 
-    return make_valid(oriented_union_simplified)
+    return oriented_valid_geom
 
 
 def generate_capture_area(polygons: Sequence[BaseGeometry], gsd: Decimal) -> dict[str, Any]:

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from sys import float_info
 from typing import cast
 
+from pytest_subtests import SubTests
 from shapely import get_exterior_ring, is_ccw
 from shapely.geometry import MultiPolygon, Polygon, shape
 from shapely.predicates import is_valid
@@ -234,7 +235,7 @@ def test_capture_area_rounding_decimal_places() -> None:
     assert capture_area == capture_area_expected
 
 
-def test_should_make_compliant_capture_area() -> None:
+def test_should_make_compliant_capture_area(subtests: SubTests) -> None:
     # Given two touching triangles
     polygons = [
         shape(

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -252,5 +252,8 @@ def test_should_make_valid_capture_area() -> None:
     ]
 
     capture_area = merge_polygons(polygons, 0.1)
-    assert is_valid(capture_area)
-    assert is_ccw(get_exterior_ring(capture_area.geoms[0]))
+    with subtests.test(msg="Valid geometry"):
+        assert is_valid(capture_area)
+
+    with subtests.test(msg="Is counterclockwise"):
+        assert is_ccw(get_exterior_ring(capture_area.geoms[0]))

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -234,7 +234,7 @@ def test_capture_area_rounding_decimal_places() -> None:
     assert capture_area == capture_area_expected
 
 
-def test_should_make_valid_capture_area() -> None:
+def test_should_make_compliant_capture_area() -> None:
     # Given two touching triangles
     polygons = [
         shape(

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -14,7 +14,6 @@ from moto.s3.responses import DEFAULT_REGION_NAME
 from mypy_boto3_s3 import S3Client
 from pytest import CaptureFixture, mark, param
 from pytest_subtests import SubTests
-from shapely.predicates import is_valid
 
 from scripts.conftest import fake_linz_slug
 from scripts.files.files_helper import ContentType
@@ -752,27 +751,6 @@ def test_should_not_add_capture_area(
 
     with subtests.test():
         assert "capture_area" not in collection.stac.get("assets", {})
-
-
-def test_should_make_valid_capture_area() -> None:
-    # Given two touching triangles
-    polygons = [
-        shapely.geometry.shape(
-            {
-                "type": "MultiPolygon",
-                "coordinates": [[[[0, 0], [0, 1], [1, 1], [0, 0]]]],
-            }
-        ),
-        shapely.geometry.shape(
-            {
-                "type": "MultiPolygon",
-                "coordinates": [[[[1, 0], [2, 2], [1, 2], [1, 0]]]],
-            }
-        ),
-    ]
-
-    capture_area = merge_polygons(polygons, 0.1)
-    assert is_valid(capture_area)
 
 
 def test_event_name_is_present(fake_collection_context: CollectionContext) -> None:

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -19,7 +19,6 @@ from scripts.conftest import fake_linz_slug
 from scripts.files.files_helper import ContentType
 from scripts.files.fs import read
 from scripts.files.fs_s3 import write
-from scripts.stac.imagery.capture_area import merge_polygons
 from scripts.stac.imagery.collection import WARN_NO_PUBLISHED_CAPTURE_AREA, ImageryCollection, MissingMetadataError
 from scripts.stac.imagery.collection_context import CollectionContext
 from scripts.stac.imagery.item import ImageryItem, STACAsset


### PR DESCRIPTION
### Motivation

When working on https://toitutewhenua.atlassian.net/browse/TDE-1604 the capture area generated did not follow the right hand rule. If the `make_valid` step is removed, the orientation is correct.

### Modifications

Do the `make_valid` step before forcing the orientation to follow the right hand winding order rule. I did contemplate an `is_valid` check but `orient` should not make the geometry invalid.

### Verification

Unit tests and a manual test with the larger capture area that had been reversed.
