### PR TITLE
feat: change aerial photos to ancillary aerial photos TDE-1924

### DIFF
--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from topo_imagery_common.datetimes import format_rfc_3339_datetime_string
 
 from scripts.stac.imagery.collection_context import CollectionContext
+from scripts.stac.imagery.constants import ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS
 
 
 def fake_linz_slug() -> str:
@@ -23,6 +24,32 @@ def fake_linz_slug() -> str:
 def fake_collection_context() -> Iterator[CollectionContext]:
     yield CollectionContext(
         category="rural-aerial-photos",
+        domain="land",
+        region="hawkes-bay",
+        gsd=Decimal("0.3"),
+        lifecycle="completed",
+        linz_slug=fake_linz_slug(),
+        collection_id="a-random-collection-id",
+    )
+
+
+@pytest.fixture
+def fake_ancillary_aerial_photos_collection_context() -> Iterator[CollectionContext]:
+    yield CollectionContext(
+        category=ANCILLARY_AERIAL_PHOTOS,
+        domain="land",
+        region="hawkes-bay",
+        gsd=Decimal("0.3"),
+        lifecycle="completed",
+        linz_slug=fake_linz_slug(),
+        collection_id="a-random-collection-id",
+    )
+
+
+@pytest.fixture
+def fake_ancillary_near_infrared_aerial_photos_collection_context() -> Iterator[CollectionContext]:
+    yield CollectionContext(
+        category=ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS,
         domain="land",
         region="hawkes-bay",
         gsd=Decimal("0.3"),

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -32,33 +32,6 @@ def fake_collection_context() -> Iterator[CollectionContext]:
         collection_id="a-random-collection-id",
     )
 
-
-@pytest.fixture
-def fake_ancillary_aerial_photos_collection_context() -> Iterator[CollectionContext]:
-    yield CollectionContext(
-        category=ANCILLARY_AERIAL_PHOTOS,
-        domain="land",
-        region="hawkes-bay",
-        gsd=Decimal("0.3"),
-        lifecycle="completed",
-        linz_slug=fake_linz_slug(),
-        collection_id="a-random-collection-id",
-    )
-
-
-@pytest.fixture
-def fake_ancillary_near_infrared_aerial_photos_collection_context() -> Iterator[CollectionContext]:
-    yield CollectionContext(
-        category=ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS,
-        domain="land",
-        region="hawkes-bay",
-        gsd=Decimal("0.3"),
-        lifecycle="completed",
-        linz_slug=fake_linz_slug(),
-        collection_id="a-random-collection-id",
-    )
-
-
 def any_epoch_datetime() -> datetime:
     """
     Get arbitrary datetime

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -8,7 +8,6 @@ import pytest
 from topo_imagery_common.datetimes import format_rfc_3339_datetime_string
 
 from scripts.stac.imagery.collection_context import CollectionContext
-from scripts.stac.imagery.constants import ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS
 
 
 def fake_linz_slug() -> str:
@@ -31,6 +30,7 @@ def fake_collection_context() -> Iterator[CollectionContext]:
         linz_slug=fake_linz_slug(),
         collection_id="a-random-collection-id",
     )
+
 
 def any_epoch_datetime() -> datetime:
     """

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -42,7 +42,7 @@ from scripts.stac.util.STAC_VERSION import STAC_VERSION
 from scripts.stac.util.media_type import StacMediaType
 from scripts.stac.util.stac_extensions import StacExtensions
 
-ANY_ORTHO_AERIAL_PHOTOS = {ANCILLARY_AERIAL_PHOTOS, URBAN_AERIAL_PHOTOS, RURAL_AERIAL_PHOTOS, NEAR_INFRARED_AERIAL_PHOTOS}
+ANY_ORTHO_AERIAL_PHOTOS = {ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS, URBAN_AERIAL_PHOTOS, RURAL_AERIAL_PHOTOS, NEAR_INFRARED_AERIAL_PHOTOS}
 ANY_SATELLITE_IMAGERY = {SATELLITE_IMAGERY, NEAR_INFRARED_SATELLITE_IMAGERY}
 IMAGERY = {SCANNED_AERIAL_PHOTOS, *ANY_SATELLITE_IMAGERY, *ANY_ORTHO_AERIAL_PHOTOS}
 ELEVATION = {DEM, DSM}
