### PR TITLE
ci: use github token rotation automation for release-please TDE-2021

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.LI_GITHUB_ACTION_TOKEN }}
+          token: ${{ secrets.LINZ_GITHUB_AUTOMATION }}
 
   publish-release:
     needs: release-please


### PR DESCRIPTION
### Motivation & Modifications

Move to short-lived token for `release-please` to meet security requirements.
