### PR TITLE
feat: Added Chatham Islands to the list of regions TDE-1971

### DIFF
--- a/scripts/stac/imagery/constants.py
+++ b/scripts/stac/imagery/constants.py
@@ -61,6 +61,7 @@ HUMAN_READABLE_REGIONS = {
     "waikato": "Waikato",
     "wellington": "Wellington",
     "west-coast": "West Coast",
+    "chatham-islands": "Chatham Islands",
 }
 
 LIFECYCLE_SUFFIXES = {


### PR DESCRIPTION
### Motivation

To add Chatham Islands to list of regions when creating collection
so that we can update our data to show the correct region

### Modifications

Chatham Islands available in list of regions

Datset is able to be updated by Land Squad to region=Chatham Islands