@@ -52,6 +52,8 @@ CAPTURE_AREA_FILE_NAME = "capture-area.geojson"
 CAPTURE_DATES_FILE_NAME = "capture-dates.geojson"
 WARN_NO_PUBLISHED_CAPTURE_AREA = "no_published_capture_area"
 GSD_UNIT = "m"
+ANCILLARY_CATEGORIES = {ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS}
+
 
 
 class SubtypeParameterError(Exception):
@@ -193,6 +195,11 @@ class ImageryCollection:
         Returns:
             Dataset Title
         """
+        category = self.stac["linz:geospatial_category"]
+
+        if category in ANCILLARY_CATEGORIES and self.stac.get("linz:event_name"):
+            return
+               
         temporal_extent = self.stac.get("extent", {}).get("temporal", {}).get("interval")
         if not temporal_extent:
             raise ValueError("temporal extent must be set before setting the title")
@@ -214,7 +221,6 @@ class ImageryCollection:
         # determine suffix based on its lifecycle
         lifecycle_suffix = LIFECYCLE_SUFFIXES.get(self.stac["linz:lifecycle"], "") if self.add_title_suffix else None
 
-        category = self.stac["linz:geospatial_category"]
 
         if category == SCANNED_AERIAL_PHOTOS:
             if not historic_survey_number:
@@ -264,8 +270,8 @@ class ImageryCollection:
 
     def set_description(self) -> None:
         """Set the descriptions for imagery and elevation datasets.
-        Urban / Rural / Aerial Photos:
-          Orthophotography within the [Region] region captured in the [year(s)] flying season.
+        Urban / Rural / Ancillary Aerial Photos:
+          Ancillary Orthophotography within the [Region] region captured in the [year(s)] flying season.
         DEM / DSM:
           [Digital Surface Model / Digital Elevation Model] within the [Region] region captured in [year(s)].
         DEM_HILLSHADE / DEM_HILLSHADE_IGOR:
@@ -276,9 +282,11 @@ class ImageryCollection:
 
         Returns:
             Dataset Description
-        """
+        """        
 
         category = self.stac["linz:geospatial_category"]
+        if category in ANCILLARY_CATEGORIES and self.stac.get("linz:event_name"):
+            return
 
         components = [DATA_DOMAINS[self.domain] if category in {*ELEVATION, *HILLSHADES} else None]
         if category in {*IMAGERY, *ELEVATION}:
@@ -310,8 +318,8 @@ class ImageryCollection:
             SCANNED_AERIAL_PHOTOS: "Scanned aerial imagery",
             SATELLITE_IMAGERY: "Satellite imagery",
             NEAR_INFRARED_SATELLITE_IMAGERY: "Near-infrared satellite imagery",
-            ANCILLARY_AERIAL_PHOTOS: "Orthophotography",
-            ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS: "Near-infrared orthophotography",
+            ANCILLARY_AERIAL_PHOTOS: "Ancillary Orthophotography",
+            ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS: "Ancillary Near-infrared orthophotography",
             URBAN_AERIAL_PHOTOS: "Orthophotography",
             RURAL_AERIAL_PHOTOS: "Orthophotography",
             NEAR_INFRARED_AERIAL_PHOTOS: "Near-infrared orthophotography",

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -42,7 +42,13 @@ from scripts.stac.util.STAC_VERSION import STAC_VERSION
 from scripts.stac.util.media_type import StacMediaType
 from scripts.stac.util.stac_extensions import StacExtensions
 
-ANY_ORTHO_AERIAL_PHOTOS = {ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS, URBAN_AERIAL_PHOTOS, RURAL_AERIAL_PHOTOS, NEAR_INFRARED_AERIAL_PHOTOS}
+ANY_ORTHO_AERIAL_PHOTOS = {
+    ANCILLARY_AERIAL_PHOTOS,
+    ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS,
+    URBAN_AERIAL_PHOTOS,
+    RURAL_AERIAL_PHOTOS,
+    NEAR_INFRARED_AERIAL_PHOTOS,
+}
 ANY_SATELLITE_IMAGERY = {SATELLITE_IMAGERY, NEAR_INFRARED_SATELLITE_IMAGERY}
 IMAGERY = {SCANNED_AERIAL_PHOTOS, *ANY_SATELLITE_IMAGERY, *ANY_ORTHO_AERIAL_PHOTOS}
 ELEVATION = {DEM, DSM}
