### PR TITLE
feat: support Chatham Islands EPSG:3793 TDE-1990

### DIFF
--- a/packages/topo-imagery-common/src/topo_imagery_common/epsg.py
+++ b/packages/topo-imagery-common/src/topo_imagery_common/epsg.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class EpsgNumber(int, Enum):
+    NZTM_2000 = 2193
+    """New Zealand Transverse Mercator 2000"""
+    WGS_1984 = 4326
+    """World Geodetic System 1984"""
+    CITM_2000 = 3793
+    """Chatham Islands Transverse Mercator 2000"""
+    NZVD_2016 = 7839
+    """New Zealand Vertical Datum 2016"""

--- a/packages/topo-imagery-common/src/topo_imagery_common/epsg.py
+++ b/packages/topo-imagery-common/src/topo_imagery_common/epsg.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import IntEnum
 
 
-class EpsgNumber(int, Enum):
+class EpsgNumber(IntEnum):
     NZTM_2000 = 2193
     """New Zealand Transverse Mercator 2000"""
     WGS_1984 = 4326

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_commands.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_commands.py
@@ -274,7 +274,7 @@ def get_footprint_command(gsd: Decimal, preset: str) -> list[str]:
     gdal_footprint_command: list[str] = [
         "gdal_footprint",
         "-t_srs",
-        f"EPSG:{EpsgNumber.WGS_1984.value}",
+        f"EPSG:{EpsgNumber.WGS_1984}",
         "-max_points",
         "unlimited",
         "-lco",

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_commands.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_commands.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from decimal import Decimal
 
 from linz_logger import get_log
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_gdal.gdal.gdal_bands import get_gdal_band_offset
-from topo_imagery_gdal.gdal.gdal_helper import EpsgNumber
 from topo_imagery_gdal.gdal.gdal_presets import (
     BASE_COG,
     COMPRESS_LZW,
@@ -101,7 +101,7 @@ def get_cutline_command(cutline: str | None) -> list[str]:
 def get_build_vrt_command(
     files: list[str],
     output: str = "output.vrt",
-    epsg: int = 2193,
+    epsg: int = EpsgNumber.NZTM_2000,
     add_alpha: bool = False,
     resolution: list[Decimal] | None = None,
 ) -> list[str]:

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
@@ -108,7 +108,7 @@ def get_srs() -> bytes:
     Returns:
         the output of `gdalsrsinfo`
     """
-    gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", f"EPSG:{EpsgNumber.NZTM_2000.value}"]
+    gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", f"EPSG:{EpsgNumber.NZTM_2000}"]
     gdalsrsinfo_result = run_gdal(gdalsrsinfo_command)
     if gdalsrsinfo_result.stderr:
         raise Exception(

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
@@ -1,7 +1,6 @@
 import json
 import os
 import subprocess
-from enum import Enum
 from shutil import rmtree
 from tempfile import mkdtemp
 from typing import cast
@@ -10,19 +9,13 @@ from linz_logger import get_log
 from topo_imagery_common.aws.aws_helper import is_s3
 from topo_imagery_common.files.files_helper import get_file_name_from_path
 from topo_imagery_common.files.fs import copy
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_common.log.time_helper import time_in_ms
 from topo_imagery_gdal.gdal.gdalinfo import GdalInfo
 
 
 class GDALExecutionException(Exception):
     pass
-
-
-class EpsgNumber(int, Enum):
-    NZTM_2000 = 2193
-    """New Zealand Transverse Mercator 2000"""
-    WGS_1984 = 4326
-    """World Geodetic System 1984"""
 
 
 def get_vfs_path(path: str) -> str:

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
@@ -7,9 +7,9 @@ from typing import cast
 
 from linz_logger import get_log
 from topo_imagery_common.aws.aws_helper import is_s3
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_common.files.files_helper import get_file_name_from_path
 from topo_imagery_common.files.fs import copy
-from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_common.log.time_helper import time_in_ms
 from topo_imagery_gdal.gdal.gdalinfo import GdalInfo
 

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
@@ -107,6 +107,12 @@ def get_srs_command(epsg: int = EpsgNumber.NZTM_2000) -> list[str]:
 
     Returns:
         a list of arguments to run `gdalsrsinfo`
+
+    Examples:
+        >>> get_srs_command(EpsgNumber.NZTM_2000)
+        ['gdalsrsinfo', '-o', 'wkt', 'EPSG:2193']
+        >>> get_srs_command(EpsgNumber.CITM_2000)
+        ['gdalsrsinfo', '-o', 'wkt', 'EPSG:3793']
     """
     return ["gdalsrsinfo", "-o", "wkt", f"EPSG:{epsg}"]
 

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
@@ -99,6 +99,18 @@ def run_gdal(
     return proc
 
 
+def get_srs_command(epsg: int = EpsgNumber.NZTM_2000) -> list[str]:
+    """Build a `gdalsrsinfo` command for the given EPSG code.
+
+    Args:
+        epsg: the EPSG code to get the srs for. Defaults to 2193 (NZTM).
+
+    Returns:
+        a list of arguments to run `gdalsrsinfo`
+    """
+    return ["gdalsrsinfo", "-o", "wkt", f"EPSG:{epsg}"]
+
+
 def get_srs(epsg: int = EpsgNumber.NZTM_2000) -> bytes:
     """Run `gdalsrsinfo` with the given EPSG code.
 
@@ -111,8 +123,7 @@ def get_srs(epsg: int = EpsgNumber.NZTM_2000) -> bytes:
     Returns:
         the output of `gdalsrsinfo`
     """
-    gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", f"EPSG:{epsg}"]
-    gdalsrsinfo_result = run_gdal(gdalsrsinfo_command)
+    gdalsrsinfo_result = run_gdal(get_srs_command(epsg))
     if gdalsrsinfo_result.stderr:
         raise Exception(
             f"Error trying to retrieve srs from epsg code, no files have been checked\n{gdalsrsinfo_result.stderr!r}"

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/gdal/gdal_helper.py
@@ -99,8 +99,11 @@ def run_gdal(
     return proc
 
 
-def get_srs() -> bytes:
-    """Run `gdalsrsinfo` with the EPSG code `2193`
+def get_srs(epsg: int = EpsgNumber.NZTM_2000) -> bytes:
+    """Run `gdalsrsinfo` with the given EPSG code.
+
+    Args:
+        epsg: the EPSG code to get the srs for. Defaults to 2193 (NZTM).
 
     Raises:
         Exception: if `gdal` has an stderr
@@ -108,7 +111,7 @@ def get_srs() -> bytes:
     Returns:
         the output of `gdalsrsinfo`
     """
-    gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", f"EPSG:{EpsgNumber.NZTM_2000}"]
+    gdalsrsinfo_command = ["gdalsrsinfo", "-o", "wkt", f"EPSG:{epsg}"]
     gdalsrsinfo_result = run_gdal(gdalsrsinfo_command)
     if gdalsrsinfo_result.stderr:
         raise Exception(

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/standardising.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/standardising.py
@@ -324,7 +324,7 @@ def apply_gdal_transformation(input_file: str, config: StandardisingConfig, tmp_
     command.extend(get_gdal_band_offset(input_file, gdal_info(input_file), config.gdal_preset))
 
     # Specify the extent to get the right boundaries in case of the tiff got no data on its edges
-    output_bounds: Bounds = get_bounds_from_name(tile_name)
+    output_bounds: Bounds = get_bounds_from_name(tile_name, target_epsg=config.target_epsg)
     min_x = output_bounds.point.x
     max_y = output_bounds.point.y
     min_y = max_y - output_bounds.size.height

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/standardising.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/standardising.py
@@ -11,6 +11,7 @@ from linz_logger import get_log
 from tifffile import TiffFile
 from topo_imagery_common.aws.aws_helper import is_s3
 from topo_imagery_common.cli.cli_helper import TileFiles
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_common.files.files_helper import ContentType, is_tiff
 from topo_imagery_common.files.fs import exists, read, write, write_all, write_sidecars
 from topo_imagery_common.log.time_helper import time_in_ms
@@ -211,7 +212,7 @@ def standardising(
 def create_vrt(
     source_tiffs: list[str],
     target_path: str,
-    epsg: int = 2193,
+    epsg: int = EpsgNumber.NZTM_2000,
     add_alpha: bool = False,
     resolution: list[Decimal] | None = None,
 ) -> str:

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
@@ -78,7 +78,7 @@ def get_bounds_from_name(tile_name: str, target_epsg: int = EpsgNumber.NZTM_2000
     else:
         raise ValueError(
             f"Unsupported target EPSG:{target_epsg} for mapsheet lookup. "
-            f"Supported: {EpsgNumber.NZTM_2000.value}, {EpsgNumber.CITM_2000.value}"
+            f"Supported: {EpsgNumber.NZTM_2000}, {EpsgNumber.CITM_2000}"
         )
 
     # check for 50k imagery

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
@@ -17,9 +17,9 @@ CHAR_A = charcodeat("A", 0)
 CHAR_S = charcodeat("S", 0)
 
 MAINLAND_EPSG = 2193
-""" EPSG code of the mainland NZTM50 mapsheet grid (NZGD2000 / New Zealand Transverse Mercator 2000) """
+""" EPSG code of the mainland NZTM50 mapsheet grid (NZGD2000 / NZTM2000) """
 CHATHAM_EPSG = 3793
-""" EPSG code of the Chatham Islands mapsheet grid (NZGD2000 / Chatham Islands TM 2000) """
+""" EPSG code of the Chatham Islands mapsheet grid (NZGD2000 / CITM2000) """
 
 
 class Point(NamedTuple):
@@ -40,12 +40,19 @@ class Bounds(NamedTuple):
 
 
 # The six Chatham Islands Topo50 mapsheets (EPSG:3793, NZGD2000 / Chatham Islands TM 2000), laid
-# out on the same 24,000m x 36,000m 1:50k grid as the mainland sheets, just with a different origin
-# and (small, fixed) set of sheet codes. Unlike the mainland grid, this is a small enough set of
-# sheets that a static lookup table transcribed from the authoritative shapefile is simpler and
-# less bug-prone than deriving a formula.
-#
-# Values transcribed from (and can be regenerated with `ogrinfo -al` against):
+# out on the same 24,000m x 36,000m 1:50k grid as the mainland sheets, with a different origin
+# and layout of sheet codes. The following sheet codes are used:
+# +------+------+------+
+# | CI01 | CI02 | CI03 |
+# |      |      |      |
+# +------+------+------+
+#        | CI04 | CI05 |
+#        |      |      |
+#        +------+------+
+#               | CI06 |
+#               |      |
+#               +------+
+# Reference:
 # https://data.linz.govt.nz/layer/50089-nz-chatham-island-linz-map-sheets-topo-150k/
 CHATHAM_SHEET_ORIGINS: dict[str, Point] = {
     "CI01": Point(x=3_458_000, y=5_176_000),  # Point Somes

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
@@ -1,6 +1,7 @@
 import re
 from typing import NamedTuple
 
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_gdal.tile.util import charcodeat
 
 SHEET_WIDTH = 24_000
@@ -16,9 +17,9 @@ GRID_SIZE_MAX = 50_000
 CHAR_A = charcodeat("A", 0)
 CHAR_S = charcodeat("S", 0)
 
-MAINLAND_EPSG = 2193
+MAINLAND_EPSG = EpsgNumber.NZTM_2000
 """ EPSG code of the mainland NZTM50 mapsheet grid (NZGD2000 / NZTM2000) """
-CHATHAM_EPSG = 3793
+CHATHAM_EPSG = EpsgNumber.CITM_2000
 """ EPSG code of the Chatham Islands mapsheet grid (NZGD2000 / CITM2000) """
 
 
@@ -63,41 +64,21 @@ CHATHAM_SHEET_ORIGINS: dict[str, Point] = {
     "CI06": Point(x=3_506_000, y=5_104_000),  # Pitt Island (Rangiauria)
 }
 
-
-def get_chatham_mapsheet_offset(sheet_code: str) -> Point:
-    """Look up the origin point for a Chatham Islands mapsheet code.
-
-    Args:
-        sheet_code: Chatham Islands topo 50 map sheet code eg "CI06"
-
-    Returns:
-        Point: The top left point of the mapsheet, in EPSG:3793
-
-    Example:
-        >>> get_chatham_mapsheet_offset("CI06")
-        Point(x=3506000, y=5104000)
-    """
-    origin = CHATHAM_SHEET_ORIGINS.get(sheet_code[:4])
-    if origin is None:
-        raise ValueError(f"Unknown Chatham Islands map sheet: {sheet_code}; known sheets: {sorted(CHATHAM_SHEET_ORIGINS)}")
-    return origin
-
-
 def get_bounds_from_name(tile_name: str, target_epsg: int = MAINLAND_EPSG) -> Bounds:
     """Get the origin coordinates and size of the tile from its name.
 
     Args:
         tile_name: the tile name as `sheetCode_gridSize_tileId`
-        target_epsg: EPSG code of the mapsheet grid the tile is named against; only
+        target_epsg: EPSG code of the mapsheet grid for the tile.
             `MAINLAND_EPSG` (2193) and `CHATHAM_EPSG` (3793) are supported
 
     Returns:
         a `Bounds` object
     """
-    if target_epsg == CHATHAM_EPSG:
-        get_offset = get_chatham_mapsheet_offset
-    elif target_epsg == MAINLAND_EPSG:
+    if target_epsg == MAINLAND_EPSG:
         get_offset = get_mapsheet_offset
+    elif target_epsg == CHATHAM_EPSG:
+        get_offset = get_chatham_mapsheet_offset
     else:
         raise ValueError(
             f"Unsupported target EPSG:{target_epsg} for mapsheet lookup; supported: {MAINLAND_EPSG}, {CHATHAM_EPSG}"
@@ -167,6 +148,26 @@ def get_mapsheet_offset(sheet_code: str) -> Point:
         y -= 1
 
     return Point(x=SHEET_WIDTH * x + SHEET_ORIGIN_LEFT, y=SHEET_ORIGIN_TOP - SHEET_HEIGHT * y)
+
+
+def get_chatham_mapsheet_offset(sheet_code: str) -> Point:
+    """Look up the origin point for a Chatham Islands mapsheet code.
+
+    Args:
+        sheet_code: Chatham Islands topo 50 map sheet code eg "CI06"
+
+    Returns:
+        Point: The top left point of the mapsheet, in EPSG:3793
+
+    Example:
+        >>> get_chatham_mapsheet_offset("CI06")
+        Point(x=3506000, y=5104000)
+    """
+    origin = CHATHAM_SHEET_ORIGINS.get(sheet_code[:4])
+    if origin is None:
+        raise ValueError(f"Unknown Chatham Islands map sheet: {sheet_code}. Known sheets: {sorted(CHATHAM_SHEET_ORIGINS)}")
+    return origin
+
 
 
 def get_tile_offset(grid_size: int, x: int, y: int) -> Bounds:

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
@@ -59,6 +59,7 @@ CHATHAM_SHEET_ORIGINS: dict[str, Point] = {
     "CI06": Point(x=3_506_000, y=5_104_000),  # Pitt Island (Rangiauria)
 }
 
+
 def get_bounds_from_name(tile_name: str, target_epsg: int = EpsgNumber.NZTM_2000) -> Bounds:
     """Get the origin coordinates and size of the tile from its name.
 

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
@@ -17,11 +17,6 @@ GRID_SIZE_MAX = 50_000
 CHAR_A = charcodeat("A", 0)
 CHAR_S = charcodeat("S", 0)
 
-MAINLAND_EPSG = EpsgNumber.NZTM_2000
-""" EPSG code of the mainland NZTM50 mapsheet grid (NZGD2000 / NZTM2000) """
-CHATHAM_EPSG = EpsgNumber.CITM_2000
-""" EPSG code of the Chatham Islands mapsheet grid (NZGD2000 / CITM2000) """
-
 
 class Point(NamedTuple):
     """Class that represents a point(x,y)"""
@@ -64,24 +59,25 @@ CHATHAM_SHEET_ORIGINS: dict[str, Point] = {
     "CI06": Point(x=3_506_000, y=5_104_000),  # Pitt Island (Rangiauria)
 }
 
-def get_bounds_from_name(tile_name: str, target_epsg: int = MAINLAND_EPSG) -> Bounds:
+def get_bounds_from_name(tile_name: str, target_epsg: int = EpsgNumber.NZTM_2000) -> Bounds:
     """Get the origin coordinates and size of the tile from its name.
 
     Args:
         tile_name: the tile name as `sheetCode_gridSize_tileId`
         target_epsg: EPSG code of the mapsheet grid for the tile.
-            `MAINLAND_EPSG` (2193) and `CHATHAM_EPSG` (3793) are supported
+            `EpsgNumber.NZTM_2000` (2193) and `EpsgNumber.CITM_2000` (3793) are supported
 
     Returns:
         a `Bounds` object
     """
-    if target_epsg == MAINLAND_EPSG:
+    if target_epsg == EpsgNumber.NZTM_2000:
         get_offset = get_mapsheet_offset
-    elif target_epsg == CHATHAM_EPSG:
+    elif target_epsg == EpsgNumber.CITM_2000:
         get_offset = get_chatham_mapsheet_offset
     else:
         raise ValueError(
-            f"Unsupported target EPSG:{target_epsg} for mapsheet lookup; supported: {MAINLAND_EPSG}, {CHATHAM_EPSG}"
+            f"Unsupported target EPSG:{target_epsg} for mapsheet lookup. "
+            f"Supported: {EpsgNumber.NZTM_2000.value}, {EpsgNumber.CITM_2000.value}"
         )
 
     # check for 50k imagery
@@ -167,7 +163,6 @@ def get_chatham_mapsheet_offset(sheet_code: str) -> Point:
     if origin is None:
         raise ValueError(f"Unknown Chatham Islands map sheet: {sheet_code}. Known sheets: {sorted(CHATHAM_SHEET_ORIGINS)}")
     return origin
-
 
 
 def get_tile_offset(grid_size: int, x: int, y: int) -> Bounds:

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
@@ -16,6 +16,11 @@ GRID_SIZE_MAX = 50_000
 CHAR_A = charcodeat("A", 0)
 CHAR_S = charcodeat("S", 0)
 
+MAINLAND_EPSG = 2193
+""" EPSG code of the mainland NZTM50 mapsheet grid (NZGD2000 / New Zealand Transverse Mercator 2000) """
+CHATHAM_EPSG = 3793
+""" EPSG code of the Chatham Islands mapsheet grid (NZGD2000 / Chatham Islands TM 2000) """
+
 
 class Point(NamedTuple):
     """Class that represents a point(x,y)"""
@@ -34,18 +39,66 @@ class Bounds(NamedTuple):
     size: Size
 
 
-def get_bounds_from_name(tile_name: str) -> Bounds:
+# The six Chatham Islands Topo50 mapsheets (EPSG:3793, NZGD2000 / Chatham Islands TM 2000), laid
+# out on the same 24,000m x 36,000m 1:50k grid as the mainland sheets, just with a different origin
+# and (small, fixed) set of sheet codes. Unlike the mainland grid, this is a small enough set of
+# sheets that a static lookup table transcribed from the authoritative shapefile is simpler and
+# less bug-prone than deriving a formula.
+#
+# Values transcribed from (and can be regenerated with `ogrinfo -al` against):
+# https://data.linz.govt.nz/layer/50089-nz-chatham-island-linz-map-sheets-topo-150k/
+CHATHAM_SHEET_ORIGINS: dict[str, Point] = {
+    "CI01": Point(x=3_458_000, y=5_176_000),  # Point Somes
+    "CI02": Point(x=3_482_000, y=5_176_000),  # Cape Young
+    "CI03": Point(x=3_506_000, y=5_176_000),  # Kaingaroa
+    "CI04": Point(x=3_482_000, y=5_140_000),  # Waitangi
+    "CI05": Point(x=3_506_000, y=5_140_000),  # Owenga
+    "CI06": Point(x=3_506_000, y=5_104_000),  # Pitt Island (Rangiauria)
+}
+
+
+def get_chatham_mapsheet_offset(sheet_code: str) -> Point:
+    """Look up the origin point for a Chatham Islands mapsheet code.
+
+    Args:
+        sheet_code: Chatham Islands topo 50 map sheet code eg "CI06"
+
+    Returns:
+        Point: The top left point of the mapsheet, in EPSG:3793
+
+    Example:
+        >>> get_chatham_mapsheet_offset("CI06")
+        Point(x=3506000, y=5104000)
+    """
+    origin = CHATHAM_SHEET_ORIGINS.get(sheet_code[:4])
+    if origin is None:
+        raise ValueError(f"Unknown Chatham Islands map sheet: {sheet_code}; known sheets: {sorted(CHATHAM_SHEET_ORIGINS)}")
+    return origin
+
+
+def get_bounds_from_name(tile_name: str, target_epsg: int = MAINLAND_EPSG) -> Bounds:
     """Get the origin coordinates and size of the tile from its name.
 
     Args:
         tile_name: the tile name as `sheetCode_gridSize_tileId`
+        target_epsg: EPSG code of the mapsheet grid the tile is named against; only
+            `MAINLAND_EPSG` (2193) and `CHATHAM_EPSG` (3793) are supported
 
     Returns:
         a `Bounds` object
     """
+    if target_epsg == CHATHAM_EPSG:
+        get_offset = get_chatham_mapsheet_offset
+    elif target_epsg == MAINLAND_EPSG:
+        get_offset = get_mapsheet_offset
+    else:
+        raise ValueError(
+            f"Unsupported target EPSG:{target_epsg} for mapsheet lookup; supported: {MAINLAND_EPSG}, {CHATHAM_EPSG}"
+        )
+
     # check for 50k imagery
     if re.match(r"^[A-Z]{2}\d{2}$", tile_name):
-        origin = get_mapsheet_offset(tile_name)
+        origin = get_offset(tile_name)
         return Bounds(
             Point(x=origin.x, y=origin.y),
             Size(SHEET_WIDTH, SHEET_HEIGHT),
@@ -62,7 +115,7 @@ def get_bounds_from_name(tile_name: str) -> Bounds:
         x = int(name_parts[2][-3:])
         y = int(name_parts[2][:3])
 
-    origin = get_mapsheet_offset(map_sheet)
+    origin = get_offset(map_sheet)
     tile_offset = get_tile_offset(grid_size=grid_size, x=x, y=y)
     return Bounds(
         Point(x=origin.x + tile_offset.point.x, y=origin.y - tile_offset.point.y),

--- a/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
+++ b/packages/topo-imagery-gdal/src/topo_imagery_gdal/tile/tile_index.py
@@ -59,6 +59,79 @@ CHATHAM_SHEET_ORIGINS: dict[str, Point] = {
     "CI06": Point(x=3_506_000, y=5_104_000),  # Pitt Island (Rangiauria)
 }
 
+# Ranges of valid sheet columns for each mainland Topo50 sheet row. Keys are the row letters, and
+# values are ranges between which there are valid sheets. For example "AS": [(21, 22), (24, 24)]
+# means the valid sheets in row AS are AS21, AS22, and AS24.
+# "CI" is deliberately absent: it's one of the mainland grid's three missing row codes, reserved
+# for the Chatham Islands map sheets (see `CHATHAM_SHEET_ORIGINS`).
+SHEET_RANGES: dict[str, list[tuple[int, int]]] = {
+    "AS": [(21, 22), (24, 24)],
+    "AT": [(23, 26)],
+    "AU": [(24, 29)],
+    "AV": [(24, 30)],
+    "AW": [(25, 32)],
+    "AX": [(27, 33)],
+    "AY": [(28, 35)],
+    "AZ": [(28, 36)],
+    "BA": [(29, 37)],
+    "BB": [(30, 37)],
+    "BC": [(30, 38), (40, 41)],
+    "BD": [(31, 46)],
+    "BE": [(31, 46)],
+    "BF": [(30, 45)],
+    "BG": [(29, 45)],
+    "BH": [(28, 44)],
+    "BJ": [(27, 43)],
+    "BK": [(28, 40)],
+    "BL": [(28, 40)],
+    "BM": [(23, 25), (32, 39)],
+    "BN": [(22, 29), (32, 38)],
+    "BP": [(22, 37)],
+    "BQ": [(21, 36)],
+    "BR": [(19, 30), (32, 34)],
+    "BS": [(19, 29)],
+    "BT": [(18, 28)],
+    "BU": [(16, 27)],
+    "BV": [(15, 27)],
+    "BW": [(14, 26)],
+    "BX": [(12, 26)],
+    "BY": [(10, 26)],
+    "BZ": [(8, 23)],
+    "CA": [(7, 22)],
+    "CB": [(6, 20)],
+    "CC": [(5, 20)],
+    "CD": [(4, 19)],
+    "CE": [(4, 18)],
+    "CF": [(4, 17)],
+    "CG": [(4, 16)],
+    "CH": [(5, 14)],
+    "CJ": [(7, 11)],
+    "CK": [(7, 9)],
+}
+
+
+def is_known_mapsheet(sheet_code: str) -> bool:
+    """Check whether a mainland Topo50 sheet code is within the known sheet ranges.
+
+    Args:
+        sheet_code: topo 50 map sheet code eg "CG10"
+
+    Returns:
+        True if `sheet_code` is a real mainland map sheet, False otherwise.
+
+    See:
+        `SHEET_RANGES`
+    """
+    row = sheet_code[:2]
+    try:
+        column = int(sheet_code[2:4])
+    except ValueError:
+        return False
+    ranges = SHEET_RANGES.get(row)
+    if ranges is None:
+        return False
+    return any(low <= column <= high for low, high in ranges)
+
 
 def get_bounds_from_name(tile_name: str, target_epsg: int = EpsgNumber.NZTM_2000) -> Bounds:
     """Get the origin coordinates and size of the tile from its name.
@@ -117,14 +190,19 @@ def get_mapsheet_offset(sheet_code: str) -> Point:
     Returns:
         Point: The top left point of the mapsheet
 
+    Raises:
+        ValueError: if `sheet_code` is not a known mainland map sheet.
+
     Example:
         >>> get_mapsheet_offset("CG10")
         Point(x=1228000, y=4866000)
     """
+    if not is_known_mapsheet(sheet_code):
+        raise ValueError(f"Unknown mainland map sheet: {sheet_code}")
 
     # from a mapsheet of "CG10", Y offset is "CG", X offset is 10
     # Y:"CG" x:"10"
-    x = int(sheet_code[-2:])  # x = 10
+    x = int(sheet_code[2:4])  # x = 10
 
     ms = sheet_code[:2]  # 'CG'
     # position difference of "S" and "A" as mapsheets start at "AS"

--- a/packages/topo-imagery-gdal/test/gdal/gdal_commands_test.py
+++ b/packages/topo-imagery-gdal/test/gdal/gdal_commands_test.py
@@ -25,7 +25,7 @@ def test_get_buffer_distance(subtests: SubTests) -> None:
 
 
 def test_preset_webp(subtests: SubTests) -> None:
-    gdal_command = get_gdal_command(CompressionPreset.WEBP.value, epsg=EpsgNumber.NZTM_2000.value)
+    gdal_command = get_gdal_command(CompressionPreset.WEBP.value, epsg=EpsgNumber.NZTM_2000)
 
     # Basic cog creation
     with subtests.test():
@@ -65,7 +65,7 @@ def test_preset_webp(subtests: SubTests) -> None:
 
 
 def test_preset_zstd(subtests: SubTests) -> None:
-    gdal_command = get_gdal_command(CompressionPreset.RGBNIR_ZSTD.value, epsg=EpsgNumber.NZTM_2000.value)
+    gdal_command = get_gdal_command(CompressionPreset.RGBNIR_ZSTD.value, epsg=EpsgNumber.NZTM_2000)
 
     # Basic cog creation
     with subtests.test():
@@ -102,7 +102,7 @@ def test_preset_zstd(subtests: SubTests) -> None:
 
 
 def test_preset_lzw(subtests: SubTests) -> None:
-    gdal_command = get_gdal_command(CompressionPreset.LZW.value, epsg=EpsgNumber.NZTM_2000.value)
+    gdal_command = get_gdal_command(CompressionPreset.LZW.value, epsg=EpsgNumber.NZTM_2000)
 
     # Basic cog creation
     with subtests.test():
@@ -142,7 +142,7 @@ def test_preset_lzw(subtests: SubTests) -> None:
 
 
 def test_preset_dem_lerc(subtests: SubTests) -> None:
-    gdal_command = get_gdal_command(CompressionPreset.DEM_LERC.value, epsg=EpsgNumber.NZTM_2000.value)
+    gdal_command = get_gdal_command(CompressionPreset.DEM_LERC.value, epsg=EpsgNumber.NZTM_2000)
     # Basic cog creation
     with subtests.test():
         assert "COG" in gdal_command

--- a/packages/topo-imagery-gdal/test/gdal/gdal_commands_test.py
+++ b/packages/topo-imagery-gdal/test/gdal/gdal_commands_test.py
@@ -2,13 +2,13 @@ from decimal import Decimal
 
 import pytest
 from pytest_subtests import SubTests
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_gdal.gdal.gdal_commands import (
     get_buffer_distance,
     get_cutline_command,
     get_footprint_command,
     get_gdal_command,
 )
-from topo_imagery_gdal.gdal.gdal_helper import EpsgNumber
 from topo_imagery_gdal.gdal.gdal_presets import CompressionPreset, HillshadePreset
 
 

--- a/packages/topo-imagery-gdal/test/gdal/gdal_helper_test.py
+++ b/packages/topo-imagery-gdal/test/gdal/gdal_helper_test.py
@@ -1,6 +1,7 @@
 from fake_gdalinfo import fake_gdalinfo
 from pytest_subtests import SubTests
-from topo_imagery_gdal.gdal.gdal_helper import is_geotiff
+from topo_imagery_common.epsg import EpsgNumber
+from topo_imagery_gdal.gdal.gdal_helper import get_srs, is_geotiff
 
 
 def test_is_geotiff(subtests: SubTests) -> None:
@@ -15,3 +16,10 @@ def test_is_geotiff(subtests: SubTests) -> None:
 
     with subtests.test():
         assert is_geotiff("file.tiff", gdalinfo_not_geotiff) is False
+
+
+def test_get_srs_uses_the_given_epsg() -> None:
+    nztm_srs = get_srs(EpsgNumber.NZTM_2000)
+    citm_srs = get_srs(EpsgNumber.CITM_2000)
+    assert nztm_srs != citm_srs
+    assert b"Chatham Islands" in citm_srs

--- a/packages/topo-imagery-gdal/test/gdal/gdal_helper_test.py
+++ b/packages/topo-imagery-gdal/test/gdal/gdal_helper_test.py
@@ -1,7 +1,7 @@
 from fake_gdalinfo import fake_gdalinfo
 from pytest_subtests import SubTests
 from topo_imagery_common.epsg import EpsgNumber
-from topo_imagery_gdal.gdal.gdal_helper import get_srs, is_geotiff
+from topo_imagery_gdal.gdal.gdal_helper import get_srs_command, is_geotiff
 
 
 def test_is_geotiff(subtests: SubTests) -> None:
@@ -18,8 +18,9 @@ def test_is_geotiff(subtests: SubTests) -> None:
         assert is_geotiff("file.tiff", gdalinfo_not_geotiff) is False
 
 
-def test_get_srs_uses_the_given_epsg() -> None:
-    nztm_srs = get_srs(EpsgNumber.NZTM_2000)
-    citm_srs = get_srs(EpsgNumber.CITM_2000)
-    assert nztm_srs != citm_srs
-    assert b"Chatham Islands" in citm_srs
+def test_get_srs_command_uses_the_given_epsg(subtests: SubTests) -> None:
+    with subtests.test("NZTM"):
+        assert get_srs_command(EpsgNumber.NZTM_2000)[-1] == "EPSG:2193"
+
+    with subtests.test("Chatham Islands"):
+        assert get_srs_command(EpsgNumber.CITM_2000)[-1] == "EPSG:3793"

--- a/packages/topo-imagery-gdal/test/gdal/gdal_helper_test.py
+++ b/packages/topo-imagery-gdal/test/gdal/gdal_helper_test.py
@@ -1,7 +1,6 @@
 from fake_gdalinfo import fake_gdalinfo
 from pytest_subtests import SubTests
-from topo_imagery_common.epsg import EpsgNumber
-from topo_imagery_gdal.gdal.gdal_helper import get_srs_command, is_geotiff
+from topo_imagery_gdal.gdal.gdal_helper import is_geotiff
 
 
 def test_is_geotiff(subtests: SubTests) -> None:
@@ -16,11 +15,3 @@ def test_is_geotiff(subtests: SubTests) -> None:
 
     with subtests.test():
         assert is_geotiff("file.tiff", gdalinfo_not_geotiff) is False
-
-
-def test_get_srs_command_uses_the_given_epsg(subtests: SubTests) -> None:
-    with subtests.test("NZTM"):
-        assert get_srs_command(EpsgNumber.NZTM_2000)[-1] == "EPSG:2193"
-
-    with subtests.test("Chatham Islands"):
-        assert get_srs_command(EpsgNumber.CITM_2000)[-1] == "EPSG:3793"

--- a/packages/topo-imagery-gdal/test/tile/tile_index_data.py
+++ b/packages/topo-imagery-gdal/test/tile/tile_index_data.py
@@ -1,5 +1,15 @@
 from typing import Any
 
+# Values transcribed from https://data.linz.govt.nz/layer/50089-nz-chatham-island-linz-map-sheets-topo-150k/
+CHATHAM_SHEET_DATA: list[dict[Any, Any]] = [
+    {"origin": {"x": 3458000, "y": 5176000}, "code": "CI01"},
+    {"origin": {"x": 3482000, "y": 5176000}, "code": "CI02"},
+    {"origin": {"x": 3506000, "y": 5176000}, "code": "CI03"},
+    {"origin": {"x": 3482000, "y": 5140000}, "code": "CI04"},
+    {"origin": {"x": 3506000, "y": 5140000}, "code": "CI05"},
+    {"origin": {"x": 3506000, "y": 5104000}, "code": "CI06"},
+]
+
 MAP_SHEET_DATA: list[dict[Any, Any]] = [
     {"origin": {"x": 1492000, "y": 6234000}, "code": "AS21"},
     {"origin": {"x": 1516000, "y": 6234000}, "code": "AS22"},

--- a/packages/topo-imagery-gdal/test/tile/tile_index_data.py
+++ b/packages/topo-imagery-gdal/test/tile/tile_index_data.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-# Values transcribed from https://data.linz.govt.nz/layer/50089-nz-chatham-island-linz-map-sheets-topo-150k/
+# Values source: https://data.linz.govt.nz/layer/50089-nz-chatham-island-linz-map-sheets-topo-150k/
 CHATHAM_SHEET_DATA: list[dict[Any, Any]] = [
     {"origin": {"x": 3458000, "y": 5176000}, "code": "CI01"},
     {"origin": {"x": 3482000, "y": 5176000}, "code": "CI02"},

--- a/packages/topo-imagery-gdal/test/tile/tile_index_test.py
+++ b/packages/topo-imagery-gdal/test/tile/tile_index_test.py
@@ -26,8 +26,8 @@ def test_get_bounds_from_50k_name() -> None:
 
 
 def test_get_bounds_from_name_chatham() -> None:
-    # Regression test for the real failing tile: mainland arithmetic previously produced
-    # EXTENT=1144000.0,4772400.0,1146400.0,4776000.0 for this tile, which doesn't overlap the
+    # Regression test for failing tile: mainland arithmetic previously produced
+    # EXTENT=1144000.0,4772400.0,1146400.0,4776000.0 for this tile, not the
     # tile's real EPSG:3793 location, causing gdal_translate to fail with
     # "Failed to compute statistics, no valid pixels found in sampling".
     expected_bounds = Bounds(Point(x=3518000, y=5086000), Size(width=2400, height=3600))

--- a/packages/topo-imagery-gdal/test/tile/tile_index_test.py
+++ b/packages/topo-imagery-gdal/test/tile/tile_index_test.py
@@ -1,7 +1,17 @@
 import pytest
 from pytest_subtests import SubTests
-from tile_index_data import MAP_SHEET_DATA
-from topo_imagery_gdal.tile.tile_index import Bounds, Point, Size, get_bounds_from_name, get_mapsheet_offset, get_tile_offset
+from tile_index_data import CHATHAM_SHEET_DATA, MAP_SHEET_DATA
+from topo_imagery_gdal.tile.tile_index import (
+    CHATHAM_EPSG,
+    MAINLAND_EPSG,
+    Bounds,
+    Point,
+    Size,
+    get_bounds_from_name,
+    get_chatham_mapsheet_offset,
+    get_mapsheet_offset,
+    get_tile_offset,
+)
 
 
 def test_get_bounds_from_name() -> None:
@@ -14,6 +24,25 @@ def test_get_bounds_from_50k_name() -> None:
     expected_bounds = Bounds(Point(x=1180000, y=4758000), Size(width=24_000, height=36_000))
     bounds = get_bounds_from_name("CK08")
     assert expected_bounds == bounds
+
+
+def test_get_bounds_from_name_chatham() -> None:
+    # Regression test for the real failing tile: mainland arithmetic previously produced
+    # EXTENT=1144000.0,4772400.0,1146400.0,4776000.0 for this tile, which doesn't overlap the
+    # tile's real EPSG:3793 location, causing gdal_translate to fail with
+    # "Failed to compute statistics, no valid pixels found in sampling".
+    expected_bounds = Bounds(Point(x=3518000, y=5086000), Size(width=2400, height=3600))
+    bounds = get_bounds_from_name("CI06_5000_0606", target_epsg=CHATHAM_EPSG)
+    assert expected_bounds == bounds
+
+
+def test_get_bounds_from_name_defaults_to_mainland() -> None:
+    assert get_bounds_from_name("CK08") == get_bounds_from_name("CK08", target_epsg=MAINLAND_EPSG)
+
+
+def test_get_bounds_from_name_unsupported_epsg() -> None:
+    with pytest.raises(ValueError, match="Unsupported target EPSG"):
+        get_bounds_from_name("CI06_5000_0606", target_epsg=2194)
 
 
 @pytest.mark.dependency()
@@ -32,3 +61,17 @@ def test_get_mapsheet_offset(subtests: SubTests) -> None:
         origin = Point(x=sheet_data["origin"]["x"], y=sheet_data["origin"]["y"])
         with subtests.test(msg=sheet_code):
             assert map_sheet_offset == origin
+
+
+def test_get_chatham_mapsheet_offset(subtests: SubTests) -> None:
+    for sheet_data in CHATHAM_SHEET_DATA:
+        sheet_code = sheet_data["code"]
+        chatham_sheet_offset = get_chatham_mapsheet_offset(sheet_code)
+        origin = Point(x=sheet_data["origin"]["x"], y=sheet_data["origin"]["y"])
+        with subtests.test(msg=sheet_code):
+            assert chatham_sheet_offset == origin
+
+
+def test_get_chatham_mapsheet_offset_unknown_sheet() -> None:
+    with pytest.raises(ValueError, match="Unknown Chatham Islands map sheet"):
+        get_chatham_mapsheet_offset("CI99")

--- a/packages/topo-imagery-gdal/test/tile/tile_index_test.py
+++ b/packages/topo-imagery-gdal/test/tile/tile_index_test.py
@@ -1,9 +1,8 @@
 import pytest
 from pytest_subtests import SubTests
 from tile_index_data import CHATHAM_SHEET_DATA, MAP_SHEET_DATA
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_gdal.tile.tile_index import (
-    CHATHAM_EPSG,
-    MAINLAND_EPSG,
     Bounds,
     Point,
     Size,
@@ -32,12 +31,12 @@ def test_get_bounds_from_name_chatham() -> None:
     # tile's real EPSG:3793 location, causing gdal_translate to fail with
     # "Failed to compute statistics, no valid pixels found in sampling".
     expected_bounds = Bounds(Point(x=3518000, y=5086000), Size(width=2400, height=3600))
-    bounds = get_bounds_from_name("CI06_5000_0606", target_epsg=CHATHAM_EPSG)
+    bounds = get_bounds_from_name("CI06_5000_0606", target_epsg=EpsgNumber.CITM_2000)
     assert expected_bounds == bounds
 
 
 def test_get_bounds_from_name_defaults_to_mainland() -> None:
-    assert get_bounds_from_name("CK08") == get_bounds_from_name("CK08", target_epsg=MAINLAND_EPSG)
+    assert get_bounds_from_name("CK08") == get_bounds_from_name("CK08", target_epsg=EpsgNumber.NZTM_2000)
 
 
 def test_get_bounds_from_name_unsupported_epsg() -> None:

--- a/packages/topo-imagery-gdal/test/tile/tile_index_test.py
+++ b/packages/topo-imagery-gdal/test/tile/tile_index_test.py
@@ -39,6 +39,19 @@ def test_get_bounds_from_name_defaults_to_mainland() -> None:
     assert get_bounds_from_name("CK08") == get_bounds_from_name("CK08", target_epsg=EpsgNumber.NZTM_2000)
 
 
+def test_get_bounds_from_50k_name_chatham() -> None:
+    expected_bounds = Bounds(Point(x=3506000, y=5104000), Size(width=24_000, height=36_000))
+    bounds = get_bounds_from_name("CI06", target_epsg=EpsgNumber.CITM_2000)
+    assert expected_bounds == bounds
+
+
+def test_get_bounds_from_name_chatham_without_target_epsg_fails_loudly() -> None:
+    # Omitting target_epsg for a Chatham tile name must not silently default to mainland
+    # arithmetic (see the regression test above) - it should fail loudly instead.
+    with pytest.raises(ValueError, match="Unknown mainland map sheet"):
+        get_bounds_from_name("CI06_5000_0606")
+
+
 def test_get_bounds_from_name_unsupported_epsg() -> None:
     with pytest.raises(ValueError, match="Unsupported target EPSG"):
         get_bounds_from_name("CI06_5000_0606", target_epsg=2194)
@@ -74,3 +87,12 @@ def test_get_chatham_mapsheet_offset(subtests: SubTests) -> None:
 def test_get_chatham_mapsheet_offset_unknown_sheet() -> None:
     with pytest.raises(ValueError, match="Unknown Chatham Islands map sheet"):
         get_chatham_mapsheet_offset("CI99")
+
+
+def test_get_mapsheet_offset_unknown_sheet(subtests: SubTests) -> None:
+    # "CI" is reserved for the Chatham Islands and out of range for the mainland grid; "AS23" is a
+    # real row with a gap that skips column 23 (see SHEET_RANGES["AS"] = [(21, 22), (24, 24)]).
+    for sheet_code in ["CI05", "CI22", "AS23"]:
+        with subtests.test(msg=sheet_code):
+            with pytest.raises(ValueError, match="Unknown mainland map sheet"):
+                get_mapsheet_offset(sheet_code)

--- a/packages/topo-imagery-pdal/src/topo_imagery_pdal/pdal_commands.py
+++ b/packages/topo-imagery-pdal/src/topo_imagery_pdal/pdal_commands.py
@@ -5,6 +5,7 @@ from tempfile import mkdtemp
 
 from linz_logger import get_log
 from topo_imagery_common.aws.aws_helper import is_s3
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_common.files.fs import copy
 from topo_imagery_common.log.time_helper import time_in_ms
 
@@ -53,7 +54,7 @@ def get_pdal_command(command: str, options: list[str]) -> list[str]:
 pdal_translate_add_proj_command = get_pdal_command(
     "translate",
     [
-        "--readers.las.spatialreference=EPSG:2193+7839",
+        f"--readers.las.spatialreference=EPSG:{EpsgNumber.NZTM_2000.value}+{EpsgNumber.NZVD_2016.value}",
         "--writers.las.filesource_id=0",
         "--writers.las.forward=all",
     ],

--- a/packages/topo-imagery-pdal/src/topo_imagery_pdal/pdal_commands.py
+++ b/packages/topo-imagery-pdal/src/topo_imagery_pdal/pdal_commands.py
@@ -54,7 +54,7 @@ def get_pdal_command(command: str, options: list[str]) -> list[str]:
 pdal_translate_add_proj_command = get_pdal_command(
     "translate",
     [
-        f"--readers.las.spatialreference=EPSG:{EpsgNumber.NZTM_2000.value}+{EpsgNumber.NZVD_2016.value}",
+        f"--readers.las.spatialreference=EPSG:{EpsgNumber.NZTM_2000}+{EpsgNumber.NZVD_2016}",
         "--writers.las.filesource_id=0",
         "--writers.las.forward=all",
     ],

--- a/scripts/generate_hillshade.py
+++ b/scripts/generate_hillshade.py
@@ -9,6 +9,7 @@ from linz_logger import get_log
 from topo_imagery_common.cli.cli_helper import InputParameterError, TileFiles, load_input_files
 from topo_imagery_common.cli.common_args import CommonArgumentParser
 from topo_imagery_common.datetimes import RFC_3339_DATETIME_FORMAT
+from topo_imagery_common.epsg import EpsgNumber
 from topo_imagery_common.files.files_helper import SUFFIX_JSON, ContentType, is_tiff
 from topo_imagery_common.files.fs import exists, read, write, write_all
 from topo_imagery_common.log.time_helper import time_in_ms
@@ -111,7 +112,7 @@ def create_hillshade(
 
         # COGify the hillshade output, using ZSTD compression
         run_gdal(
-            get_gdal_command(CompressionPreset.DEM_ZSTD.value, 2193),
+            get_gdal_command(CompressionPreset.DEM_ZSTD.value, EpsgNumber.NZTM_2000),
             input_file=hillshade_working_path,
             output_file=hillshade_cog_working_path,
         )

--- a/scripts/standardise_validate.py
+++ b/scripts/standardise_validate.py
@@ -176,7 +176,7 @@ def main() -> None:
         return
 
     # SRS needed for FileCheck (non visual QA)
-    srs = get_srs()
+    srs = get_srs(standardising_config.target_epsg)
 
     for file in tiff_files:
         stac_item_path = file.get_path_standardised().rsplit(".", 1)[0] + SUFFIX_JSON


### PR DESCRIPTION
### Motivation

In order to standardise Chatham Islands datasets, EPSG 3793 (CITM2000) needs to be accepted and the relevant map sheet origins supported.

### Modifications

Look up table for Chatham Islands map sheets, support EPSG 3793 and some refactoring to move the EPSG codes into a common function.

### Verification

Unit tests, end-to-end tests and workflow run.