### PR TITLE
fix: filter non-polygons artifacts from capture-area TDE-1857

### DIFF
--- a/scripts/stac/imagery/capture_area.py
+++ b/scripts/stac/imagery/capture_area.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence
 from linz_logger import get_log
 from shapely import BufferCapStyle, BufferJoinStyle, to_geojson, union_all, wkt
 from shapely.constructive import make_valid
+from shapely.geometry import MultiPolygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import orient
 
@@ -42,6 +43,30 @@ def to_feature(geometry: BaseGeometry) -> dict[str, Any]:
     return {"geometry": json.loads(to_geojson(geometry)), "type": "Feature", "properties": {}}
 
 
+def extract_polygons(geometry: BaseGeometry) -> BaseGeometry:
+    """Extract only Polygon and MultiPolygon geometries.
+    If the geometry is a GeometryCollection, it will filter out Points, LineStrings, etc.
+
+    Args:
+        geometry: A BaseGeometry, potentially a GeometryCollection containing mixed types.
+
+    Returns:
+        A Polygon, MultiPolygon, or the original geometry if no extraction is needed.
+    """
+    if geometry.geom_type == "GeometryCollection":
+        polys = []
+        for geom in geometry.geoms:
+            if geom.geom_type == "Polygon":
+                polys.append(geom)
+            elif geom.geom_type == "MultiPolygon":
+                polys.extend(geom.geoms)
+
+        if len(polys) == 1:
+            return polys[0]
+        return MultiPolygon(polys)
+    return geometry
+
+
 def merge_polygons(polygons: Sequence[BaseGeometry], buffer_distance: float) -> BaseGeometry:
     """Merge a list of polygons by converting them to a single geometry that covers the same area.
     A buffer distance is used to buffer out the polygons before dissolving them together and then negative buffer them back in.
@@ -66,9 +91,12 @@ def merge_polygons(polygons: Sequence[BaseGeometry], buffer_distance: float) -> 
     union_rounded = wkt.loads(wkt.dumps(union_simplified, rounding_precision=8))
     # Ensure geometry is valid
     valid_geom = make_valid(union_rounded)
+    # Remove potential non-polygon geometries that may have been created during the make_valid process
+    filtered_geom = extract_polygons(valid_geom)
+
     # Apply right-hand rule winding order (exterior rings should be counter-clockwise) to the geometry
     # Ref: https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6
-    oriented_valid_geom = orient(valid_geom, sign=1.0)
+    oriented_valid_geom = orient(filtered_geom, sign=1.0)
 
     return oriented_valid_geom
 

--- a/scripts/stac/imagery/tests/capture_area_test.py
+++ b/scripts/stac/imagery/tests/capture_area_test.py
@@ -4,10 +4,10 @@ from typing import cast
 
 from pytest_subtests import SubTests
 from shapely import get_exterior_ring, is_ccw
-from shapely.geometry import MultiPolygon, Polygon, shape
+from shapely.geometry import GeometryCollection, LineString, MultiPolygon, Point, Polygon, shape
 from shapely.predicates import is_valid
 
-from scripts.stac.imagery.capture_area import generate_capture_area, merge_polygons, to_feature
+from scripts.stac.imagery.capture_area import extract_polygons, generate_capture_area, merge_polygons, to_feature
 
 # In the following tests, the expected and result GeoJSON documents are printed if the test fails.
 # This allows to visualize the geometry for debugging purpose.
@@ -267,3 +267,27 @@ def test_should_make_compliant_capture_area(subtests: SubTests) -> None:
 
     with subtests.test(msg="Is counterclockwise"):
         assert is_ccw(get_exterior_ring(merged_polygons.geoms[0]))
+
+
+def test_extract_polygons_from_geometry_collection() -> None:
+    poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+    line = LineString([(0, 0), (1, 1)])
+    pt = Point(0, 0)
+
+    gc = GeometryCollection([poly, line, pt])
+    result = extract_polygons(gc)
+
+    assert result.geom_type == "Polygon"
+    assert result.equals_exact(poly, tolerance=0.0)
+
+
+def test_extract_multiple_polygons_from_geometry_collection() -> None:
+    poly1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+    poly2 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3), (2, 2)])
+    line = LineString([(0, 0), (1, 1)])
+
+    gc = GeometryCollection([poly1, poly2, line])
+    result = extract_polygons(gc)
+
+    assert result.geom_type == "MultiPolygon"
+    assert len(result.geoms) == 2


### PR DESCRIPTION
### Motivation

When generating the `capture-area.geojson` for datasets such as the hillshades, [`make_valid()`](https://shapely.readthedocs.io/en/latest/reference/shapely.make_valid.html) on buffered union polygons would sometimes return a `GeometryCollection`. This collection can include unwanted artifacts like `LineString` or `Point` geometries (often caused by self-intersections or tiny gaps collapsing during the simplification process) in the middle of the geometry. It can make the capture-area not readable by some geo-spatial tools such QGIS or [Basemaps](https://basemaps.linz.govt.nz/).

### Modifications

Added logic to explicitly filter out any non-polygon geometries (such as `Point` and `LineString`) when a `GeometryCollection` is encountered.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Unit tests
Workflow - hillshade capture-area is now readable in QGIS
<img width="740" height="824" alt="image" src="https://github.com/user-attachments/assets/c97020a7-5082-4d95-a1e5-1a4271794154" />

<!-- TODO: Say how you tested your changes. -->