@@ -53,7 +59,6 @@ CAPTURE_DATES_FILE_NAME = "capture-dates.geojson"
 WARN_NO_PUBLISHED_CAPTURE_AREA = "no_published_capture_area"
 GSD_UNIT = "m"
 ANCILLARY_CATEGORIES = {ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS}
-
 
 
 class SubtypeParameterError(Exception):
@@ -199,7 +204,7 @@ class ImageryCollection:
 
         if category in ANCILLARY_CATEGORIES and self.stac.get("linz:event_name"):
             return
-               
+
         temporal_extent = self.stac.get("extent", {}).get("temporal", {}).get("interval")
         if not temporal_extent:
             raise ValueError("temporal extent must be set before setting the title")
@@ -220,7 +225,6 @@ class ImageryCollection:
 
         # determine suffix based on its lifecycle
         lifecycle_suffix = LIFECYCLE_SUFFIXES.get(self.stac["linz:lifecycle"], "") if self.add_title_suffix else None
-
 
         if category == SCANNED_AERIAL_PHOTOS:
             if not historic_survey_number:
@@ -282,7 +286,7 @@ class ImageryCollection:
 
         Returns:
             Dataset Description
-        """        
+        """
 
         category = self.stac["linz:geospatial_category"]
         if category in ANCILLARY_CATEGORIES and self.stac.get("linz:event_name"):

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -17,7 +17,8 @@ from scripts.json_codec import dict_to_json_bytes
 from scripts.stac.imagery.capture_area import generate_capture_area
 from scripts.stac.imagery.collection_context import CollectionContext
 from scripts.stac.imagery.constants import (
-    AERIAL_PHOTOS,
+    ANCILLARY_AERIAL_PHOTOS,
+    ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS,
     DATA_CATEGORIES,
     DATA_DOMAINS,
     DEM,
@@ -41,7 +42,7 @@ from scripts.stac.util.STAC_VERSION import STAC_VERSION
 from scripts.stac.util.media_type import StacMediaType
 from scripts.stac.util.stac_extensions import StacExtensions
 
-ANY_ORTHO_AERIAL_PHOTOS = {AERIAL_PHOTOS, URBAN_AERIAL_PHOTOS, RURAL_AERIAL_PHOTOS, NEAR_INFRARED_AERIAL_PHOTOS}
+ANY_ORTHO_AERIAL_PHOTOS = {ANCILLARY_AERIAL_PHOTOS, URBAN_AERIAL_PHOTOS, RURAL_AERIAL_PHOTOS, NEAR_INFRARED_AERIAL_PHOTOS}
 ANY_SATELLITE_IMAGERY = {SATELLITE_IMAGERY, NEAR_INFRARED_SATELLITE_IMAGERY}
 IMAGERY = {SCANNED_AERIAL_PHOTOS, *ANY_SATELLITE_IMAGERY, *ANY_ORTHO_AERIAL_PHOTOS}
 ELEVATION = {DEM, DSM}
@@ -309,7 +310,8 @@ class ImageryCollection:
             SCANNED_AERIAL_PHOTOS: "Scanned aerial imagery",
             SATELLITE_IMAGERY: "Satellite imagery",
             NEAR_INFRARED_SATELLITE_IMAGERY: "Near-infrared satellite imagery",
-            AERIAL_PHOTOS: "Orthophotography",
+            ANCILLARY_AERIAL_PHOTOS: "Orthophotography",
+            ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS: "Near-infrared orthophotography",
             URBAN_AERIAL_PHOTOS: "Orthophotography",
             RURAL_AERIAL_PHOTOS: "Orthophotography",
             NEAR_INFRARED_AERIAL_PHOTOS: "Near-infrared orthophotography",

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -197,9 +197,11 @@ class ImageryCollection:
 
     def set_title(self) -> None:
         """Set the title based on the STAC metadata.
-        Satellite Imagery / Urban Aerial Photos / Rural Aerial Photos / Scanned Aerial Photos:
+        Satellite Imagery / Near-Infrared Satellite Imagery / Urban Aerial Photos / Rural Aerial Photos /
+        Near-Infrared Aerial Photos / Ancillary Aerial Photos / Ancillary Near-Infrared Aerial Photos /
+        Scanned Aerial Photos:
           https://github.com/linz/imagery/blob/master/docs/naming.md
-        DEM / DSM:
+        DEM / DSM / DEM Hillshade / DEM Hillshade Igor / DSM Hillshade / DSM Hillshade Igor:
           https://github.com/linz/elevation/blob/master/docs/naming.md
 
         Raises:
@@ -282,15 +284,24 @@ class ImageryCollection:
 
     def set_description(self) -> None:
         """Set the descriptions for imagery and elevation datasets.
-        Urban / Rural / Ancillary Aerial Photos:
-          Ancillary orthophotography within the [Region] region captured in the [year(s)] flying season.
+        Urban / Rural Aerial Photos / Near-Infrared Aerial Photos:
+          [Orthophotography / Near-infrared orthophotography] within the [Region] region captured in the
+          [year(s)] flying season.
+        Ancillary Aerial Photos / Ancillary Near-Infrared Aerial Photos:
+          [Ancillary orthophotography / Ancillary near-infrared orthophotography] within the [Region] region
+          captured in the [year(s)] flying season. If published as part of a named event, the "Ancillary"
+          prefix is dropped and the description reads as plain (near-infrared) orthophotography instead.
         DEM / DSM:
-          [Digital Surface Model / Digital Elevation Model] within the [Region] region captured in [year(s)].
-        DEM_HILLSHADE / DEM_HILLSHADE_IGOR:
-          [Digital Elevation Model] [mono-directional / whiter multi-directional] hillshade derived from 1m LiDAR.
-          Gaps filled with lower resolution elevation data (8m contour) as needed.
-        Satellite Imagery / Scanned Aerial Photos:
-          [Satellite imagery | Scanned Aerial Photos] within the [Region] region captured in [year(s)].
+          [Digital Elevation Model / Digital Surface Model] within the [Region] region captured in [year(s)].
+        DEM/DSM Hillshade / Hillshade Igor:
+          [Digital Elevation Model / Digital Surface Model] [mono-directional / whiter multi-directional]
+          hillshade derived from 1m LiDAR. Gaps filled with lower resolution elevation data (8m contour) as needed.
+        Satellite Imagery / Near-Infrared Satellite Imagery / Scanned Aerial Photos:
+          [Satellite imagery / Near-infrared satellite imagery / Scanned aerial imagery] within the [Region]
+          region captured in [year(s)].
+
+        If `linz:event_name` is set, the description is suffixed with
+        ", published as a record of the [event name] event."
 
         Returns:
             Dataset Description

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -59,6 +59,15 @@ CAPTURE_DATES_FILE_NAME = "capture-dates.geojson"
 WARN_NO_PUBLISHED_CAPTURE_AREA = "no_published_capture_area"
 GSD_UNIT = "m"
 ANCILLARY_CATEGORIES = {ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS}
+# When an ancillary category is published as part of a named event, the title/description
+# read as plain (non-ancillary) orthophotography instead of "Ancillary ...".
+EVENTS = {
+    ANCILLARY_AERIAL_PHOTOS: {"title": "Aerial Photos", "description": "Orthophotography"},
+    ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS: {
+        "title": "Near-Infrared Aerial Photos",
+        "description": "Near-infrared orthophotography",
+    },
+}
 
 
 class SubtypeParameterError(Exception):
@@ -201,9 +210,7 @@ class ImageryCollection:
             Dataset Title
         """
         category = self.stac["linz:geospatial_category"]
-
-        if category in ANCILLARY_CATEGORIES and self.stac.get("linz:event_name"):
-            return
+        is_ancillary_event = category in ANCILLARY_CATEGORIES and bool(self.stac.get("linz:event_name"))
 
         temporal_extent = self.stac.get("extent", {}).get("temporal", {}).get("interval")
         if not temporal_extent:
@@ -238,10 +245,11 @@ class ImageryCollection:
             ]
 
         elif category in {*ANY_SATELLITE_IMAGERY, *ANY_ORTHO_AERIAL_PHOTOS}:
+            category_title = EVENTS[category]["title"] if is_ancillary_event else DATA_CATEGORIES[category]
             components = [
                 geographic_description or region,
                 gsd_str,
-                DATA_CATEGORIES[category],
+                category_title,
                 date,
                 lifecycle_suffix,
             ]
@@ -289,8 +297,6 @@ class ImageryCollection:
         """
 
         category = self.stac["linz:geospatial_category"]
-        if category in ANCILLARY_CATEGORIES and self.stac.get("linz:event_name"):
-            return
 
         components = [DATA_DOMAINS[self.domain] if category in {*ELEVATION, *HILLSHADES} else None]
         if category in {*IMAGERY, *ELEVATION}:
@@ -317,6 +323,7 @@ class ImageryCollection:
         end_year = convert_utc_to_nz_datetime(parse_rfc_3339_datetime(temporal_extent[0][1])).year
 
         category = self.stac["linz:geospatial_category"]
+        is_ancillary_event = category in ANCILLARY_CATEGORIES and bool(self.stac.get("linz:event_name"))
 
         base_descriptions = {
             SCANNED_AERIAL_PHOTOS: "Scanned aerial imagery",
@@ -331,8 +338,10 @@ class ImageryCollection:
             DSM: "Digital Surface Model",
         }
 
+        base_description = EVENTS[category]["description"] if is_ancillary_event else base_descriptions[category]
+
         components = [
-            base_descriptions[category],
+            base_description,
             "within the",
             HUMAN_READABLE_REGIONS[self.stac["linz:region"]],
             "region captured in",

--- a/scripts/stac/imagery/collection.py
+++ b/scripts/stac/imagery/collection.py
@@ -275,7 +275,7 @@ class ImageryCollection:
     def set_description(self) -> None:
         """Set the descriptions for imagery and elevation datasets.
         Urban / Rural / Ancillary Aerial Photos:
-          Ancillary Orthophotography within the [Region] region captured in the [year(s)] flying season.
+          Ancillary orthophotography within the [Region] region captured in the [year(s)] flying season.
         DEM / DSM:
           [Digital Surface Model / Digital Elevation Model] within the [Region] region captured in [year(s)].
         DEM_HILLSHADE / DEM_HILLSHADE_IGOR:
@@ -322,8 +322,8 @@ class ImageryCollection:
             SCANNED_AERIAL_PHOTOS: "Scanned aerial imagery",
             SATELLITE_IMAGERY: "Satellite imagery",
             NEAR_INFRARED_SATELLITE_IMAGERY: "Near-infrared satellite imagery",
-            ANCILLARY_AERIAL_PHOTOS: "Ancillary Orthophotography",
-            ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS: "Ancillary Near-infrared orthophotography",
+            ANCILLARY_AERIAL_PHOTOS: "Ancillary orthophotography",
+            ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS: "Ancillary near-infrared orthophotography",
             URBAN_AERIAL_PHOTOS: "Orthophotography",
             RURAL_AERIAL_PHOTOS: "Orthophotography",
             NEAR_INFRARED_AERIAL_PHOTOS: "Near-infrared orthophotography",

--- a/scripts/stac/imagery/constants.py
+++ b/scripts/stac/imagery/constants.py
@@ -1,5 +1,6 @@
 # CATEGORIES
-AERIAL_PHOTOS = "aerial-photos"
+AERIAL_PHOTOS = "ancillary-aerial-photos"
+ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS = "ancillary-near-infrared-aerial-photos"
 SCANNED_AERIAL_PHOTOS = "scanned-aerial-photos"
 RURAL_AERIAL_PHOTOS = "rural-aerial-photos"
 NEAR_INFRARED_AERIAL_PHOTOS = "near-infrared-aerial-photos"
@@ -18,7 +19,8 @@ COASTAL = "coastal"
 
 
 DATA_CATEGORIES = {
-    AERIAL_PHOTOS: "Aerial Photos",
+    ANCILLARY_AERIAL_PHOTOS: "Ancillary Aerial Photos",
+    ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS: "Ancillary Near-Infrared Aerial Photos",
     SCANNED_AERIAL_PHOTOS: "Scanned Aerial Photos",
     RURAL_AERIAL_PHOTOS: "Rural Aerial Photos",
     NEAR_INFRARED_AERIAL_PHOTOS: "Near-Infrared Aerial Photos",

--- a/scripts/stac/imagery/constants.py
+++ b/scripts/stac/imagery/constants.py
@@ -1,5 +1,5 @@
 # CATEGORIES
-AERIAL_PHOTOS = "ancillary-aerial-photos"
+ANCILLARY_AERIAL_PHOTOS = "ancillary-aerial-photos"
 ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS = "ancillary-near-infrared-aerial-photos"
 SCANNED_AERIAL_PHOTOS = "scanned-aerial-photos"
 RURAL_AERIAL_PHOTOS = "rural-aerial-photos"

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -470,11 +470,11 @@ published as a record of the Cyclone Gabrielle event.",
                 linz_slug=fake_linz_slug(),
                 gsd=Decimal("0.3"),
                 collection_id="a-random-collection-id",
+            ),
+            "Hawke's Bay 0.3m Ancillary Aerial Photos (2023)",
+            "Ancillary Orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
+            id="Ancillary Aerial Photos",
         ),
-        "Hawke's Bay 0.3m Ancillary Aerial Photos (2023)",
-        "Ancillary Orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
-        id="Ancillary Aerial Photos",
-    ),
         param(
             CollectionContext(
                 category="ancillary-near-infrared-aerial-photos",
@@ -484,11 +484,11 @@ published as a record of the Cyclone Gabrielle event.",
                 linz_slug=fake_linz_slug(),
                 gsd=Decimal("0.3"),
                 collection_id="a-random-collection-id",
+            ),
+            "Hawke's Bay 0.3m Ancillary Near-Infrared Aerial Photos (2023)",
+            "Ancillary Near-infrared orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
+            id="Ancillary Near-Infrared Aerial Photos",
         ),
-        "Hawke's Bay 0.3m Ancillary Near-Infrared Aerial Photos (2023)",
-        "Ancillary Near-infrared orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
-        id="Ancillary Near-Infrared Aerial Photos",
-    ),
     ],
 )
 def test_set_title_set_description(
@@ -1087,6 +1087,7 @@ def test_ancillary_near_infrared_aerial_photos_category(
     fake_ancillary_near_infrared_aerial_photos_collection_context: CollectionContext,
 ) -> None:
     assert fake_ancillary_near_infrared_aerial_photos_collection_context.category == ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS
+
 
 def test_title_and_description_not_updated_when_event_name_set_for_ancillary(subtests: SubTests) -> None:
     context = CollectionContext(

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -461,6 +461,34 @@ published as a record of the Cyclone Gabrielle event.",
             "minimize effects on other map features.",
             id="Coastal 1m DEM Hillshade Igor",
         ),
+        param(
+            CollectionContext(
+                category="ancillary-aerial-photos",
+                domain="land",
+                region="hawkes-bay",
+                lifecycle="completed",
+                linz_slug=fake_linz_slug(),
+                gsd=Decimal("0.3"),
+                collection_id="a-random-collection-id",
+        ),
+        "Hawke's Bay 0.3m Ancillary Aerial Photos (2023)",
+        "Ancillary Orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
+        id="Ancillary Aerial Photos",
+    ),
+        param(
+            CollectionContext(
+                category="ancillary-near-infrared-aerial-photos",
+                domain="land",
+                region="hawkes-bay",
+                lifecycle="completed",
+                linz_slug=fake_linz_slug(),
+                gsd=Decimal("0.3"),
+                collection_id="a-random-collection-id",
+        ),
+        "Hawke's Bay 0.3m Ancillary Near-Infrared Aerial Photos (2023)",
+        "Ancillary Near-infrared orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
+        id="Ancillary Near-Infrared Aerial Photos",
+    ),
     ],
 )
 def test_set_title_set_description(
@@ -1059,3 +1087,22 @@ def test_ancillary_near_infrared_aerial_photos_category(
     fake_ancillary_near_infrared_aerial_photos_collection_context: CollectionContext,
 ) -> None:
     assert fake_ancillary_near_infrared_aerial_photos_collection_context.category == ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS
+
+def test_title_and_description_not_updated_when_event_name_set_for_ancillary(subtests: SubTests) -> None:
+    context = CollectionContext(
+        category="ancillary-aerial-photos",
+        domain="land",
+        region="hawkes-bay",
+        lifecycle="completed",
+        linz_slug=fake_linz_slug(),
+        gsd=Decimal("0.3"),
+        collection_id="a-random-collection-id",
+        event_name="Forest Assessment",
+    )
+    collection = ImageryCollection(context, any_epoch_datetime_string(), any_epoch_datetime_string())
+    with subtests.test(msg="title"):
+        collection.set_title()
+        assert collection.stac["title"] == ""
+    with subtests.test(msg="description"):
+        collection.set_description()
+        assert collection.stac["description"] == ""

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -21,6 +21,7 @@ from topo_imagery_common.files.fs_s3 import write
 from scripts.conftest import any_epoch_datetime_string, fake_linz_slug
 from scripts.stac.imagery.collection import WARN_NO_PUBLISHED_CAPTURE_AREA, ImageryCollection, MissingMetadataError
 from scripts.stac.imagery.collection_context import CollectionContext
+from scripts.stac.imagery.constants import ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS
 from scripts.stac.imagery.item import ImageryItem, STACAsset
 from scripts.stac.imagery.provider import ProviderRole
 from scripts.stac.imagery.tests.generators import any_stac_processing
@@ -1048,3 +1049,13 @@ def test_update_metadata(fake_collection_context: CollectionContext, subtests: S
     with subtests.test(msg="Optional metadata should be removed if not passed"):
         assert collection.stac.get("linz:event_name") is None
         assert collection.stac.get("linz:geographic_description") is None
+
+
+def test_ancillary_aerial_photos_category(fake_ancillary_aerial_photos_collection_context: CollectionContext) -> None:
+    assert fake_ancillary_aerial_photos_collection_context.category == ANCILLARY_AERIAL_PHOTOS
+
+
+def test_ancillary_near_infrared_aerial_photos_category(
+    fake_ancillary_near_infrared_aerial_photos_collection_context: CollectionContext,
+) -> None:
+    assert fake_ancillary_near_infrared_aerial_photos_collection_context.category == ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -472,7 +472,7 @@ published as a record of the Cyclone Gabrielle event.",
                 collection_id="a-random-collection-id",
             ),
             "Hawke's Bay 0.3m Ancillary Aerial Photos (2023)",
-            "Ancillary Orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
+            "Ancillary orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
             id="Ancillary Aerial Photos",
         ),
         param(
@@ -486,8 +486,40 @@ published as a record of the Cyclone Gabrielle event.",
                 collection_id="a-random-collection-id",
             ),
             "Hawke's Bay 0.3m Ancillary Near-Infrared Aerial Photos (2023)",
-            "Ancillary Near-infrared orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
+            "Ancillary near-infrared orthophotography within the Hawke's Bay region captured in the 2023 flying season.",
             id="Ancillary Near-Infrared Aerial Photos",
+        ),
+        param(
+            CollectionContext(
+                category="ancillary-aerial-photos",
+                domain="land",
+                region="hawkes-bay",
+                lifecycle="completed",
+                linz_slug=fake_linz_slug(),
+                gsd=Decimal("0.3"),
+                collection_id="a-random-collection-id",
+                event_name="Forest Assessment",
+            ),
+            "Hawke's Bay 0.3m Aerial Photos (2023)",
+            "Orthophotography within the Hawke's Bay region captured in the 2023 flying season, "
+            "published as a record of the Forest Assessment event.",
+            id="Ancillary Aerial Photos with Event",
+        ),
+        param(
+            CollectionContext(
+                category="ancillary-near-infrared-aerial-photos",
+                domain="land",
+                region="hawkes-bay",
+                lifecycle="completed",
+                linz_slug=fake_linz_slug(),
+                gsd=Decimal("0.3"),
+                collection_id="a-random-collection-id",
+                event_name="Forest Assessment",
+            ),
+            "Hawke's Bay 0.3m Near-Infrared Aerial Photos (2023)",
+            "Near-infrared orthophotography within the Hawke's Bay region captured in the 2023 flying season, "
+            "published as a record of the Forest Assessment event.",
+            id="Ancillary Near-Infrared Aerial Photos with Event",
         ),
     ],
 )
@@ -1079,31 +1111,27 @@ def test_update_metadata(fake_collection_context: CollectionContext, subtests: S
         assert collection.stac.get("linz:geographic_description") is None
 
 
-def test_ancillary_aerial_photos_category(fake_ancillary_aerial_photos_collection_context: CollectionContext) -> None:
-    assert fake_ancillary_aerial_photos_collection_context.category == ANCILLARY_AERIAL_PHOTOS
-
-
-def test_ancillary_near_infrared_aerial_photos_category(
-    fake_ancillary_near_infrared_aerial_photos_collection_context: CollectionContext,
-) -> None:
-    assert fake_ancillary_near_infrared_aerial_photos_collection_context.category == ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS
-
-
-def test_title_and_description_not_updated_when_event_name_set_for_ancillary(subtests: SubTests) -> None:
+def test_ancillary_aerial_photos_category() -> None:
     context = CollectionContext(
-        category="ancillary-aerial-photos",
+        category=ANCILLARY_AERIAL_PHOTOS,
         domain="land",
         region="hawkes-bay",
+        gsd=Decimal("0.3"),
         lifecycle="completed",
         linz_slug=fake_linz_slug(),
-        gsd=Decimal("0.3"),
         collection_id="a-random-collection-id",
-        event_name="Forest Assessment",
     )
-    collection = ImageryCollection(context, any_epoch_datetime_string(), any_epoch_datetime_string())
-    with subtests.test(msg="title"):
-        collection.set_title()
-        assert collection.stac["title"] == ""
-    with subtests.test(msg="description"):
-        collection.set_description()
-        assert collection.stac["description"] == ""
+    assert context.category == ANCILLARY_AERIAL_PHOTOS
+
+
+def test_ancillary_near_infrared_aerial_photos_category() -> None:
+    context = CollectionContext(
+        category=ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS,
+        domain="land",
+        region="hawkes-bay",
+        gsd=Decimal("0.3"),
+        lifecycle="completed",
+        linz_slug=fake_linz_slug(),
+        collection_id="a-random-collection-id",
+    )
+    assert context.category == ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -21,7 +21,6 @@ from topo_imagery_common.files.fs_s3 import write
 from scripts.conftest import any_epoch_datetime_string, fake_linz_slug
 from scripts.stac.imagery.collection import WARN_NO_PUBLISHED_CAPTURE_AREA, ImageryCollection, MissingMetadataError
 from scripts.stac.imagery.collection_context import CollectionContext
-from scripts.stac.imagery.constants import ANCILLARY_AERIAL_PHOTOS, ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS
 from scripts.stac.imagery.item import ImageryItem, STACAsset
 from scripts.stac.imagery.provider import ProviderRole
 from scripts.stac.imagery.tests.generators import any_stac_processing

--- a/scripts/stac/imagery/tests/collection_test.py
+++ b/scripts/stac/imagery/tests/collection_test.py
@@ -1109,29 +1109,3 @@ def test_update_metadata(fake_collection_context: CollectionContext, subtests: S
     with subtests.test(msg="Optional metadata should be removed if not passed"):
         assert collection.stac.get("linz:event_name") is None
         assert collection.stac.get("linz:geographic_description") is None
-
-
-def test_ancillary_aerial_photos_category() -> None:
-    context = CollectionContext(
-        category=ANCILLARY_AERIAL_PHOTOS,
-        domain="land",
-        region="hawkes-bay",
-        gsd=Decimal("0.3"),
-        lifecycle="completed",
-        linz_slug=fake_linz_slug(),
-        collection_id="a-random-collection-id",
-    )
-    assert context.category == ANCILLARY_AERIAL_PHOTOS
-
-
-def test_ancillary_near_infrared_aerial_photos_category() -> None:
-    context = CollectionContext(
-        category=ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS,
-        domain="land",
-        region="hawkes-bay",
-        gsd=Decimal("0.3"),
-        lifecycle="completed",
-        linz_slug=fake_linz_slug(),
-        collection_id="a-random-collection-id",
-    )
-    assert context.category == ANCILLARY_NEAR_INFRARED_AERIAL_PHOTOS


### PR DESCRIPTION
### Motivation

To separately categorise opportunity imagery, project imagery and other random imagery
so that it can easily be split out from higher quality imagery


### Modifications

Change existing (but underutilised) aerial-photos geospatial category to ancillary-aerial-photos and add ancillary-near-infrared-aerial-photos. 
Added test fixtures and basic tests. 


