### PR TITLE
feat: add GSD metadata to collection.json TDE-1657

### DIFF
--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -97,6 +97,7 @@ class ImageryCollection:
             "linz:region": context.region,
             "linz:security_classification": "unclassified",
             "linz:slug": context.linz_slug,
+            "gsd": float(context.gsd),
             "created": created_datetime,
             "updated": updated_datetime,
         }

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -449,10 +449,11 @@ def test_set_title_set_description(
 
 
 def test_set_gsd(
-    context: CollectionContext,
+    fake_collection_context: CollectionContext,
 ) -> None:
-    collection = ImageryCollection(context, any_epoch_datetime_string(), any_epoch_datetime_string())
-    assert collection.stac["gsd"] == 0.3
+    fake_collection_context.gsd = Decimal("123.456")
+    collection = ImageryCollection(fake_collection_context, any_epoch_datetime_string(), any_epoch_datetime_string())
+    assert collection.stac["gsd"] == 123.456
 
 
 def test_set_title_set_description_long_date(fake_collection_context: CollectionContext, subtests: SubTests) -> None:

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -448,6 +448,13 @@ def test_set_title_set_description(
         assert collection.stac["description"] == expected_description
 
 
+def test_set_gsd(
+    context: CollectionContext,
+) -> None:
+    collection = ImageryCollection(context, any_epoch_datetime_string(), any_epoch_datetime_string())
+    assert collection.stac["gsd"] == 0.3
+
+
 def test_set_title_set_description_long_date(fake_collection_context: CollectionContext, subtests: SubTests) -> None:
     fake_collection_context.category = "rural-aerial-photos"
     fake_collection_context.historic_survey_number = None
@@ -595,6 +602,7 @@ def test_write_collection(fake_collection_context: CollectionContext) -> None:
     rmtree(target)
 
     assert collection["title"] == collectionObj.stac["title"]
+    assert collection["gsd"] == collectionObj.stac["gsd"]
 
 
 def test_write_collection_special_chars(fake_collection_context: CollectionContext) -> None:


### PR DESCRIPTION
### Motivation
As an imagery maintainer
I want to make sure the GSD values across a survey is consistent in all TIFF images
so that the data is consistent and accurate (in line with the metadata)

GSD value of the associated assets needs to be saved in the `collection.json` file for easy access when validating GSD in stac-setup.


### Modifications
Added `gsd` metadata to our STAC collection.

### Verification

added unit tests.