### PR TITLE
ci: specify github environment when deploying containers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-containers:
     runs-on: ubuntu-latest
+    environment: prod
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.label.name == 'container' }}
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Description
 
-This is a collection of Python scripts used for processing topographic data in and for the cloud (AWS)
+This is a collection of Python scripts used for processing topographic data in and for the cloud (AWS).
 
 The associated Docker container is provided to run the Python scripts which use the [GDAL library](https://gdal.org/). It is based on [`osgeo/gdal:ubuntu-small-*` Docker image](https://github.com/OSGeo/gdal/pkgs/container/gdal).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Description
 
-This is a collection of Python scripts used for processing topographic data in and for the cloud (AWS).
+This is a collection of Python scripts used for processing topographic data in and for the cloud (AWS)
 
 The associated Docker container is provided to run the Python scripts which use the [GDAL library](https://gdal.org/). It is based on [`osgeo/gdal:ubuntu-small-*` Docker image](https://github.com/OSGeo/gdal/pkgs/container/gdal).
 


### PR DESCRIPTION
### Motivation & Modifications

The new GitHub CI is restricted to certain environments, this needs to be specified in order to publish containers.
