### PR TITLE
test: cover str_to_positive_int failure cases

### DIFF
--- a/packages/topo-imagery-common/test/cli/cli_helper_test.py
+++ b/packages/topo-imagery-common/test/cli/cli_helper_test.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentTypeError
 from datetime import datetime
 from typing import Any
 
@@ -11,6 +12,7 @@ from topo_imagery_common.cli.cli_helper import (
     get_non_empty_features,
     get_tile_files,
     parse_list,
+    str_to_positive_int,
     valid_date,
 )
 
@@ -196,3 +198,25 @@ def test_get_non_empty_features_single_feature() -> None:
     features = get_non_empty_features(geojson, "/tmp/test/test.geojson")
     assert len(features) == 1
     assert features[0]["type"] == "Feature"
+
+
+def test_str_to_positive_int_returns_int_when_value_is_positive() -> None:
+    assert str_to_positive_int("5") == 5
+
+
+def test_str_to_positive_int_raises_when_value_is_not_an_integer() -> None:
+    with raises(ArgumentTypeError) as e:
+        str_to_positive_int("foo")
+    assert str(e.value) == "'foo' is not a valid integer"
+
+
+def test_str_to_positive_int_raises_when_value_is_zero() -> None:
+    with raises(ArgumentTypeError) as e:
+        str_to_positive_int("0")
+    assert str(e.value) == "must be >= 1"
+
+
+def test_str_to_positive_int_raises_when_value_is_negative() -> None:
+    with raises(ArgumentTypeError) as e:
+        str_to_positive_int("-1")
+    assert str(e.value) == "must be >= 1"


### PR DESCRIPTION
### Motivation

`str_to_positive_int` in the common CLI helper is an argparse type function whose whole job is to reject bad input. It raises `argparse.ArgumentTypeError` in two cases (non-integer input, and a value below 1), but neither rejection path had a test. The module only carried a happy-path doctest, so a regression in the error handling could pass CI unnoticed.

This follows CONTRIBUTING.md, which asks tests to cover edge cases and failure scenarios.

### Modifications

Add four unit tests to `packages/topo-imagery-common/test/cli/cli_helper_test.py`:

- valid positive integer returns the parsed int
- non-integer input raises `ArgumentTypeError` with `'foo' is not a valid integer`
- `"0"` raises `ArgumentTypeError` with `must be >= 1`
- `"-1"` raises `ArgumentTypeError` with `must be >= 1`

Test names follow the repo's `test_<behaviour>_when_<condition>` pattern. No production code changed. One logical change, 24 lines added, one file.

### Verification

```
uv sync --frozen --no-install-project
uv run pytest --doctest-modules packages/topo-imagery-common
uv run black --check packages/topo-imagery-common/test/cli/cli_helper_test.py
uv run isort --check-only packages/topo-imagery-common/test/cli/cli_helper_test.py
uv run mypy packages/topo-imagery-common/test/cli/cli_helper_test.py
uv run pylint packages/topo-imagery-common/test/cli/cli_helper_test.py
```

Local results:

- Tests: PASS (63 passed in the common package; the cli_helper suite goes 21 -> 25)
- black: PASS (file unchanged)
- isort: PASS
- mypy: PASS (no issues)
- pylint: PASS (10.00/10)